### PR TITLE
Load to Maya USD Proxy Shape using AYON Entity URI for AYON USD Resolver

### DIFF
--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -69,6 +69,47 @@ def get_reference_node_parents(*args, **kwargs):
     return lib.get_reference_node_parents(*args, **kwargs)
 
 
+def get_ayon_entity_uri_from_representation_context(context: dict) -> str:
+    """Resolve AYON Entity URI from representation context.
+
+    Note:
+        The representation context is the `get_representation_context` dict
+        containing the `project`, `folder, `representation` and so forth.
+        It is not the representation entity `context` key.
+
+    Arguments:
+        context (dict): The representation context.
+
+    Raises:
+        RuntimeError: Unable to resolve to a single valid URI.
+
+    Returns:
+        str: The AYON entity URI.
+
+    """
+    # TODO: This is a 1:1 copy from ayon-houdini and may be good to refactor
+    #    and de-duplicate across the codebase, e.g. to core functionality
+    project_name = context["project"]["name"]
+    representation_id = context["representation"]["id"]
+    response = ayon_api.post(
+        f"projects/{project_name}/uris",
+        entityType="representation",
+        ids=[representation_id])
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Unable to resolve AYON entity URI for '{project_name}' "
+            f"representation id '{representation_id}': {response.text}"
+        )
+    uris = response.data["uris"]
+    if len(uris) != 1:
+        raise RuntimeError(
+            f"Unable to resolve AYON entity URI for '{project_name}' "
+            f"representation id '{representation_id}' to single URI. "
+            f"Received data: {response.data}"
+        )
+    return uris[0]["uri"]
+
+
 @six.add_metaclass(ABCMeta)
 class MayaCreatorBase(object):
 
@@ -638,6 +679,17 @@ class Loader(LoaderPlugin):
     hosts = ["maya"]
     settings_category = SETTINGS_CATEGORY
     load_settings = {}  # defined in settings
+
+    use_ayon_entity_uri = False
+
+    @classmethod
+    def filepath_from_context(cls, context):
+        # TODO: This is a 1:1 copy from ayon-houdini and may be good to
+        #  refactor and de-duplicate across the codebase, e.g. to core
+        if cls.use_ayon_entity_uri:
+            return get_ayon_entity_uri_from_representation_context(context)
+
+        return super().filepath_from_context(context)
 
     @classmethod
     def apply_settings(cls, project_settings):

--- a/client/ayon_maya/plugins/load/load_maya_usd.py
+++ b/client/ayon_maya/plugins/load/load_maya_usd.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 import maya.cmds as cmds
-from ayon_core.pipeline import get_representation_path
-from ayon_core.pipeline.load import get_representation_path_from_context
 from ayon_maya.api.lib import namespaced, unique_namespace
 from ayon_maya.api.pipeline import containerise
 from ayon_maya.api import plugin
@@ -18,6 +16,9 @@ class MayaUsdLoader(plugin.Loader):
     icon = "code-fork"
     color = "orange"
 
