### PR TITLE
Pointcache/Animation: Adhere to the "visible only" toggle

### DIFF
--- a/client/ayon_maya/plugins/publish/collect_pointcache_visible_only.py
+++ b/client/ayon_maya/plugins/publish/collect_pointcache_visible_only.py
@@ -1,0 +1,26 @@
+import pyblish.api
+from ayon_maya.api import plugin
+
+
+class CollectPointcacheVisibleOnly(plugin.MayaInstancePlugin):
+    """Collect pointcache visible only data for instance."""
+
+    order = pyblish.api.CollectorOrder + 0.4
+    families = ["pointcache", "animation", "model", "vrayproxy.alembic"]
+    label = "Collect Pointcache Visible Only"
+
+    def process(self, instance):
+
+        if instance.data["productType"] == "animation":
+            plugin_name = "ExtractAnimation"
+        else:
+            plugin_name = "ExtractAlembic"
+
+        publish_attributes = instance.data.get("publish_attributes", {})
+        plugin_attr_values = publish_attributes.get(plugin_name, {})
+
+        if "visibleOnly" in plugin_attr_values:
+            value = plugin_attr_values["visibleOnly"]
+            instance.data["visibleOnly"] = value
+            self.log.debug(
+                f"Transferring visibleOnly to instance.data: {value}")

--- a/client/ayon_maya/plugins/publish/extract_pointcache.py
+++ b/client/ayon_maya/plugins/publish/extract_pointcache.py
@@ -195,7 +195,7 @@ class ExtractAlembic(plugin.MayaExtractorPlugin, AYONPyblishPluginMixin):
             ),
         }
 
-        if instance.data.get("visibleOnly", False):
+        if attribute_values.get("visibleOnly", False):
             # If we only want to include nodes that are visible in the frame
             # range then we need to do our own check. Alembic's `visibleOnly`
             # flag does not filter out those that are only hidden on some

--- a/client/ayon_maya/plugins/publish/validate_alembic_options_defaults.py
+++ b/client/ayon_maya/plugins/publish/validate_alembic_options_defaults.py
@@ -40,10 +40,6 @@ class ValidateAlembicDefaultsPointcache(
         settings = self._get_settings(instance.context)
         attributes = self._get_publish_attributes(instance)
 
-        import pprint
-        self.log.info(pprint.pformat(settings))
-        self.log.info(pprint.pformat(attributes))
-
         invalid = {}
         for key, value in attributes.items():
             if key not in settings:

--- a/client/ayon_maya/plugins/publish/validate_alembic_options_defaults.py
+++ b/client/ayon_maya/plugins/publish/validate_alembic_options_defaults.py
@@ -3,6 +3,7 @@ import inspect
 import pyblish.api
 from ayon_core.pipeline import OptionalPyblishPluginMixin
 from ayon_core.pipeline.publish import PublishValidationError, RepairAction
+from ayon_core.pipeline.create.context import PublishAttributeValues
 from ayon_maya.api import plugin
 
 
@@ -38,6 +39,10 @@ class ValidateAlembicDefaultsPointcache(
 
         settings = self._get_settings(instance.context)
         attributes = self._get_publish_attributes(instance)
+
+        import pprint
+        self.log.info(pprint.pformat(settings))
+        self.log.info(pprint.pformat(attributes))
 
         invalid = {}
         for key, value in attributes.items():
@@ -101,8 +106,10 @@ class ValidateAlembicDefaultsPointcache(
 
         # Set the settings values on the create context then save to workfile.
         settings = cls._get_settings(instance.context)
-        attributes = cls._get_publish_attributes(create_instance)
-        for key in attributes:
+        attributes: PublishAttributeValues = (
+            cls._get_publish_attributes(create_instance)
+        )
+        for key in attributes.keys():
             if key not in settings:
                 # This may occur if attributes have changed over time and an
                 # existing instance has older legacy attributes that do not


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Actually trigger the visible only logic when it is enabled.


## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->


With Visible Only enabled for the alembic exports it should ONLY include objects that are visible at least once in the timeline during the to be exproted frame range.

So create a group with four cubes:



## Testing notes:

1. Create some cubes with visibilities.
```
grp/
    cube_visible
    cube_invisible
    cube_visible_in_range
    cube_visible_outside_range
```

2. And then publish the frame range with visible only enabled.
3. Load back in. Only the cubes visible inside the frame range should be included in the export when loading back in.

---

Clickup AY-6188