### PR TITLE
Improve Maya USD Extraction

### DIFF
--- a/client/ayon_maya/plugins/create/create_maya_usd.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd.py
@@ -2,21 +2,22 @@ from ayon_maya.api import plugin, lib
 from ayon_core.lib import (
     BoolDef,
     EnumDef,
-    TextDef
+    TextDef,
+    UILabelDef,
+    UISeparatorDef,
 )
 
 from maya import cmds
 
 
 class CreateMayaUsd(plugin.MayaCreator):
-    """Create Maya USD Export"""
+    """Create Maya USD Export from maya scene objects"""
 
     identifier = "io.openpype.creators.maya.mayausd"
     label = "Maya USD"
     product_type = "usd"
     icon = "cubes"
     description = "Create Maya USD Export"
-
     cache = {}
 
     def get_publish_families(self):
@@ -44,7 +45,15 @@ class CreateMayaUsd(plugin.MayaCreator):
 
             self.cache["jobContextItems"] = job_context_items
 
-        defs = lib.collect_animation_defs()
+        defs = [
+            BoolDef("exportAnimationData",
+                    label="Export Animation Data",
+                    tooltip="When disabled no frame range is exported and "
+                            "only the start frame is used to define the "
+                            "static export frame.",
+                    default=True)
+        ]
+        defs.extend(lib.collect_animation_defs())
         defs.extend([
             EnumDef("defaultUSDFormat",
                     label="File format",
@@ -53,6 +62,17 @@ class CreateMayaUsd(plugin.MayaCreator):
                         "usda": "ASCII"
                     },
                     default="usdc"),
+            # TODO: Remove note from tooltip when issue is resolved, see:
+            #  https://github.com/Autodesk/maya-usd/issues/3389
+            BoolDef("exportRoots",
+                    label="Export as roots",
+                    tooltip=(
+                        "Export the members of the object sets without "
+                        "their parents.\n"
+                        "Note: There's an export bug that when this is "
+                        "enabled MayaUsd fails to export instance meshes"
+                    ),
+                    default=True),
             BoolDef("stripNamespaces",
                     label="Strip Namespaces",
                     tooltip=(
@@ -99,4 +119,128 @@ class CreateMayaUsd(plugin.MayaCreator):
                     multiselection=True),
         ])
 
