### PR TITLE
Redshift: Set Rendersettings actually apply `multilayer_exr` and `force_combine`

### DIFF
--- a/client/ayon_maya/api/lib_rendersettings.py
+++ b/client/ayon_maya/api/lib_rendersettings.py
@@ -228,7 +228,7 @@ class RenderSettings(object):
         self._set_global_output_settings()
         cmds.setAttr("redshiftOptions.imageFormat", img_ext)
         cmds.setAttr("redshiftOptions.exrMultipart",
-                     redshift_render_presets["multilayer_exr"])
+                     redshift_render_presets.get("multipart_exr", True))
         cmds.setAttr("redshiftOptions.exrForceMultilayer",
                      redshift_render_presets["force_combine"])
         cmds.setAttr("defaultResolution.width", width)

--- a/client/ayon_maya/api/lib_rendersettings.py
+++ b/client/ayon_maya/api/lib_rendersettings.py
@@ -227,6 +227,10 @@ class RenderSettings(object):
 
         self._set_global_output_settings()
         cmds.setAttr("redshiftOptions.imageFormat", img_ext)
+        cmds.setAttr("redshiftOptions.exrMultipart",
+                     redshift_render_presets["multilayer_exr"])
+        cmds.setAttr("redshiftOptions.exrForceMultilayer",
+                     redshift_render_presets["force_combine"])
         cmds.setAttr("defaultResolution.width", width)
         cmds.setAttr("defaultResolution.height", height)
         self._additional_attribs_setter(additional_options)

--- a/server/settings/render_settings.py
+++ b/server/settings/render_settings.py
@@ -346,7 +346,7 @@ class RedshiftSettingsModel(BaseSettingsModel):
         enum_resolver=redshift_image_output_enum,
         title="Output Image Format"
     )
