### PR TITLE
Implement Maya USD Proxy extractor for one of the layers in the proxy

### DIFF
--- a/client/ayon_maya/plugins/create/create_maya_usd_layer.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd_layer.py
@@ -1,0 +1,59 @@
+from ayon_maya.api import plugin
+from ayon_core.lib import EnumDef
+
+
+class CreateMayaUsdLayer(plugin.MayaCreator):
+    """Create Maya USD Export from `mayaUsdProxyShape` layer"""
+
+    identifier = "io.openpype.creators.maya.mayausdlayer"
+    label = "Maya USD Export Layer"
+    family = "usd"
+    icon = "cubes"
+    description = "Create mayaUsdProxyShape layer export"
+
+    def get_publish_families(self):
+        return ["usd", "mayaUsdLayer"]
+
+    def get_instance_attr_defs(self):
+
+        from maya import cmds
+        import mayaUsd
+
+        # Construct the stage + layer EnumDef from the maya proxies in the
+        # scene and the Sdf.Layer stack of the Usd.Stage per proxy.
+        items = []
+        for proxy in cmds.ls(type="mayaUsdProxyShape", long=True):
+            stage = mayaUsd.ufe.getStage("|world{}".format(proxy))
+            if not stage:
+                continue
+
+            for layer in stage.GetLayerStack(includeSessionLayers=False):
+
+                proxy_nice_name = proxy.rsplit("|", 2)[-2]
+                layer_nice_name = layer.GetDisplayName()
+                label = "{} -> {}".format(proxy_nice_name, layer_nice_name)
+                value = ">".join([proxy, layer.identifier])
+
+                items.append({
+                    "label": label,
+                    "value": value
+                })
+
+        if not items:
+            # EnumDef is not allowed to be empty
+            items.append("<NONE>")
+
+        defs = [
+            EnumDef("defaultUSDFormat",
+                    label="File format",
+                    items={
+                        "usdc": "Binary",
+                        "usda": "ASCII"
+                    },
+                    default="usdc"),
+            EnumDef("stageLayerIdentifier",
+                    label="Stage and Layer Identifier",
+                    items=items)
+        ]
+
+        return defs

--- a/client/ayon_maya/plugins/create/create_maya_usd_layer.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd_layer.py
@@ -7,7 +7,7 @@ class CreateMayaUsdLayer(plugin.MayaCreator):
 
     identifier = "io.openpype.creators.maya.mayausdlayer"
     label = "Maya USD Export Layer"
-    family = "usd"
+    product_type = "usd"
     icon = "cubes"
     description = "Create mayaUsdProxyShape layer export"
 

--- a/client/ayon_maya/plugins/publish/extract_maya_usd_layer.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd_layer.py
@@ -1,0 +1,63 @@
+import os
+
+from maya import cmds
+from ayon_core.pipeline import publish
+
+
+class ExtractMayaUsdLayer(publish.Extractor):
+    """Extractor for Maya USD Layer from `mayaUsdProxyShape`
+
+    Exports a single Sdf.Layer from a mayaUsdPlugin `mayaUsdProxyShape`.
+    These layers are the same managed via Maya's Windows > USD Layer Editor.
+
+    """
+
+    label = "Extract Maya USD Layer"
+    hosts = ["maya"]
+    families = ["mayaUsdLayer"]
+
+    def process(self, instance):
+
+        import mayaUsd
+
+        # Load plugin first
+        cmds.loadPlugin("mayaUsdPlugin", quiet=True)
+
+        data = instance.data["stageLayerIdentifier"]
+        proxy, layer_identifier = data.split(">", 1)
+
+        # TODO: The stage and layer should actually be retrieved during
+        #  Collecting so that they can be validated upon and potentially that
+        #  any 'child layers' can potentially be recursively exported along
+        stage = mayaUsd.ufe.getStage('|world' + proxy)
+        layers = stage.GetLayerStack(includeSessionLayers=False)
+        layer = next(
+            layer for layer in layers if layer.identifier == layer_identifier
+        )
+
+        # Define output file path
+        staging_dir = self.staging_dir(instance)
+        file_name = "{0}.usd".format(instance.name)
+        file_path = os.path.join(staging_dir, file_name)
+        file_path = file_path.replace('\\', '/')
+
+        self.log.debug("Exporting USD layer to: {}".format(file_path))
+        layer.Export(file_path, args={
+            "format": instance.data.get("defaultUSDFormat", "usdc")
+        })
+
+        # TODO: We might want to remap certain paths - to do so we could take
+        #  the SdfLayer and transfer its contents into a anonymous SdfLayer
+        #  then we can use the copy to alter it in memory to our like before
+        #  writing out
+
+        representation = {
+            'name': "usd",
+            'ext': "usd",
+            'files': file_name,
+            'stagingDir': staging_dir
+        }
+        instance.data.setdefault("representations", []).append(representation)
+        self.log.debug(
+            "Extracted instance {} to {}".format(instance.name, file_path)
+        )

--- a/client/ayon_maya/plugins/publish/extract_maya_usd_layer.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd_layer.py
@@ -24,8 +24,9 @@ class ExtractMayaUsdLayer(publish.Extractor):
         cmds.loadPlugin("mayaUsdPlugin", quiet=True)
 
         data = instance.data["stageLayerIdentifier"]
-        proxy, layer_identifier = data.split(">", 1)
+        self.log.debug(f"Using proxy layer: {data}")
 
+        proxy, layer_identifier = data.split(">", 1)
         # TODO: The stage and layer should actually be retrieved during
         #  Collecting so that they can be validated upon and potentially that
         #  any 'child layers' can potentially be recursively exported along


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Add Creator to extract a single USD layer from a Maya USD Proxy Shape as output data.

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

This would be used to do e.g. an export of LookdevX (Maya's USD shader assignments) materials with their bindings to the geometry.

Separated from #2 

## Testing notes:

1. Creator should work
2. Instance should allow you to pick _which_ USD maya proxy shape layer from the scene to export