### PR TITLE
Create Multi-shot layout: Add label only if not same as shot name.

### DIFF
--- a/client/ayon_maya/plugins/create/create_multishot_layout.py
+++ b/client/ayon_maya/plugins/create/create_multishot_layout.py
@@ -161,8 +161,10 @@ class CreateMultishotLayout(plugin.MayaCreator):
                 layout_task_name = pre_create_data["taskName"]
                 layout_task_entity = task_entities[layout_task_name]
 
-            shot_name = f"{shot['name']}%s" % (
-                f" ({shot['label']})" if shot["label"] else "")
+            shot_name = shot['name']
+            if shot["label"] and shot["label"] != shot_name:
+                shot_name += f" ({shot['label']})"
+
             cmds.shot(sequenceStartTime=shot["attrib"]["clipIn"],
                       sequenceEndTime=shot["attrib"]["clipOut"],
                       shotName=shot_name)


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

In recent versions of AYON the "label" is always set by default and matches the "name" whereas previously, "label" defaulted to an empty value. Hence, due to that update, this logic now needed to change to correctly detect whether a customized label was set.

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

Fixes an issue where the shot name in camera sequencer would be `shot (shot)` where the labels between the brackets matched the shot name, making it look odd.

## Testing notes:

1. Run create multi-shot layout
2. Have shots with and without customized labels
3. Only those with customized labels should have that between brackest like `{name} ({label})`