-    multilayer_exr: bool = SettingsField(title="Multilayer (exr)")
+    multipart_exr: bool = SettingsField(title="Multipart (exr)")
     force_combine: bool = SettingsField(title="Force combine beauty and AOVs")
     aov_list: list[str] = SettingsField(
         default_factory=list,
@@ -481,7 +481,7 @@ DEFAULT_RENDER_SETTINGS = {
         "primary_gi_engine": "0",
         "secondary_gi_engine": "0",
         "image_format": "exr",
-        "multilayer_exr": True,
+        "multipart_exr": True,
         "force_combine": True,
         "aov_list": [],
         "additional_options": []

--- a/server/settings/render_settings.py
+++ b/server/settings/render_settings.py
@@ -224,59 +224,58 @@ def redshift_image_output_enum():
 
 
 def redshift_aov_list_enum():
-    """Return enumerator for Vray AOVs.
+    """Return enumerator for Redshift AOVs.
 
-        Note: Key is value, Value in this case is Label. This
-            was taken from v3 settings.
-        """
+    *Tested in Redshift 3.6.03
+    """
     return [
-        {"value": "empty", "label": "< none >"},
-        {"value": "AO", "label": "Ambient Occlusion"},
+        {"value": "Ambient Occlusion", "label": "Ambient Occlusion"},
         {"value": "Background", "label": "Background"},
         {"value": "Beauty", "label": "Beauty"},
-        {"value": "BumpNormals", "label": "Bump Normals"},
+        {"value": "Bump Normals", "label": "Bump Normals"},
         {"value": "Caustics", "label": "Caustics"},
-        {"value": "CausticsRaw", "label": "Caustics Raw"},
+        {"value": "Caustics Raw", "label": "Caustics Raw"},
         {"value": "Cryptomatte", "label": "Cryptomatte"},
         {"value": "Custom", "label": "Custom"},
-        {"value": "Z", "label": "Depth"},
-        {"value": "DiffuseFilter", "label": "Diffuse Filter"},
-        {"value": "DiffuseLighting", "label": "Diffuse Lighting"},
-        {"value": "DiffuseLightingRaw", "label": "Diffuse Lighting Raw"},
+        {"value": "Depth", "label": "Depth"},
+        {"value": "Diffuse Filter", "label": "Diffuse Filter"},
+        {"value": "Diffuse Lighting", "label": "Diffuse Lighting"},
+        {"value": "Diffuse Lighting Raw", "label": "Diffuse Lighting Raw"},
         {"value": "Emission", "label": "Emission"},
-        {"value": "GI", "label": "Global Illumination"},
-        {"value": "GIRaw", "label": "Global Illumination Raw"},
+        {"value": "Global Illumination", "label": "Global Illumination"},
+        {"value": "Global Illumination Raw",
+         "label": "Global Illumination Raw"},
         {"value": "Matte", "label": "Matte"},
-        {"value": "MotionVectors", "label": "Ambient Occlusion"},
-        {"value": "N", "label": "Normals"},
-        {"value": "ID", "label": "ObjectID"},
-        {"value": "ObjectBumpNormal", "label": "Object-Space Bump Normals"},
-        {"value": "ObjectPosition", "label": "Object-Space Positions"},
-        {"value": "PuzzleMatte", "label": "Puzzle Matte"},
+        {"value": "Motion Vectors", "label": "Motion Vectors"},
+        {"value": "Normals", "label": "Normals"},
+        {"value": "ObjectID", "label": "ObjectID"},
+        {"value": "Object-Space Bump Normals",
+         "label": "Object-Space Bump Normals"},
+        {"value": "Object-Space Positions",
+         "label": "Object-Space Positions"},
+        {"value": "Puzzle Matte", "label": "Puzzle Matte"},
         {"value": "Reflections", "label": "Reflections"},
-        {"value": "ReflectionsFilter", "label": "Reflections Filter"},
-        {"value": "ReflectionsRaw", "label": "Reflections Raw"},
+        {"value": "Reflections Filter", "label": "Reflections Filter"},
+        {"value": "Reflections Raw", "label": "Reflections Raw"},
         {"value": "Refractions", "label": "Refractions"},
-        {"value": "RefractionsFilter", "label": "Refractions Filter"},
-        {"value": "RefractionsRaw", "label": "Refractions Filter"},
+        {"value": "Refractions Filter", "label": "Refractions Filter"},
+        {"value": "Refractions Raw", "label": "Refractions Raw"},
         {"value": "Shadows", "label": "Shadows"},
-        {"value": "SpecularLighting", "label": "Specular Lighting"},
-        {"value": "SSS", "label": "Sub Surface Scatter"},
-        {"value": "SSSRaw", "label": "Sub Surface Scatter Raw"},
-        {
-            "value": "TotalDiffuseLightingRaw",
-            "label": "Total Diffuse Lighting Raw"
-        },
-        {
-            "value": "TotalTransLightingRaw",
-            "label": "Total Translucency Filter"
-        },
-        {"value": "TransTint", "label": "Translucency Filter"},
-        {"value": "TransGIRaw", "label": "Translucency Lighting Raw"},
-        {"value": "VolumeFogEmission", "label": "Volume Fog Emission"},
-        {"value": "VolumeFogTint", "label": "Volume Fog Tint"},
-        {"value": "VolumeLighting", "label": "Volume Lighting"},
-        {"value": "P", "label": "World Position"},
+        {"value": "Specular Lighting", "label": "Specular Lighting"},
+        {"value": "Sub Surface Scatter", "label": "Sub Surface Scatter"},
+        {"value": "Sub Surface Scatter Raw",
+         "label": "Sub Surface Scatter Raw"},
+        {"value": "Total Diffuse Lighting Raw",
+         "label": "Total Diffuse Lighting Raw"},
+        {"value": "Total Translucency Lighting Raw",
+         "label": "Total Translucency Lighting Raw"},
+        {"value": "Translucency Filter", "label": "Translucency Filter"},
+        {"value": "Translucency Lighting Raw",
+         "label": "Translucency Lighting Raw"},
+        {"value": "Volume Fog Emission", "label": "Volume Fog Emission"},
+        {"value": "Volume Fog Tint", "label": "Volume Fog Tint"},
+        {"value": "Volume Lighting", "label": "Volume Lighting"},
+        {"value": "World Position", "label": "World Position"},
     ]
 
 

--- a/server/settings/render_settings.py
+++ b/server/settings/render_settings.py
@@ -193,13 +193,21 @@ def vray_aov_list_enum():
     ]
 
 
-def redshift_engine_enum():
+def redshift_primary_gi_engine_enum():
     """Get Redshift engine type enumerator."""
     return [
         {"value": "0", "label": "None"},
-        {"value": "1", "label": "Photon Map"},
-        {"value": "2", "label": "Irradiance Cache"},
-        {"value": "3", "label": "Brute Force"}
+        {"value": "3", "label": "Irradiance Cache"},
+        {"value": "4", "label": "Brute Force"}
+    ]
+
+
+def redshift_secondary_gi_engine_enum():
+    """Get Redshift engine type enumerator."""
+    return [
+        {"value": "0", "label": "None"},
+        {"value": "2", "label": "Irradiance Point Cloud"},
+        {"value": "4", "label": "Brute Force"}
     ]
 
 
@@ -335,11 +343,11 @@ class RedshiftSettingsModel(BaseSettingsModel):
     # both engines are using the same enumerator,
     #   both were originally str because of JSON limitation.
     primary_gi_engine: str = SettingsField(
-        enum_resolver=redshift_engine_enum,
+        enum_resolver=redshift_primary_gi_engine_enum,
         title="Primary GI Engine"
     )
     secondary_gi_engine: str = SettingsField(
-        enum_resolver=redshift_engine_enum,
+        enum_resolver=redshift_secondary_gi_engine_enum,
         title="Secondary GI Engine"
     )
     image_format: str = SettingsField(


### PR DESCRIPTION
## Changelog Description

Fix applying of **Force combine beauty and AOVs into a single file** and **Multipart EXR** in Redshift Rendersettings from settings defined in AYON settings.

## Additional info

The settings already existed but seemed to have been used nowhere - even back in OpenPype.

Note: There has been some discussion that Multilayer is not the same as Multipart so either the settings name and label is wrong, or we're setting the wrong attribute here? Any clue @m-u-r-p-h-y @antirotor ?

## Testing notes:

1. Change settings
```
ayon+settings://maya/render_settings/redshift_renderer/multilayer_exr
ayon+settings://maya/render_settings/redshift_renderer/force_combine
```
2. Launch Maya, set redshift as renderer.
3. Click "AYON > Set Render Settings" in menu in Maya
4. The Redshift render settings should now have been updated.

![image](https://github.com/user-attachments/assets/d8c7b119-5b72-4b6b-bffd-e306fb674952)
