### PR TITLE
add alembic options for extract layout

### DIFF
--- a/client/ayon_maya/plugins/create/create_layout.py
+++ b/client/ayon_maya/plugins/create/create_layout.py
@@ -17,5 +17,9 @@ class CreateLayout(plugin.MayaCreator):
                     label="Group Loaded Assets",
                     tooltip="Enable this when you want to publish group of "
                             "loaded asset",
-                    default=False)
+                    default=False),
+            BoolDef("alembic",
+                    label="Layout for Alembic Export",
+                    tooltip="Create layout which stores transformation for "
+                            "alembic export")
         ]

--- a/client/ayon_maya/plugins/create/create_layout.py
+++ b/client/ayon_maya/plugins/create/create_layout.py
@@ -17,9 +17,5 @@ class CreateLayout(plugin.MayaCreator):
                     label="Group Loaded Assets",
                     tooltip="Enable this when you want to publish group of "
                             "loaded asset",
-                    default=False),
-            BoolDef("alembic",
-                    label="Layout for Alembic Export",
-                    tooltip="Create layout which stores transformation for "
-                            "alembic export")
+                    default=False)
         ]

--- a/client/ayon_maya/plugins/create/create_layout.py
+++ b/client/ayon_maya/plugins/create/create_layout.py
@@ -20,6 +20,6 @@ class CreateLayout(plugin.MayaCreator):
                     default=False),
             EnumDef("layout_options",
                     items=["fbx", "abc"],
-                    label="Export Layout For Fbx",
+                    label="Export Layout Options",
                     default="fbx")
         ]

--- a/client/ayon_maya/plugins/create/create_layout.py
+++ b/client/ayon_maya/plugins/create/create_layout.py
@@ -1,5 +1,5 @@
 from ayon_maya.api import plugin
-from ayon_core.lib import BoolDef
+from ayon_core.lib import BoolDef, EnumDef
 
 
 class CreateLayout(plugin.MayaCreator):
@@ -17,5 +17,9 @@ class CreateLayout(plugin.MayaCreator):
                     label="Group Loaded Assets",
                     tooltip="Enable this when you want to publish group of "
                             "loaded asset",
-                    default=False)
+                    default=False),
+            EnumDef("layout_options",
+                    items=["fbx", "abc"],
+                    label="Export Layout For Fbx",
+                    default="fbx")
         ]

--- a/client/ayon_maya/plugins/publish/collect_layout_options.py
+++ b/client/ayon_maya/plugins/publish/collect_layout_options.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+import pyblish.api
+from ayon_maya.api import plugin
+
+
+class CollectLayoutOptions(plugin.MayaInstancePlugin):
+    """Collect Camera for FBX export."""
+
+    order = pyblish.api.CollectorOrder + 0.2
+    label = "Collect Layout Options"
+    families = ["layout"]
+
+    def process(self, instance):
+        if instance.data.get("layout_options") == "fbx":
+            instance.data["families"] += ["layout.fbx"]
+        elif instance.data.get("layout_options") == "abc":
+            instance.data["families"] += ["layout.abc"]
+        else:
+            self.log.error("No layout options found.")

--- a/client/ayon_maya/plugins/publish/extract_layout.py
+++ b/client/ayon_maya/plugins/publish/extract_layout.py
@@ -116,6 +116,7 @@ class ExtractLayout(plugin.MayaExtractorPlugin):
             # TODO use product entity to get product type rather than
             #    data in representation 'context'
             repre_context = representation["context"]
+            repre_ext = repre_context["ext"]
             product_type = repre_context.get("product", {}).get("type")
             if not product_type:
                 product_type = repre_context.get("family")
@@ -125,7 +126,8 @@ class ExtractLayout(plugin.MayaExtractorPlugin):
                 "instance_name": cmds.getAttr(
                     "{}.namespace".format(container)),
                 "representation": str(representation_id),
-                "version": str(version_id)
+                "version": str(version_id),
+                "ext": repre_ext
             }
 
 
@@ -134,6 +136,7 @@ class ExtractLayout(plugin.MayaExtractorPlugin):
 
             matrix = om.MMatrix(local_matrix)
             if instance.data.get("alembic", False):
+                self.log.debug("Converting transformation for alembic export.")
                 matrix = convert_transformation_matrix_abc(matrix, local_rotation)
             t_matrix = convert_matrix_to_4x4_list(matrix)
 

