### PR TITLE
Disallow empty `cbId` value to pass through

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -1406,7 +1406,12 @@ def get_id_required_nodes(referenced_nodes=False,
     def _add_to_result_if_valid(obj):
         """Add to `result` if the object should be included"""
         fn_dep.setObject(obj)
-        if not existing_ids and fn_dep.hasAttribute("cbId"):
+        if (
+                not existing_ids
+                and fn_dep.hasAttribute("cbId")
+                # May not be an empty value
+                and fn_dep.findPlug("cbId", True).asString()
+        ):
             return
 
         if not referenced_nodes and fn_dep.isFromReferencedFile:

--- a/client/ayon_maya/plugins/publish/validate_node_ids.py
+++ b/client/ayon_maya/plugins/publish/validate_node_ids.py
@@ -62,4 +62,4 @@ class ValidateNodeIDs(plugin.MayaInstancePlugin):
                                              # Exclude those with already
                                              # existing ids
                                              existing_ids=False)
-        return id_nodes
+        return list(id_nodes)

--- a/create_package.py
+++ b/create_package.py
@@ -132,10 +132,7 @@ def safe_copy_file(src_path: str, dst_path: str):
         return
 
     dst_dir: str = os.path.dirname(dst_path)
-    try:
-        os.makedirs(dst_dir)
-    except Exception:
-        pass
+    os.makedirs(dst_dir, exist_ok=True)
 
     shutil.copy2(src_path, dst_path)
 
@@ -355,6 +352,8 @@ def copy_addon_package(
     # Copy server content
     for src_file, dst_subpath in files_mapping:
         dst_path: str = os.path.join(addon_output_dir, dst_subpath)
+        dst_dir: str = os.path.dirname(dst_path)
+        os.makedirs(dst_dir, exist_ok=True)
         if isinstance(src_file, io.BytesIO):
             with open(dst_path, "wb") as stream:
                 stream.write(src_file.getvalue())


### PR DESCRIPTION
### Issue

If a `cbId` attribute existed on a node, but was an empty value (e.g. user cleared it; I'm looking at you @LiborBatek ) then it would magically pass validation but break in collecting looks.

### Solution

Do not allow empty values to pass through.

### Testing notes

1. Create a model
2. Save scene
3. go to the `cbId` attribute in attribute editor, and clear the value (make it an empty string)
4. Publish the model.

The model should be invalidated and the id be regenerated.