### PR TITLE
AY-6654 Look: Fix None values in collecting and applying attributes

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -1734,6 +1734,7 @@ def apply_attributes(attributes, nodes_by_id):
                 if value is None:
                     log.warning(
                         f"Skipping setting {node}.{attr} with value 'None'")
+                    continue
 
                 set_attribute(attr, value, node)
 

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -1731,6 +1731,10 @@ def apply_attributes(attributes, nodes_by_id):
         attr_value = attr_data["attributes"]
         for node in nodes:
             for attr, value in attr_value.items():
+                if value is None:
+                    log.warning(
+                        f"Skipping setting {node}.{attr} with value 'None'")
+
                 set_attribute(attr, value, node)
 
 

--- a/client/ayon_maya/plugins/publish/collect_look.py
+++ b/client/ayon_maya/plugins/publish/collect_look.py
@@ -545,9 +545,24 @@ class CollectLook(plugin.MayaInstancePlugin):
                     self.log.warning("Attribute '{}' is mixed-type and is "
                                      "not supported yet.".format(attribute))
                     continue
-                if cmds.getAttr(attribute, type=True) == "message":
+
+                attribute_type = cmds.getAttr(attribute, type=True)
+                if attribute_type == "message":
                     continue
-                node_attributes[attr] = cmds.getAttr(attribute, asString=True)
+
+                # Maya has a tendency to return string attribute values as
+                # `None` if it is an empty string and the attribute has never
+                # been set but is still at default value.
+                value = cmds.getAttr(attribute, asString=True)
+                if value is None:
+                    # If the attribute type is `string` we will convert it
+                    # to enforce an empty string value
+                    if attribute_type == "string":
+                        value = ""
+                    else:
+                        continue
+
+                node_attributes[attr] = value
             # Only include if there are any properties we care about
             if not node_attributes:
                 continue


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

This fixes a case where looks failed to apply due to `None` values being present in the collected attributes.
These will now be ignored in collected. There's an edge case where Maya returns `None` for string attributes that have no values set - those are captured now explicitly to just `""` to still collect and apply them later.

Existing looks will now also apply correctly with `None` value in their look attributes, but the attributes with `None` values will be ignored with a warning.

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

## Testing notes:

1. Load a model reference
2. Create a string attribute, e.g. `test`
3. Do not set any value for it.
    - Maya will return None for this attribute, e.g. select the object and run:
```python
from maya import cmds
print(cmds.getAttr(".test"))
```
It will print `None`.
4. Publish the look for this mesh
5. The published `.json` file should have attribute value for `test` set to `""`

To test the 'backwards compatible fix':
- Publish the same look with `develop` branch. The value will be `null` in the `.json` file.`
- OR, just open the last published `.json` file, and edit the `""` value to `null`

Then, confirm that applying the look succeeds without errors but with a warning regarding the `None` value when applying with this PR. For example in my test run it logged:

```
// Warning: ayon_maya.api.lib : Skipping setting |_GRP|cube_GEO.test with value 'None'
```