### PR TITLE
Remove deprecated `ocio_config` `ImageIOConfigModel` settings

### DIFF
--- a/server/settings/imageio.py
+++ b/server/settings/imageio.py
@@ -11,32 +11,6 @@ from ayon_server.settings import (
 )
 
 
-class ImageIOConfigModel(BaseSettingsModel):
-    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
-    path in the Core addon profiles here
-    (ayon+settings://core/imageio/ocio_config_profiles).
-    """
-
-    override_global_config: bool = SettingsField(
-        False,
-        title="Override global OCIO config",
-        description=(
-            "DEPRECATED functionality. Please set the OCIO config path in the "
-            "Core addon profiles here (ayon+settings://core/imageio/"
-            "ocio_config_profiles)."
-        ),
-    )
-    filepath: list[str] = SettingsField(
-        default_factory=list,
-        title="Config path",
-        description=(
-            "DEPRECATED functionality. Please set the OCIO config path in the "
-            "Core addon profiles here (ayon+settings://core/imageio/"
-            "ocio_config_profiles)."
-        ),
-    )
-
-
 class ImageIOFileRuleModel(BaseSettingsModel):
     name: str = SettingsField("", title="Rule name")
     pattern: str = SettingsField("", title="Regex pattern")
@@ -96,10 +70,6 @@ class ImageIOSettings(BaseSettingsModel):
     activate_host_color_management: bool = SettingsField(
         True, title="Enable Color Management"
     )
-    ocio_config: ImageIOConfigModel = SettingsField(
-        default_factory=ImageIOConfigModel,
-        title="OCIO config"
-    )
     file_rules: ImageIOFileRulesModel = SettingsField(
         default_factory=ImageIOFileRulesModel,
         title="File Rules"
@@ -123,10 +93,6 @@ class ImageIOSettings(BaseSettingsModel):
 
 DEFAULT_IMAGEIO_SETTINGS = {
     "activate_host_color_management": True,
-    "ocio_config": {
-        "override_global_config": False,
-        "filepath": []
-    },
     "file_rules": {
         "activate_host_rules": False,
         "rules": []


### PR DESCRIPTION
## Changelog Description

Remove deprecated `ocio_config` `ImageIOConfigModel` settings

## Additional info

With [the support of profiles to determine OCIO config in ayon-core](https://github.com/ynput/ayon-core/pull/490) this logic has been superseded and should be removed from each addon still having the deprecated settings.