+    # TODO: Add to settings
+    use_ayon_entity_uri = True
+
     def load(self, context, name=None, namespace=None, options=None):
         folder_name = context["folder"]["name"]
         namespace = namespace or unique_namespace(
@@ -29,7 +30,7 @@ class MayaUsdLoader(plugin.Loader):
         # Make sure we can load the plugin
         cmds.loadPlugin("mayaUsdPlugin", quiet=True)
 
-        path = get_representation_path_from_context(context)
+        path = self.filepath_from_context(context)
 
         # Create the shape
         cmds.namespace(addNamespace=namespace)
@@ -72,13 +73,12 @@ class MayaUsdLoader(plugin.Loader):
         members = cmds.sets(node, query=True) or []
         shapes = cmds.ls(members, type="mayaUsdProxyShape")
 
-        repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = self.filepath_from_context(context)
         for shape in shapes:
             cmds.setAttr("{}.filePath".format(shape), path, type="string")
 
         cmds.setAttr("{}.representation".format(node),
-                     repre_entity["id"],
+                     context["representation"]["id"],
                      type="string")
 
     def switch(self, container, context):

--- a/client/ayon_maya/plugins/load/load_maya_usd.py
+++ b/client/ayon_maya/plugins/load/load_maya_usd.py
@@ -16,9 +16,6 @@ class MayaUsdLoader(plugin.Loader):
     icon = "code-fork"
     color = "orange"
 
-    # TODO: Add to settings
-    use_ayon_entity_uri = True
-
     def load(self, context, name=None, namespace=None, options=None):
         folder_name = context["folder"]["name"]
         namespace = namespace or unique_namespace(

--- a/server/settings/loaders.py
+++ b/server/settings/loaders.py
@@ -122,9 +122,9 @@ class OxRigLoaderModel(LoaderEnabledModel):
     create_cache_instance_on_load: bool = SettingsField(
         title="Create Ornatrix Cache instance on load",
         description=(
-            "When enabled, upon loading an Ornatrix Rig product a new Ornatrix cache "
-            "instance is automatically created as preparation to publishing "
-            "the output directly."
+            "When enabled, upon loading an Ornatrix Rig product a new "
+            "Ornatrix cache instance is automatically created as preparation "
+            "to publishing the output directly."
         )
     )
 

--- a/server/settings/loaders.py
+++ b/server/settings/loaders.py
@@ -6,6 +6,17 @@ class LoaderEnabledModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="Enabled")
 
 
+class LoaderEnabledUseAyonEntityURIModel(LoaderEnabledModel):
+    use_ayon_entity_uri: bool = SettingsField(
+        title="Use AYON Entity URI",
+        description=(
+            "Use the AYON Entity URI on load instead of the resolved filepath "
+            "so that the AYON USD Resolver will resolve the paths at runtime. "
+            "This should be enabled when using the AYON USD Resolver."
+        )
+    )
+
+
 class ColorsSetting(BaseSettingsModel):
     model: ColorRGBA_uint8 = SettingsField(
         (209, 132, 30, 1.0), title="Model:")
@@ -177,6 +188,10 @@ class LoadersModel(BaseSettingsModel):
         default_factory=LoaderEnabledModel,
         title="Matchmove Loader"
     )
+    MayaUsdLoader: LoaderEnabledUseAyonEntityURIModel = SettingsField(
+        default_factory=LoaderEnabledUseAyonEntityURIModel,
+        title="Maya Load USD to Maya Proxy Loader"
+    )
     MultiverseUsdLoader: LoaderEnabledModel = SettingsField(
         default_factory=LoaderEnabledModel,
         title="Multiverse USD Loader"
@@ -287,6 +302,10 @@ DEFAULT_LOADERS_SETTING = {
     "ImagePlaneLoader": {"enabled": True},
     "LookLoader": {"enabled": True},
     "MatchmoveLoader": {"enabled": True},
+    "MayaUsdLoader": {
+        "enabled": True,
+        "use_ayon_entity_uri": True
+    },
     "MultiverseUsdLoader": {"enabled": True},
     "MultiverseUsdOverLoader": {"enabled": True},
     "RedshiftProxyLoader": {"enabled": True},


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Load to Maya USD Proxy Shape using AYON Entity URI for AYON USD Resolver

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

Matches this AYON Houdini PR: https://github.com/ynput/ayon-houdini/pull/26 and hence also highlights what we may want to de-duplicate and re-use code for.

![image](https://github.com/user-attachments/assets/ce15208d-7674-47bf-a603-2ed8ce730097)

![image](https://github.com/user-attachments/assets/41cdde09-5129-46dc-880a-019a92400dfb)


### TODO

 - [x] Allow to toggle in settings whether path should be AYON Entity URI or regular resolved path

## Testing notes:

1. Upload new addon
2. Enable `ayon+settings://maya/load/MayaUsdLoader/use_ayon_entity_uri`
3. Load USD to Maya USD Proxy

![image](https://github.com/user-attachments/assets/43dd78da-acf0-44e8-ad1e-8f45c1e35f02)


4. It should use the AYON Entity URI as filepath.
5. It should work with the AYON USD resolver.