+        return defs
+
+
+class CreateMayaUsdContribution(CreateMayaUsd):
+    """
+
+    When writing a USD as 'contribution' it will be added into what it's
+    contributing to. It will usually contribute to either the main *asset*
+    or *shot* but can be customized.
+
+    Usually the contribution is done into a Department Layer, like e.g.
+    model, rig, look for models and layout, animation, fx, lighting for shots.
+
+    Each department contribution will be 'sublayered' into the departments
+    contribution.
+
+    """
+
+    identifier = "io.openpype.creators.maya.mayausd.assetcontribution"
+    label = "Maya USD Asset Contribution"
+    product_type = "usd"
+    icon = "cubes"
+    description = "Create Maya USD Contribution"
+
+    # default_variants = ["main"]
+    # TODO: Do not include material for model publish
+    # TODO: Do only include material + assignments for material publish
+    #       + attribute overrides onto existing geo? (`over`?)
+    #       Define all in `geo` as `over`?
+
+    bootstrap = "asset"
+
+    contribution_asset_layer = None
+
+    def create_template_hierarchy(self, folder_name, variant):
+        """Create the asset root template to hold the geo for the usd asset.
+
+        Args:
+            folder_name: Asset name to use for the group
+            variant: Variant name to use as namespace.
+                This is needed so separate asset contributions can be
+                correctly created from a single scene.
+
+        Returns:
+            list: The root node and geometry group.
+
+        """
+
+        def set_usd_type(node, value):
+            attr = "USD_typeName"
+            if not cmds.attributeQuery(attr, node=node, exists=True):
+                cmds.addAttr(node, ln=attr, dt="string")
+            cmds.setAttr(f"{node}.{attr}", value, type="string")
+
+        # Ensure simple unique namespace (add trailing number)
+        namespace = variant
+        name = f"{namespace}:{folder_name}"
+        i = 1
+        while cmds.objExists(name):
+            name = f"{namespace}{i}:{folder_name}"
+            i += 1
+
+        # Define template hierarchy {folder_name}/geo
+        root = cmds.createNode("transform",
+                               name=name,
+                               skipSelect=True)
+        geo = cmds.createNode("transform",
+                              name="geo",
+                              parent=root,
+                              skipSelect=True)
+        set_usd_type(geo, "Scope")
+        # Lock + hide transformations since we're exporting as Scope
+        for attr in ["tx", "ty", "tz", "rx", "ry", "rz", "sx", "sy", "sz"]:
+            cmds.setAttr(f"{geo}.{attr}", lock=True, keyable=False)
+
+        return [root, geo]
+
+    def create(self, subset_name, instance_data, pre_create_data):
+
+        # Create template hierarchy
+        if pre_create_data.get("createTemplateHierarchy", True):
+            members = []
+            if pre_create_data.get("use_selection"):
+                members = cmds.ls(selection=True,
+                                  long=True,
+                                  type="dagNode")
+
+            folder_path = instance_data["folderPath"]
+            folder_name = folder_path.rsplit("/", 1)[-1]
+
+            root, geo = self.create_template_hierarchy(
+                folder_name=folder_name,
+                variant=instance_data["variant"]
+            )
+
+            if members:
+                cmds.parent(members, geo)
+
+            # Select root and enable selection just so parent class'
+            # create adds it to the created instance
+            cmds.select(root, replace=True, noExpand=True)
+            pre_create_data["use_selection"] = True
+
+        # Create as if we're the other plug-in so that the instance after
+        # creation thinks it was created by `CreateMayaUsd` and this Creator
+        # here is solely used to apply different default values
+        # TODO: Improve this hack
+        CreateMayaUsd(
+            project_settings=self.project_settings,
+            create_context=self.create_context
+        ).create(
+            subset_name,
+            instance_data,
+            pre_create_data
+        )
+
+    def get_pre_create_attr_defs(self):
+        defs = super(CreateMayaUsdContribution,
+                     self).get_pre_create_attr_defs()
+        defs.extend([
+            BoolDef("createTemplateHierarchy",
+                    label="Create template hierarchy",
+                    default=True)
+        ])
         return defs

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -2,7 +2,6 @@ import contextlib
 import json
 import os
 
-import pyblish.api
 import six
 
 from ayon_core.pipeline import publish

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -4,9 +4,34 @@ import os
 
 import pyblish.api
 import six
-from ayon_maya.api.lib import maintained_selection
+
+from ayon_core.pipeline import publish
+from ayon_core.lib import BoolDef
+from ayon_maya.api.lib import maintained_selection, maintained_time
 from ayon_maya.api import plugin
+
 from maya import cmds
+import maya.api.OpenMaya as om
+
+
+def parse_version(version_str):
+    """Parse string like '0.26.0' to (0, 26, 0)"""
+    return tuple(int(v) for v in version_str.split("."))
+
+
+def get_node_hash(node):
+    """Return integer MObjectHandle hash code.
+
+    Arguments:
+        node (str): Maya node path.
+
+    Returns:
+        int: MObjectHandle.hashCode()
+
+    """
+    sel = om.MSelectionList()
+    sel.add(node)
+    return om.MObjectHandle(sel.getDependNode(0)).hashCode()
 
 
 @contextlib.contextmanager
@@ -43,8 +68,6 @@ def usd_export_attributes(nodes, attrs=None, attr_prefixes=None, mapping=None):
     # todo: this might be better done with a custom export chaser
     #   see `chaser` argument for `mayaUSDExport`
 
-    import maya.api.OpenMaya as om
-
     if not attrs and not attr_prefixes:
         # context manager does nothing
         yield
@@ -60,16 +83,23 @@ def usd_export_attributes(nodes, attrs=None, attr_prefixes=None, mapping=None):
     usd_json_attr = "USD_UserExportedAttributesJson"
     strings = attrs + ["{}*".format(prefix) for prefix in attr_prefixes]
     context_state = {}
+
+    # Keep track of the processed nodes as a node might appear more than once
+    # e.g. when there are instances.
+    processed = set()
     for node in set(nodes):
         node_attrs = cmds.listAttr(node, st=strings)
         if not node_attrs:
             # Nothing to do for this node
             continue
 
