### PR TITLE
Extract Review: Fix "displayLights" not adhering to project settings of used profile

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -288,8 +288,12 @@ def generate_capture_preset(instance, camera, path,
 
     # Override viewport options by instance data
     viewport_options = preset.setdefault("viewport_options", {})
-    viewport_options["displayLights"] = instance.data["displayLights"]
     viewport_options["imagePlane"] = instance.data.get("imagePlane", True)
+
+    # When using 'project settings' we preserve the capture preset that
+    # was picked, then we do not override it with the instance data
+    if instance.data["displayLights"] != "project_settings":
+        viewport_options["displayLights"] = instance.data["displayLights"]
 
     # Override transparency if requested.
     transparency = instance.data.get("transparency", 0)

--- a/client/ayon_maya/plugins/publish/collect_review.py
+++ b/client/ayon_maya/plugins/publish/collect_review.py
@@ -33,11 +33,6 @@ class CollectReview(plugin.MayaInstancePlugin):
 
         # Collect display lights.
         display_lights = instance.data.get("displayLights", "default")
-        if display_lights == "project_settings":
-            settings = instance.context.data["project_settings"]
-            settings = settings["maya"]["publish"]["ExtractPlayblast"]
-            settings = settings["capture_preset"]["ViewportOptions"]
-            display_lights = settings["displayLights"]
 
         # Collect camera focal length.
         burninDataMembers = instance.data.get("burninDataMembers", {})


### PR DESCRIPTION
## Changelog Description

Fix `displayLights` not adhering to picked profile's "project settings" but instead using the deprecated old settings

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

Reported on discord by a client.

## Testing notes:

1. Configure Extract Playblast profiles: `ayon+settings://maya/publish/ExtractPlayblast/profiles`
2. Set a custom `ayon+settings://maya/publish/ExtractPlayblast/profiles/0/capture_preset/ViewportOptions/displayLights` value
3. In review instance in Maya keep display lights toggle to "project settings".
4. It should take the value from the selected profile now, not the old deprecated settings.
5. (If new style profiles ARE NOT configured, it should still take from the deprecated settings)
6. If in publisher UI display lights toggle is NOT set to 'project settings' it should use whatever is set on the instance instead.
