### PR TITLE
feature: add option for including shaders on model export.

### DIFF
--- a/client/ayon_maya/plugins/create/create_model.py
+++ b/client/ayon_maya/plugins/create/create_model.py
@@ -39,5 +39,9 @@ class CreateModel(plugin.MayaCreator):
                     placeholder="attr1, attr2"),
             TextDef("attrPrefix",
                     label="Custom Attributes Prefix",
-                    placeholder="prefix1, prefix2")
+                    placeholder="prefix1, prefix2"),
+            BoolDef("include_shaders",
+                    label="Include Shaders",
+                    tooltip="Include shaders in the geometry export.",
+                    default=False),
         ]

--- a/client/ayon_maya/plugins/create/create_model.py
+++ b/client/ayon_maya/plugins/create/create_model.py
@@ -16,6 +16,7 @@ class CreateModel(plugin.MayaCreator):
 
     write_color_sets = False
     write_face_sets = True
+    include_shaders = False
 
     def get_instance_attr_defs(self):
 
@@ -43,5 +44,5 @@ class CreateModel(plugin.MayaCreator):
             BoolDef("include_shaders",
                     label="Include Shaders",
                     tooltip="Include shaders in the geometry export.",
-                    default=False),
+                    default=self.include_shaders),
         ]

--- a/client/ayon_maya/plugins/publish/extract_model.py
+++ b/client/ayon_maya/plugins/publish/extract_model.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Extract model as Maya Scene."""
 import os
+from contextlib import nullcontext
 
 from ayon_core.pipeline import publish
 from ayon_maya.api import lib
@@ -69,6 +70,10 @@ class ExtractModel(plugin.MayaExtractorPlugin,
                           noIntermediate=True,
                           long=True)
 
+        # Check if shaders should be included as part of the model export. If
+        # False, the default shader is assigned to the geometry.
+        include_shaders = instance.data.get("include_shaders", False)
+
         with lib.no_display_layers(instance):
             with lib.displaySmoothness(members,
                                        divisionsU=0,
@@ -76,8 +81,11 @@ class ExtractModel(plugin.MayaExtractorPlugin,
                                        pointsWire=4,
                                        pointsShaded=1,
                                        polygonObject=1):
-                with lib.shader(members,
-                                shadingEngine="initialShadingGroup"):
+                with (
+                    nullcontext()
+                    if include_shaders
+                    else lib.shader(members, shadingEngine="initialShadingGroup")
+                ):
                     with lib.maintained_selection():
                         cmds.select(members, noExpand=True)
                         cmds.file(path,

--- a/client/ayon_maya/plugins/publish/extract_obj.py
+++ b/client/ayon_maya/plugins/publish/extract_obj.py
@@ -2,12 +2,14 @@
 import os
 
 import pyblish.api
+from ayon_core.pipeline import OptionalPyblishPluginMixin
 from ayon_maya.api import lib
 from ayon_maya.api import plugin
 from maya import cmds
 
 
-class ExtractObj(plugin.MayaExtractorPlugin):
+class ExtractObj(plugin.MayaExtractorPlugin,
+                 OptionalPyblishPluginMixin):
     """Extract OBJ from Maya.
 
     This extracts reproducible OBJ exports ignoring any of the settings
@@ -28,6 +30,8 @@ class ExtractObj(plugin.MayaExtractorPlugin):
     }
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
 
         # Define output path
 

--- a/client/ayon_maya/plugins/publish/extract_obj.py
+++ b/client/ayon_maya/plugins/publish/extract_obj.py
@@ -56,8 +56,9 @@ class ExtractObj(plugin.MayaExtractorPlugin):
         # Check if shaders should be included as part of the model export. If
         # False, the default shader is assigned to the geometry.
         include_shaders = instance.data.get("include_shaders", False)
+        options = self.obj_options.copy()
         if include_shaders:
-            self.obj_options["materials"] = 1
+            options["materials"] = 1
 
             # Materials for `.obj` files are exported to a `.mtl` file that
             # usually lives next to the `.obj` and is referenced to by filename
@@ -74,8 +75,8 @@ class ExtractObj(plugin.MayaExtractorPlugin):
             transfers.append((mtl_source, mtl_destination))
 
         # Format options for the OBJexport command.
-        options = ';'.join(
-            f"{key}={val}" for key, val in self.obj_options.items()
+        options_str = ';'.join(
+            f"{key}={val}" for key, val in options.items()
         )
 
         # Export    
@@ -91,7 +92,7 @@ class ExtractObj(plugin.MayaExtractorPlugin):
                     cmds.file(path,
                               exportSelected=True,
                               type='OBJexport',
-                              op=options,
+                              op=options_str,
                               preserveReferences=True,
                               force=True)
 

--- a/client/ayon_maya/plugins/publish/extract_obj.py
+++ b/client/ayon_maya/plugins/publish/extract_obj.py
@@ -59,6 +59,20 @@ class ExtractObj(plugin.MayaExtractorPlugin):
         if include_shaders:
             self.obj_options["materials"] = 1
 
+            # Materials for `.obj` files are exported to a `.mtl` file that
+            # usually lives next to the `.obj` and is referenced to by filename
+            # from the `.obj` file itself, like:
+            # mtllib modelMain.mtl
+            # We want to copy the file over and preserve the filename for
+            # the materials to load correctly for the obj file, so we add it
+            # as explicit file transfer
+            mtl_source = path[:-len(".obj")] + ".mtl"
+            mtl_filename = os.path.basename(mtl_source)
+            mtl_destination = os.path.join(instance.data["publishDir"],
+                                           mtl_filename)
+            transfers = instance.data.setdefault("transfers", [])
+            transfers.append((mtl_source, mtl_destination))
+
         # Format options for the OBJexport command.
         options = ';'.join(
             f"{key}={val}" for key, val in self.obj_options.items()

--- a/server/settings/creators.py
+++ b/server/settings/creators.py
@@ -55,6 +55,7 @@ class BasicExportMeshModel(BaseSettingsModel):
         default_factory=list,
         title="Default Products"
     )
+    include_shaders: bool = SettingsField(title="Include Shaders")
 
 
 class CreateAnimationModel(BaseSettingsModel):
@@ -311,7 +312,8 @@ DEFAULT_CREATORS_SETTINGS = {
             "Main",
             "Proxy",
             "Sculpt"
-        ]
+        ],
+        "include_shaders": False,
     },
     "CreatePointCache": {
         "enabled": True,


### PR DESCRIPTION
## Changelog Description

This is a duplication of the old PR https://github.com/ynput/ayon-core/pull/444 which got closed as part of the migration to the new repository. 

The current default behaviour when exporting a model is that the shaders from Maya will be stripped, but for certain workflows (such as ours) we want to pass the shaders down from the modelling step - this PR allows for that without changing the default behaviour from current.

## Additional info

@antirotor based on the discussion in the last PR and personal preference I switched the setting from `strip_shaders` to `include_shaders` and made the default False - let me know if you'd prefer it as a strip setting and I can update the PR.

## Testing notes:

Tested by exporting a model through Maya and ensuring that the model retains it's shaders with the option on - with existing behaviour when published without `include_shaders` on.