--- a/client/ayon_maya/plugins/publish/extract_layout.py
+++ b/client/ayon_maya/plugins/publish/extract_layout.py
@@ -29,7 +29,7 @@ def convert_matrix_to_4x4_list(
     return result
 
 
-def convert_transformation_matrix(transform_mm: om.MMatrix, rotation: list) -> om.MMatrix:
+def convert_transformation_matrix_abc(transform_mm: om.MMatrix, rotation: list) -> om.MMatrix:
     """Convert matrix to list of transformation matrix for Unreal Engine import.
 
     Args:
@@ -133,7 +133,8 @@ class ExtractLayout(plugin.MayaExtractorPlugin):
             local_rotation = cmds.xform(asset, query=True, rotation=True, euler=True)
 
             matrix = om.MMatrix(local_matrix)
-            matrix = convert_transformation_matrix(matrix, local_rotation)
+            if instance.data.get("alembic", False):
+                matrix = convert_transformation_matrix_abc(matrix, local_rotation)
             t_matrix = convert_matrix_to_4x4_list(matrix)
 
             json_element["transform_matrix"] = [

--- a/client/ayon_maya/plugins/publish/extract_layout.py
+++ b/client/ayon_maya/plugins/publish/extract_layout.py
@@ -29,31 +29,6 @@ def convert_matrix_to_4x4_list(
     return result
 
 
-def convert_transformation_matrix(transform_mm: om.MMatrix, rotation: list) -> om.MMatrix:
-    """Convert matrix to list of transformation matrix for Unreal Engine import.
-
-    Args:
-        transform_mm (om.MMatrix): Local Matrix for the asset
-        rotation (list): Rotations of the asset
-
-    Returns:
-        List[om.MMatrix]: List of transformation matrix of the asset
-    """
-    convert_transform = om.MTransformationMatrix(transform_mm)
-
-    convert_translation = convert_transform.translation(om.MSpace.kWorld)
-    convert_translation = om.MVector(convert_translation.x, convert_translation.z, convert_translation.y)
-    convert_scale = convert_transform.scale(om.MSpace.kObject)
-    convert_transform.setTranslation(convert_translation, om.MSpace.kWorld)
-    converted_rotation = om.MEulerRotation(
-        math.radians(rotation[0]), math.radians(rotation[2]), math.radians(rotation[1])
-    )
-    convert_transform.setRotation(converted_rotation)
-    convert_transform.setScale([convert_scale[0], convert_scale[2], convert_scale[1]], om.MSpace.kObject)
-
-    return convert_transform.asMatrix()
-
-
 class ExtractLayout(plugin.MayaExtractorPlugin):
     """Extract a layout."""
 
@@ -177,9 +152,33 @@ class ExtractLayout(plugin.MayaExtractorPlugin):
 
     def create_transformation_matrix(self, local_matrix, local_rotation):
         matrix = om.MMatrix(local_matrix)
-        matrix = convert_transformation_matrix(matrix, local_rotation)
+        matrix = self.convert_transformation_matrix(matrix, local_rotation)
         t_matrix = convert_matrix_to_4x4_list(matrix)
         return t_matrix
+
+    def convert_transformation_matrix(self, transform_mm: om.MMatrix, rotation: list) -> om.MMatrix:
+        """Convert matrix to list of transformation matrix for Unreal Engine import.
+
+        Args:
+            transform_mm (om.MMatrix): Local Matrix for the asset
+            rotation (list): Rotations of the asset
+
+        Returns:
+            List[om.MMatrix]: List of transformation matrix of the asset
+        """
+        convert_transform = om.MTransformationMatrix(transform_mm)
+
+        convert_translation = convert_transform.translation(om.MSpace.kWorld)
+        convert_translation = om.MVector(convert_translation.x, convert_translation.z, convert_translation.y)
+        convert_scale = convert_transform.scale(om.MSpace.kObject)
+        convert_transform.setTranslation(convert_translation, om.MSpace.kWorld)
+        converted_rotation = om.MEulerRotation(
+            math.radians(rotation[0]), math.radians(rotation[2]), math.radians(rotation[1])
+        )
+        convert_transform.setRotation(converted_rotation)
+        convert_transform.setScale([convert_scale[0], convert_scale[2], convert_scale[1]], om.MSpace.kObject)
+
+        return convert_transform.asMatrix()
 
 
 class ExtractLayoutAbc(ExtractLayout):
@@ -189,10 +188,27 @@ class ExtractLayoutAbc(ExtractLayout):
     families = ["layout.abc"]
     project_container = "AVALON_CONTAINERS"
 
-    def create_transformation_matrix(self, local_matrix, local_rotation):
-        # TODO: need to find the correct implementation of layout for alembic
-        matrix = om.MMatrix(local_matrix)
-        matrix = convert_transformation_matrix(matrix, local_rotation)
-        t_matrix = convert_matrix_to_4x4_list(matrix)
-        return t_matrix
+    def convert_transformation_matrix(self, transform_mm: om.MMatrix, rotation: list) -> om.MMatrix:
+        """Convert matrix to list of transformation matrix for Unreal Engine import.
 
+        Args:
+            transform_mm (om.MMatrix): Local Matrix for the asset
+            rotation (list): Rotations of the asset
+
+        Returns:
+            List[om.MMatrix]: List of transformation matrix of the asset
+        """
+        # TODO: need to find the correct implementation of layout for alembic
+        convert_transform = om.MTransformationMatrix(transform_mm)
+
+        convert_translation = convert_transform.translation(om.MSpace.kWorld)
+        convert_translation = om.MVector(convert_translation.x, convert_translation.z, convert_translation.y)
+        convert_scale = convert_transform.scale(om.MSpace.kObject)
+        convert_transform.setTranslation(convert_translation, om.MSpace.kWorld)
+        converted_rotation = om.MEulerRotation(
+            math.radians(rotation[0]), math.radians(rotation[2]), math.radians(rotation[1])
+        )
+        convert_transform.setRotation(converted_rotation)
+        convert_transform.setScale([convert_scale[0], convert_scale[2], convert_scale[1]], om.MSpace.kObject)
+
+        return convert_transform.asMatrix()

--- a/client/ayon_maya/plugins/publish/extract_layout.py
+++ b/client/ayon_maya/plugins/publish/extract_layout.py
@@ -2,7 +2,6 @@ import json
 import math
 import os
 from typing import List
-from ayon_core.pipeline.publish import OptionalPyblishPluginMixin
 from ayon_api import get_representation_by_id
 from ayon_maya.api import plugin
 from maya import cmds

--- a/client/ayon_maya/plugins/publish/extract_layout.py
+++ b/client/ayon_maya/plugins/publish/extract_layout.py
@@ -29,7 +29,7 @@ def convert_matrix_to_4x4_list(
     return result
 
 
-def convert_transformation_matrix_abc(transform_mm: om.MMatrix, rotation: list) -> om.MMatrix:
+def convert_transformation_matrix(transform_mm: om.MMatrix, rotation: list) -> om.MMatrix:
     """Convert matrix to list of transformation matrix for Unreal Engine import.
 
     Args:
@@ -177,6 +177,7 @@ class ExtractLayout(plugin.MayaExtractorPlugin):
 
     def create_transformation_matrix(self, local_matrix, local_rotation):
         matrix = om.MMatrix(local_matrix)
+        matrix = convert_transformation_matrix(matrix, local_rotation)
         t_matrix = convert_matrix_to_4x4_list(matrix)
         return t_matrix
 
@@ -189,7 +190,9 @@ class ExtractLayoutAbc(ExtractLayout):
     project_container = "AVALON_CONTAINERS"
 
     def create_transformation_matrix(self, local_matrix, local_rotation):
+        # TODO: need to find the correct implementation of layout for alembic
         matrix = om.MMatrix(local_matrix)
-        matrix = convert_transformation_matrix_abc(matrix, local_rotation)
+        matrix = convert_transformation_matrix(matrix, local_rotation)
         t_matrix = convert_matrix_to_4x4_list(matrix)
         return t_matrix
+


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-maya/issues/63
With the enum options to export layout with the user's preference.
![image](https://github.com/user-attachments/assets/974b784e-f484-4b56-bed6-fb987e72c3bc)
This PR is purposed to separate the fbx and abc layout so that we can be more innovative to improve the transformation for abc transformation later

## Additional info
For this PR, make sure you use all alembic references when you use alembic layout.
And all fbx imports for fbx layout.


## Testing notes:

1. Publish Layout in Maya
2. Load Layout in Unreal