### PR TITLE
Fix publishing USD from maya with asset/shot contributions enabled

### DIFF
--- a/client/ayon_maya/plugins/publish/collect_user_defined_attributes.py
+++ b/client/ayon_maya/plugins/publish/collect_user_defined_attributes.py
@@ -13,7 +13,7 @@ class CollectUserDefinedAttributes(plugin.MayaInstancePlugin):
     def process(self, instance):
 
         # Collect user defined attributes.
-        if not instance.data["creator_attributes"].get(
+        if not instance.data.get("creator_attributes", {}).get(
             "includeUserDefinedAttributes"
         ):
             return

--- a/client/ayon_maya/plugins/publish/validate_instance_has_members.py
+++ b/client/ayon_maya/plugins/publish/validate_instance_has_members.py
@@ -24,8 +24,15 @@ class ValidateInstanceHasMembers(plugin.MayaInstancePlugin):
 
     def process(self, instance):
         # Allow renderlayer, rendersetup and workfile to be empty
-        skip_families = {"workfile", "renderlayer", "rendersetup"}
-        if instance.data.get("productType") in skip_families:
+        skip_families = {"workfile",
+                         "renderlayer",
+                         "rendersetup",
+                         "mayaUsdLayer",
+                         "usdLayer",
+                         "usdAsset"}
+        families = {instance.data.get("family")}
+        families.update(instance.data.get("families", []))
+        if families.intersection(skip_families):
             return
 
         invalid = self.get_invalid(instance)


### PR DESCRIPTION
Fix a bug where USD `usdAsset` (asset and shot) contributions fail to publish.

### Additional Info

Clickup AY-6115

### Testing notes

1. Publish a USD file from Maya should not raise any errors WITH USD Contribution checkbox enabled
2. Publish a USD file from Maya should not raise any errors WITH USD Contribution checkbox disabled

The USD contribution checkbox:
> Thanks - on a USD instance there should be a setting on the instance under a section **USD Contribution** which has **Enable** checkbox.
> 
> See also screenshots [here](https://community.ynput.io/t/ayon-usd-workflow-guide/1545/2?u=bigroy).