### PR TITLE
Improve applying render resolution and aspect ratio on render settings reset

### DIFF
--- a/client/ayon_maya/api/lib_rendersettings.py
+++ b/client/ayon_maya/api/lib_rendersettings.py
@@ -110,7 +110,7 @@ class RenderSettings(object):
             self._set_arnold_settings()
 
         if renderer == "vray":
-            self._set_vray_settings(aov_separator)
+            self._set_vray_settings(width, height, pixel_aspect, aov_separator)
 
         if renderer == "redshift":
             self._set_redshift_settings()


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Fix pixel aspect ratio / device aspect ratio getting messed up for Arnold renderer on render settings reset.

Additionally:
- This now applies the resolution from the task entity, not the folder entity.
- This now also applies pixel aspect ratio as defined on the entity.

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

This fixes a bug when resetting render resolution for Arnold where on reset the pixel/device aspect ratio would be oddly set with a pixel aspect ratio that is not 1.0.

E.g. left is before, right is after resetting render settings **without this PR**
![image](https://github.com/user-attachments/assets/1b36d70b-2490-47f0-8731-d1ce5b20dfe9)

After this PR the pixel aspect ratio will now adhere to what is specified on the task entity.
_This bug was only occurring if the current renderer render settings were reset for was actively Arnold (mtoa) renderer._

## Testing notes:

1. Resetting render settings should work for the different renderers and should set the resolution (and pixel aspect ratio correctly!)
    - [x] Arnold (mtoa)
    - [x] Redshift (should work if Arnold works because it uses same attributes as Arnold)
    - [x] V-Ray (may be good to check because it uses a custom render settings node!)
    - [ ] Renderman (should work if Arnold works because it uses same attributes as Arnold)

Note that this is about **Set Render Settings** or the feature that it automatically does so on creating a render publish instance in the scene (enabled by default).

![image](https://github.com/user-attachments/assets/ad8b0534-0921-4dc2-add9-eb276326030f)
