### PR TITLE
Get visible in range: Avoid deprecation warning

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -3678,7 +3678,7 @@ def iter_visible_nodes_in_range(nodes, start, end):
                                                                 None)
                     if dependency_visible is None:
                         mplug = get_visibility_mplug(dependency)
-                        dependency_visible = mplug.asBool(context)
+                        dependency_visible = mplug.asBool()
                         frame_visibilities[dependency] = dependency_visible
 
                     if not dependency_visible:

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -3671,7 +3671,7 @@ def iter_visible_nodes_in_range(nodes, start, end):
         # again if it was checked on this frame and also is a dependency
         # for another node
         frame_visibilities = {}
-        with dgcontext(mtime) as context:
+        with dgcontext(mtime):
             for node, dependencies in list(node_dependencies.items()):
                 for dependency in dependencies:
                     dependency_visible = frame_visibilities.get(dependency,


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Avoid deprecation warning when calling `iter_visible_nodes_in_range`

```
DeprecationWarning: Call MPlug::asType() instead. If needed, use MDGContextGuard switch context.
```

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

Follow-up PR to https://github.com/ynput/ayon-maya/pull/40 but also separate of it since it's a separate issue.
Calling the `iter_visible_nodes_in_range` function may log a deprecation warning in maya (once)

## Testing notes:

1. Create a group with some cubes underneath
2. Animate the cubes where they are sometimes off in visibility and sometimes on.
3. Select the group 
4. Then select a frame range (set in script!) where only a few of the objects are visible during that time.
5. **Go to a frame where some of the objects are NOT visible** (otherwise the problematic code is 'optimized out' because it does a check for visibility on current frame first)

Run script:
```python
import ayon_maya.api.lib as lib
from maya import cmds

# Ensure deprecation warnings trigger each run
import warnings
warnings.resetwarnings()

# Reload the lib so we can live check things while changing the code in dev mode
import importlib
importlib.reload(lib)

FRAME_START = 1002
FRAME_END = 1010

grp = cmds.ls(sl=1)[0]
children = cmds.listRelatives(grp, children=True, fullPath=True)
if not children:
    raise RuntimeError(f"No children for {grp}")

visible = lib.iter_visible_nodes_in_range(children, FRAME_START, FRAME_END)

for node in visible:
    print(f"Visible node: {node}")
```

**The important bit:** The visibility should **still be detected correctly** So it should still report the correct objects visible in the selected frame range, even if not visible on current frame!
