### PR TITLE
Bugfix: Update instance frame ranges on context change

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -3199,15 +3199,15 @@ def update_content_on_context_change():
 
     host = registered_host()
     create_context = CreateContext(host)
-    folder_entity = get_current_task_entity(fields={"attrib"})
+    task_entity = get_current_task_entity(fields={"attrib"})
 
     instance_values = {
         "folderPath": create_context.get_current_folder_path(),
         "task": create_context.get_current_task_name(),
     }
     creator_attribute_values = {
-        "frameStart": folder_entity["attrib"]["frameStart"],
-        "frameEnd": folder_entity["attrib"]["frameEnd"],
+        "frameStart": task_entity["attrib"]["frameStart"],
+        "frameEnd": task_entity["attrib"]["frameEnd"],
     }
 
     has_changes = False

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -3206,8 +3206,8 @@ def update_content_on_context_change():
         "task": create_context.get_current_task_name(),
     }
     creator_attribute_values = {
-        "frameStart": task_entity["attrib"]["frameStart"],
-        "frameEnd": task_entity["attrib"]["frameEnd"],
+        "frameStart": float(task_entity["attrib"]["frameStart"]),
+        "frameEnd": float(task_entity["attrib"]["frameEnd"]),
     }
 
     has_changes = False

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -3231,7 +3231,7 @@ def update_content_on_context_change():
 
             # Update instance creator attribute value
             print(f"Updating {instance.product_name} {key} to: {value}")
-            instance[key] = value
+            creator_attributes[key] = value
             has_changes = True
 
     if has_changes:


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Fix updating of frame ranges for the publish instances when saving the maya scene into another context and pressing OK with "Publish instances" checkbox enabled in the update to new context dialog.

![image](https://github.com/user-attachments/assets/a65b2c93-74fd-459b-aceb-812f82083234)

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

- It was basically a typo where it was trying to set the value into the `instance` instead of the `creator_attributes`.
- When fixed, I also noticed the attributes turned into integers even though by default they are floats - so I converted the values explicitly.
- The variable name `folder_entity` was used for what was the `task_entity` so renamed that as well.

### Question 1: Should it also update frame ranges?

The code does not update the handle start or handle end. And I wonder, should it? If so, we'd need to add:
```python
        "handleStart": float(task_entity["attrib"]["handleStart"]),
        "handleEnd": float(task_entity["attrib"]["handleEnd"]),
```

### Question 2: Should updating of the frame ranges become a separate checkbox from updating the target context (folder/task) in the instance?

Would there be cases where you do want to update the instance to the new folder+task but do not want to update the frame ranges for the instances to the new context? If so, should it be a separate checkbox in the dialog?


## Testing notes:

1. Create a scene with instances that have frame ranges (e.g. review, pointcache, animation instances)
2. Save into another context with a different frame range on the task entity
3. Pressing ok on the 'update to changed context prompt' should update the frame ranges on the publish instances.

---

Clickup AY-6148
