### PR TITLE
Connect Geometry: Do not error on non-unique node names

### DIFF
--- a/client/ayon_maya/plugins/inventory/connect_geometry.py
+++ b/client/ayon_maya/plugins/inventory/connect_geometry.py
@@ -1,7 +1,7 @@
 from maya import cmds
 
 from ayon_core.pipeline import InventoryAction, get_repres_contexts
-from ayon_maya.api.lib import get_id
+from ayon_maya.api.lib import get_id, get_container_members
 
 
 class ConnectGeometry(InventoryAction):
@@ -117,8 +117,7 @@ class ConnectGeometry(InventoryAction):
                     id.
         """
         data = {"node_types": set(), "ids": {}}
-        ref_node = cmds.sets(container, query=True, nodesOnly=True)[0]
-        for node in cmds.referenceQuery(ref_node, nodes=True):
+        for node in get_container_members(container):
             node_type = cmds.nodeType(node)
             data["node_types"].add(node_type)
 
@@ -127,7 +126,7 @@ class ConnectGeometry(InventoryAction):
             if node_type != "mesh":
                 continue
 
-            transform = cmds.listRelatives(node, parent=True)[0]
+            transform = cmds.listRelatives(node, parent=True, fullPath=True)[0]
             data["ids"][get_id(transform)] = transform
 
         return data


### PR DESCRIPTION
Fixes an issue using Inventory action "Connect Geometry" where if the hierarchy of the loaded containers contains non-unique node names it would result in an error.

Original error:
```python
Traceback (most recent call last):
#   File "C:\Users\USER\AppData\Local\Ynput\AYON\addons\openpype_3.18.7\openpype\tools\ayon_sceneinventory\view.py", line 458, in _process_custom_action
#     result = action.process(containers)
#   File "C:\Users\USER\AppData\Local\Ynput\AYON\addons\openpype_3.18.7\openpype\hosts\maya\plugins\inventory\connect_geometry.py", line 66, in process
#     source_data = self.get_container_data(source_object)
#   File "C:\Users\USER\AppData\Local\Ynput\AYON\addons\openpype_3.18.7\openpype\hosts\maya\plugins\inventory\connect_geometry.py", line 117, in get_container_data
#     node_type = cmds.nodeType(node)
# RuntimeError: nodeType: No object or UFE path string matches name 'NAMESPACE:_GRP'.
```

Example hierarchy:
![example](https://github.com/user-attachments/assets/f0dfd553-4ba7-4e8d-b59c-59c1cb91049c)