### PR TITLE
Look Assigner: Ignore invalid entity ids in `get_folders` query 

### DIFF
--- a/client/ayon_maya/tools/mayalookassigner/commands.py
+++ b/client/ayon_maya/tools/mayalookassigner/commands.py
@@ -130,6 +130,12 @@ def create_items_from_nodes(nodes):
     project_name = get_current_project_name()
     folder_ids = set(id_hashes.keys())
 
+    # Ignore invalid ids
+    folder_ids = {
+        folder_id for folder_id in folder_ids
+        if ayon_api.utils.convert_entity_id(folder_id)
+    }
+
     folder_entities = ayon_api.get_folders(
         project_name, folder_ids, fields={"id", "path"}
     )


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Fixes an issue where look assigner would not list anything if it had to list entries that had invalid ids (those that are NOT valid `uuid` patterns) and hence the `ayon_api.get_folders` query would fail.

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

Ignore invalid entity ids in `get_folders` query to avoid `GraphQlQueryFailed` exception which then also fails to return for the valid ids in the set.

Fixes #84

Note that due to other logic in the code a warning will still be logged for these invalid ids, which is as intended. For example:
```
// Warning: ayon_maya.tools.mayalookassigner.commands : Id found on 2 nodes for which no folder is found database, skipping 'ac991b60b4c5a70'
// Warning: ayon_maya.tools.mayalookassigner.commands : Id found on 2 nodes for which no folder is found database, skipping 'ac991b60b1eeb7fc773031a70'
```

## Testing notes:

1. Load some assets
2. Go to the `cbId` attribute. Remove some characters from before the `:` in the value.
3. Try the look assigner on that node - it doesn't list anything. (should log a warning instead!)
4. Now try that node together with nodes that do have valid ids - it still lists nothing. (should list instead, plus log warning)

OR

Load a scene with OpenPype assets together with a scene with AYON asset. Look assigner should still list entries for AYON.
