### PR TITLE
Add optional and active state for fbx camera collector in ayon setting

### DIFF
--- a/client/ayon_maya/plugins/publish/collect_fbx_camera.py
+++ b/client/ayon_maya/plugins/publish/collect_fbx_camera.py
@@ -1,17 +1,23 @@
 # -*- coding: utf-8 -*-
 import pyblish.api
 from ayon_maya.api import plugin
+from ayon_core.pipeline.publish import OptionalPyblishPluginMixin
 from maya import cmds  # noqa
 
 
-class CollectFbxCamera(plugin.MayaInstancePlugin):
+class CollectFbxCamera(plugin.MayaInstancePlugin,
+                       OptionalPyblishPluginMixin):
     """Collect Camera for FBX export."""
 
     order = pyblish.api.CollectorOrder + 0.2
     label = "Collect Camera for FBX export"
     families = ["camera"]
+    optional = True
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
+
         if not instance.data.get("families"):
             instance.data["families"] = []
 

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -180,10 +180,6 @@ class CollectFbxAnimationModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="Collect Fbx Animation")
 
 
-class CollectFbxCameraModel(BaseSettingsModel):
-    enabled: bool = SettingsField(title="CollectFbxCamera")
-
-
 class CollectGLTFModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="CollectGLTF")
 
@@ -639,8 +635,8 @@ class PublishersModel(BaseSettingsModel):
         default_factory=CollectFbxAnimationModel,
         title="Collect FBX Animation",
     )
-    CollectFbxCamera: CollectFbxCameraModel = SettingsField(
-        default_factory=CollectFbxCameraModel,
+    CollectFbxCamera: BasicValidateModel = SettingsField(
+        default_factory=BasicValidateModel,
         title="Collect Camera for FBX export",
     )
     CollectFbxModel: BasicValidateModel = SettingsField(
@@ -1091,7 +1087,9 @@ DEFAULT_PUBLISH_SETTINGS = {
         "enabled": False
     },
     "CollectFbxCamera": {
-        "enabled": False
+        "enabled": False,
+        "optional": True,
+        "active": True
     },
     "CollectFbxModel": {
         "enabled": False,


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-maya/issues/81


## Additional info
Build maya addon with this branch and install it into ayon server

## Testing notes:

1. Build maya addon with this branch and install it into ayon server
2. You can choose whether you want to enable the fbx camera collector through `ayon+settings://maya/publish/CollectFbxCamera`
3. Launch Maya
4. Create Camera Instance
5. Publish
