### PR TITLE
Make sure implicit thumbnail in higher priority over the thumbnail source

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_maya/plugins/publish/extract_thumbnail.py
@@ -13,7 +13,7 @@ class ExtractThumbnail(plugin.MayaExtractorPlugin):
     capture.
 
     """
-
+    order = pyblish.api.ExtractorOrder - 0.3
     label = "Thumbnail"
     families = ["review"]
 

--- a/client/ayon_maya/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_maya/plugins/publish/extract_thumbnail.py
@@ -2,6 +2,8 @@ import glob
 import os
 import tempfile
 
+import pyblish.api
+
 from ayon_maya.api import lib
 from ayon_maya.api import plugin
 


### PR DESCRIPTION
## Changelog Description
When users trying to create screengrab thumbnails and publish along with the review product type, it will error out the intgerate.py due to the duplicate of the thumbnail representation data. This PR is to make sure the extract thumbnail is always at the higher priority than the extract thumbnail sources

## Additional info
please test on some other hosts with thumbnail extractors in review family, maybe similar bug is hit when you publish both screengrab and review family

ported from https://github.com/ynput/ayon-core/pull/695

## Testing notes:

1. Launch Maya/Max
2. Create Review Instance
3. Create Screengrab in publisher tab
4. Publish

- No error should occur.
- The thumbnail set in the publisher UI will be ignored/discarded; instead the thumbnail from Maya's Extract Review will be forcefully used. As such, setting a thumbnail in the publisher UI does _nothing_ for review instances.