### PR TITLE
Expose Maya Validate Single Assembly for rigs to settings

### DIFF
--- a/client/ayon_maya/plugins/publish/validate_single_assembly.py
+++ b/client/ayon_maya/plugins/publish/validate_single_assembly.py
@@ -1,11 +1,13 @@
 from ayon_core.pipeline.publish import (
     PublishValidationError,
     ValidateContentsOrder,
+    OptionalPyblishPluginMixin
 )
 from ayon_maya.api import plugin
 
 
-class ValidateSingleAssembly(plugin.MayaInstancePlugin):
+class ValidateSingleAssembly(plugin.MayaInstancePlugin,
+                             OptionalPyblishPluginMixin):
     """Ensure the content of the instance is grouped in a single hierarchy
 
     The instance must have a single root node containing all the content.
@@ -25,6 +27,9 @@ class ValidateSingleAssembly(plugin.MayaInstancePlugin):
     label = 'Single Assembly'
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
+
         from maya import cmds
 
         assemblies = cmds.ls(instance, assemblies=True)

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -939,6 +939,10 @@ class PublishersModel(BaseSettingsModel):
             title="Validate Rig Controllers (Arnold Attributes)",
         )
     )
+    ValidateSingleAssembly: BasicValidateModel = SettingsField(
+        default_factory=BasicValidateModel,
+        title="Validate Single Assembly",
+    )
     ValidateSkeletalMeshHierarchy: BasicValidateModel = SettingsField(
         default_factory=BasicValidateModel,
         title="Validate Skeletal Mesh Top Node",
@@ -1472,6 +1476,11 @@ DEFAULT_PUBLISH_SETTINGS = {
         "active": True
     },
     "ValidateRigControllersArnoldAttributes": {
+        "enabled": True,
+        "optional": False,
+        "active": True
+    },
+    "ValidateSingleAssembly": {
         "enabled": True,
         "optional": False,
         "active": True


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Expose Maya Validate Single Assembly for rigs to settings

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

See: https://community.ynput.io/t/unreal-skeletal-mesh-publish-from-maya/1602/4?u=bigroy

## Testing notes:

1. Upload new package.
2. Configure Validate Single Assembly settings
3. Publish of rig should adhere to these settings