+        hash_code = get_node_hash(node)
+        if hash_code in processed:
+            continue
+
         node_attr_data = {}
         for node_attr in set(node_attrs):
             node_attr_data[node_attr] = mapping.get(node_attr, {})
-
         if cmds.attributeQuery(usd_json_attr, node=node, exists=True):
             existing_node_attr_value = cmds.getAttr(
                 "{}.{}".format(node, usd_json_attr)
@@ -81,6 +111,7 @@ def usd_export_attributes(nodes, attrs=None, attr_prefixes=None, mapping=None):
                 existing_node_attr_data = json.loads(existing_node_attr_value)
                 node_attr_data.update(existing_node_attr_data)
 
+        processed.add(hash_code)
         context_state[node] = json.dumps(node_attr_data)
 
     sel = om.MSelectionList()
@@ -111,7 +142,8 @@ def usd_export_attributes(nodes, attrs=None, attr_prefixes=None, mapping=None):
         dg_mod.undoIt()
 
 
-class ExtractMayaUsd(plugin.MayaExtractorPlugin):
+class ExtractMayaUsd(plugin.MayaExtractorPlugin,
+                     publish.OptionalPyblishPluginMixin):
     """Extractor for Maya USD Asset data.
 
     Upon publish a .usd (or .usdz) asset file will typically be written.
@@ -146,8 +178,12 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin):
             "exportRefsAsInstanceable": bool,
             "eulerFilter": bool,
             "renderableOnly": bool,
-            "jobContext": (list, None)  # optional list
-            # "worldspace": bool,
+            "convertMaterialsTo": str,
+            "shadingMode": (str, None),  # optional str
+            "jobContext": (list, None),  # optional list
+            "filterTypes": (list, None),  # optional list
+            "staticSingleSample": bool,
+            "worldspace": bool,
         }
 
     @property
@@ -158,18 +194,22 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin):
         return {
             "defaultUSDFormat": "usdc",
             "stripNamespaces": False,
-            "mergeTransformAndShape": False,
+            "mergeTransformAndShape": True,
             "exportDisplayColor": False,
             "exportColorSets": True,
             "exportInstances": True,
             "exportUVs": True,
             "exportVisibility": True,
-            "exportComponentTags": True,
+            "exportComponentTags": False,
             "exportRefsAsInstanceable": False,
             "eulerFilter": True,
             "renderableOnly": False,
-            "jobContext": None
-            # "worldspace": False
+            "shadingMode": "none",
+            "convertMaterialsTo": "none",
+            "jobContext": None,
+            "filterTypes": None,
+            "staticSingleSample": True,
+            "worldspace": False
         }
 
     def parse_overrides(self, instance, options):
@@ -202,6 +242,10 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin):
         return members
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
+
+        attr_values = self.get_attr_values_from_data(instance.data)
 
         # Load plugin first
         cmds.loadPlugin("mayaUsdPlugin", quiet=True)
@@ -227,10 +271,45 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin):
             self.log.error('No members!')
             return
 
-        start = instance.data["frameStartHandle"]
-        end = instance.data["frameEndHandle"]
+        export_anim_data = instance.data.get("exportAnimationData", True)
+        start = instance.data.get("frameStartHandle", 0)
+
+        if export_anim_data:
+            end = instance.data["frameEndHandle"]
+            options["frameRange"] = (start, end)
+            options["frameStride"] = instance.data.get("step", 1.0)
+
+        if instance.data.get("exportRoots", True):
+            # Do not include 'objectSets' as roots because the export command
+            # will fail. We only include the transforms among the members.
+            options["exportRoots"] = cmds.ls(members,
+                                             type="transform",
+                                             long=True)
+        else:
+            options["selection"] = True
+
+        options["stripNamespaces"] = attr_values.get("stripNamespaces", True)
+        options["exportComponentTags"] = attr_values.get("exportComponentTags",
+                                                         False)
+        options["worldspace"] = attr_values.get("worldspace", True)
+
+        # TODO: Remove hardcoded filterTypes
+        # We always filter constraint types because they serve no valuable
+        # data (it doesn't preserve the actual constraint) but it does
+        # introduce the problem that Shapes do not merge into the Transform
+        # on export anymore because they are usually parented under transforms
+        # See: https://github.com/Autodesk/maya-usd/issues/2070
+        options["filterTypes"] = ["constraint"]
 
         def parse_attr_str(attr_str):
+            """Return list of strings from `a,b,c,,d` to `[a, b, c, d]`.
+
+            Args:
+                attr_str (str): Concatenated attributes by comma
+
+            Returns:
+                List[str]: list of attributes
+            """
             result = list()
             for attr in attr_str.split(","):
                 attr = attr.strip()
@@ -244,16 +323,40 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin):
         attrs += ["cbId"]
         attr_prefixes = parse_attr_str(instance.data.get("attrPrefix", ""))
 
+        # Remove arguments for Maya USD versions not supporting them yet
+        # Note: Maya 2022.3 ships with Maya USD 0.13.0.
+        # TODO: Remove this backwards compatibility if Maya 2022 support is
+        #   dropped
+        maya_usd_version = parse_version(
+            cmds.pluginInfo("mayaUsdPlugin", query=True, version=True)
+        )
+        for key, required_minimal_version in {
+            "exportComponentTags": (0, 14, 0),
+            "jobContext": (0, 15, 0)
+        }.items():
+            if key in options and maya_usd_version < required_minimal_version:
+                self.log.warning(
+                    "Ignoring export flag '%s' because Maya USD version "
+                    "%s is lower than minimal supported version %s.",
+                    key,
+                    maya_usd_version,
+                    required_minimal_version
+                )
+                del options[key]
+
         self.log.debug('Exporting USD: {} / {}'.format(file_path, members))
-        with maintained_selection():
-            with usd_export_attributes(instance[:],
-                                       attrs=attrs,
-                                       attr_prefixes=attr_prefixes):
-                cmds.mayaUSDExport(file=file_path,
-                                   frameRange=(start, end),
-                                   frameStride=instance.data.get("step", 1.0),
-                                   exportRoots=members,
-                                   **options)
+        with maintained_time():
+            with maintained_selection():
+                if not export_anim_data:
+                    # Use start frame as current time
+                    cmds.currentTime(start)
+
+                with usd_export_attributes(instance[:],
+                                           attrs=attrs,
+                                           attr_prefixes=attr_prefixes):
+                    cmds.select(members, replace=True, noExpand=True)
+                    cmds.mayaUSDExport(file=file_path,
+                                       **options)
 
         representation = {
             'name': "usd",
@@ -267,6 +370,25 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin):
             "Extracted instance {} to {}".format(instance.name, file_path)
         )
 
+    @classmethod
+    def get_attribute_defs(cls):
+        return super(ExtractMayaUsd, cls).get_attribute_defs() + [
+            BoolDef("stripNamespaces",
+                    label="Strip Namespaces (USD)",
+                    tooltip="Strip Namespaces in the USD Export",
+                    default=True),
+            BoolDef("worldspace",
+                    label="World-Space (USD)",
+                    tooltip="Export all root prim using their full worldspace "
+                            "transform instead of their local transform.",
+                    default=True),
+            BoolDef("exportComponentTags",
+                    label="Export Component Tags",
+                    tooltip="When enabled, export any geometry component tags "
+                            "as UsdGeomSubset data.",
+                    default=False)
+        ]
+
 
 class ExtractMayaUsdAnim(ExtractMayaUsd):
     """Extractor for Maya USD Animation Sparse Cache data.
@@ -276,10 +398,16 @@ class ExtractMayaUsdAnim(ExtractMayaUsd):
 
     Upon publish a .usd sparse cache will be written.
     """
-    label = "Extract Maya USD Animation Sparse Cache"
-    families = ["animation", "mayaUsd"]
-    match = pyblish.api.Subset
+    label = "Extract USD Animation"
+    families = ["animation"]
 
+    # Exposed in settings
+    optional = True
+    active = False
+
+    # TODO: Support writing out point deformation only, avoid writing UV sets
+    #       component tags and potentially remove `faceVertexCounts`,
+    #       `faceVertexIndices` and `doubleSided` parameters as well.
     def filter_members(self, members):
         out_set = next((i for i in members if i.endswith("out_SET")), None)
 
@@ -289,3 +417,33 @@ class ExtractMayaUsdAnim(ExtractMayaUsd):
 
         members = cmds.ls(cmds.sets(out_set, query=True), long=True)
         return members
+
+
+class ExtractMayaUsdModel(ExtractMayaUsd):
+    """Extractor for Maya USD Asset data for model family
+
+    Upon publish a .usd (or .usdz) asset file will typically be written.
+    """
+
+    label = "Extract USD"
+    families = ["model"]
+
+    # Exposed in settings
+    optional = True
+    active = False
+
+    def process(self, instance):
+        # TODO: Fix this without changing instance data
+        instance.data["exportAnimationData"] = False
+        super(ExtractMayaUsdModel, self).process(instance)
+
+
+class ExtractMayaUsdPointcache(ExtractMayaUsd):
+    """Extractor for Maya USD for 'pointcache' family"""
+
+    label = "Extract USD"
+    families = ["pointcache"]
+
+    # Exposed in settings
+    optional = True
+    active = False

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -538,6 +538,24 @@ class ExtractModelModel(BaseSettingsModel):
     active: bool = SettingsField(title="Active")
 
 
+class ExtractMayaUsdModelModel(BaseSettingsModel):
+    enabled: bool = SettingsField(title="Enabled")
+    optional: bool = SettingsField(title="Optional")
+    active: bool = SettingsField(title="Active")
+
+
+class ExtractMayaUsdPointcacheModel(BaseSettingsModel):
+    enabled: bool = SettingsField(title="Enabled")
+    optional: bool = SettingsField(title="Optional")
+    active: bool = SettingsField(title="Active")
+
+
+class ExtractMayaUsdAnimationModel(BaseSettingsModel):
+    enabled: bool = SettingsField(title="Enabled")
+    optional: bool = SettingsField(title="Optional")
+    active: bool = SettingsField(title="Active")
+
+
 class ExtractMayaSceneRawModel(BaseSettingsModel):
     """Add loaded instances to those published families:"""
     enabled: bool = SettingsField(title="ExtractMayaSceneRaw")
@@ -1042,6 +1060,18 @@ class PublishersModel(BaseSettingsModel):
     ExtractAlembic: ExtractAlembicModel = SettingsField(
         default_factory=ExtractAlembicModel,
         title="Extract Alembic"
+    )
+    ExtractMayaUsdModel: ExtractMayaUsdModelModel = SettingsField(
+        default_factory=ExtractMayaUsdModelModel,
+        title="Extract Maya USD with Model"
+    )
+    ExtractMayaUsdPointcache: ExtractMayaUsdPointcacheModel = SettingsField(
+        default_factory=ExtractMayaUsdPointcacheModel,
+        title="Extract Maya USD with Pointcache"
+    )
+    ExtractMayaUsdAnimation: ExtractMayaUsdAnimationModel = SettingsField(
+        default_factory=ExtractMayaUsdAnimationModel,
+        title="Extract Maya USD with Animation"
     )
 
 
@@ -1663,5 +1693,20 @@ DEFAULT_PUBLISH_SETTINGS = {
         "writeNormals": True,
         "writeUVSets": False,
         "writeVisibility": False
+    },
+    "ExtractMayaUsdModel": {
+        "enabled": True,
+        "optional": True,
+        "active": False,
+    },
+    "ExtractMayaUsdPointcache": {
+        "enabled": True,
+        "optional": True,
+        "active": False,
+    },
+    "ExtractMayaUsdAnimation": {
+        "enabled": True,
+        "optional": True,
+        "active": False,
     }
 }


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Add more options to the Maya USD Extractor:
- Expose USD extractor for model and pointcache family
- Do not export shaders by default
- Allow to Enable/disable animation data
- Update defaults to be more sensible like maya's defaults
- Allow using export roots to exclude parents in export
- Allow to export in worldspace when parents are not included
- Ignore constraints to avoid constraints breaking merge transform/shape behavior

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

Separated from #2

## Testing notes:

1. Maya USD extraction should work
2. When enabled, model extraction with Extract `usd` enabled should work
3. When enabled, pointcache extraction with Extract `usd` enabled should work
4. When enabled, animation extraction with Extract `usd` enabled should work
5. The Maya USD Creator has a **Create Asset Hierarchy** checkbox (on Create tab) which should do what it describes:

![image](https://github.com/user-attachments/assets/2b180ab2-b5b6-4cc5-b849-be916425b791)
