### PR TITLE
Fix bug where maya rig behaves different when loaded due to display handle logic

### DIFF
--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -212,8 +212,12 @@ class ReferenceLoader(plugin.ReferenceLoader):
                 ).get('display_handle', True)
                 if display_handle:
                     cmds.setAttr(f"{group_name}.displayHandle", display_handle)
-                    
                     # get bounding box
+                    # Bugfix: We force a refresh here because there is a
+                    # reproducable case with Advanced Skeleton rig where the
+                    # call to `exactWorldBoundingBox` directly after the
+                    # reference without it breaks the behavior of the rigs
+                    # making it appear as if parts of the mesh are static.
                     cmds.refresh()
                     bbox = cmds.exactWorldBoundingBox(group_name)
                     # get pivot position on world space

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -214,11 +214,11 @@ class ReferenceLoader(plugin.ReferenceLoader):
                         green,
                         blue
                     )
-
                 cmds.setAttr(
                     "{}.displayHandle".format(group_name), display_handle
                 )
                 # get bounding box
+                cmds.refresh()
                 bbox = cmds.exactWorldBoundingBox(group_name)
                 # get pivot position on world space
                 pivot = cmds.xform(group_name, q=True, sp=True, ws=True)
@@ -246,7 +246,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
                         group_name = root_nodes[0]
                     cmds.setAttr("{}.translate".format(group_name),
                                  *options["translate"])
-            return new_nodes
+            return
 
     def switch(self, container, context):
         self.update(container, context)

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -264,11 +264,11 @@ class ReferenceLoader(plugin.ReferenceLoader):
         """Enable display handle and move select handle to object center"""
         cmds.setAttr(f"{group_name}.displayHandle", True)
         # get bounding box
-        # Bugfix: We force a refresh here because there is a
-        # reproducable case with Advanced Skeleton rig where the
-        # call to `exactWorldBoundingBox` directly after the
-        # reference without it breaks the behavior of the rigs
-        # making it appear as if parts of the mesh are static.
+        # Bugfix: We force a refresh here because there is a reproducable case
+        # with Advanced Skeleton rig where the call to `exactWorldBoundingBox`
+        # directly after the reference without it breaks the behavior of the
+        # rigs making it appear as if parts of the mesh are static.
+        # TODO: Preferably we have a better fix than requiring refresh on loads
         cmds.refresh()
         bbox = cmds.exactWorldBoundingBox(group_name)
         # get pivot position on world space

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -194,14 +194,6 @@ class ReferenceLoader(plugin.ReferenceLoader):
                         cmds.xform(group_name, zeroTransformPivots=True)
 
                 settings = get_project_settings(project_name)
-
-                display_handle = settings['maya']['load'].get(
-                    'reference_loader', {}
-                ).get('display_handle', True)
-                cmds.setAttr(
-                    "{}.displayHandle".format(group_name), display_handle
-                )
-
                 color = plugin.get_load_color_for_product_type(
                     product_type, settings
                 )
@@ -214,26 +206,30 @@ class ReferenceLoader(plugin.ReferenceLoader):
                         green,
                         blue
                     )
-                cmds.setAttr(
-                    "{}.displayHandle".format(group_name), display_handle
-                )
-                # get bounding box
-                cmds.refresh()
-                bbox = cmds.exactWorldBoundingBox(group_name)
-                # get pivot position on world space
-                pivot = cmds.xform(group_name, q=True, sp=True, ws=True)
-                # center of bounding box
-                cx = (bbox[0] + bbox[3]) / 2
-                cy = (bbox[1] + bbox[4]) / 2
-                cz = (bbox[2] + bbox[5]) / 2
-                # add pivot position to calculate offset
-                cx = cx + pivot[0]
-                cy = cy + pivot[1]
-                cz = cz + pivot[2]
-                # set selection handle offset to center of bounding box
-                cmds.setAttr("{}.selectHandleX".format(group_name), cx)
-                cmds.setAttr("{}.selectHandleY".format(group_name), cy)
-                cmds.setAttr("{}.selectHandleZ".format(group_name), cz)
+
+                display_handle = settings['maya']['load'].get(
+                    'reference_loader', {}
+                ).get('display_handle', True)
+                if display_handle:
+                    cmds.setAttr(f"{group_name}.displayHandle", display_handle)
+                    
+                    # get bounding box
+                    cmds.refresh()
+                    bbox = cmds.exactWorldBoundingBox(group_name)
+                    # get pivot position on world space
+                    pivot = cmds.xform(group_name, q=True, sp=True, ws=True)
+                    # center of bounding box
+                    cx = (bbox[0] + bbox[3]) / 2
+                    cy = (bbox[1] + bbox[4]) / 2
+                    cz = (bbox[2] + bbox[5]) / 2
+                    # add pivot position to calculate offset
+                    cx = cx + pivot[0]
+                    cy = cy + pivot[1]
+                    cz = cz + pivot[2]
+                    # set selection handle offset to center of bounding box
+                    cmds.setAttr("{}.selectHandleX".format(group_name), cx)
+                    cmds.setAttr("{}.selectHandleY".format(group_name), cy)
+                    cmds.setAttr("{}.selectHandleZ".format(group_name), cz)
 
             if product_type == "rig":
                 self._post_process_rig(namespace, context, options)

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -224,7 +224,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
                         group_name = root_nodes[0]
                     cmds.setAttr("{}.translate".format(group_name),
                                  *options["translate"])
-            return
+            return new_nodes
 
     def switch(self, container, context):
         self.update(container, context)

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -261,7 +261,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
                              " transforms of cameras.")
 
     def _set_display_handle(self, group_name: str):
-        """Enable display handle """
+        """Enable display handle and move select handle to object center"""
         cmds.setAttr(f"{group_name}.displayHandle", True)
         # get bounding box
         # Bugfix: We force a refresh here because there is a


### PR DESCRIPTION
## Changelog Description 

- Perform `maya.cmds.refresh` before `maya.cmds.exactWorldBoundingBox` call to resolve issue with rig behaving different on load
- Only perform the logic to set display handle if it's enabled in settings
- Cosmetics/cleanup of code.

## Additional info

For whatever reason the example rig failed to behave normally if we'd call `maya.cmds.exactWorldBoundingBox` directly 

## Testing notes:

1. Maya rig load should work without issue
2. Other reference loads with display handle enabled/disabled should also still work.

This may need a particular "rig" file from Advanced Skeleton to test the _actual issue_ being solved with this PR. However, the file provided for developing this PR was confidential.