### PR TITLE
Maya Scene exports do not default to including nodes that not children of members

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_maya_scene_raw.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_scene_raw.py
@@ -66,7 +66,7 @@ class ExtractMayaSceneRaw(plugin.MayaExtractorPlugin, AYONPyblishPluginMixin):
 
         # Whether to include all nodes in the instance (including those from
         # history) or only use the exact set members
-        members_only = instance.data.get("exactSetMembersOnly", False)
+        members_only = instance.data.get("exactSetMembersOnly", True)
         if members_only:
             members = instance.data.get("setMembers", list())
             if not members:


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

On Maya scene exports only include the relevant history for the selected nodes downstream and upstream and not upstream, and also their downstream descendant children.

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

Note: This may affect maya scene exports, camera rig exports and layout exports. However, I do feel this is a way more sensible default behavior on exports _with_ construction history enabled.

With this change, if you have a hierarchy like:
```
grp/
    obj1
    obj2
```
And `obj1` is inside the instance then after this PR `obj2` is not included.
Before this PR all other descendents from upstream groups would be included, regardless of whether they were "inputs" to the `obj1`.

After this PR, if `obj2` is an input connection to `obj1` (e.g. there are active constraints driving `obj1` or some other connections driving it) then `obj2` **will still be included.**

As such, only objects actively contributing to members of the instance will still be included in the output.

## Testing notes:

1. Recreate the aforementioned hierarchy from additional info.
2. Publish `obj1` - it should not include `obj2`
3. Now make a connection from `obj2` to `obj1` (e.g. translate connection)
4. Now `obj2` should also be included in `obj2`.
5. Now disconnect the connection, and key `obj1`  transforms.
6. The keys should be exported along just fine.