### PR TITLE
Set instance frame range attribute defaults to current task entity attributes

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -588,7 +588,6 @@ def collect_animation_defs(fps=False, create_context=None):
     use_entity_frame_range = False
     if create_context is not None:
         project_settings = create_context.get_current_project_settings()
-        print(project_settings["maya"]["create"])
         use_entity_frame_range: bool = project_settings["maya"]["create"].get(
             "use_entity_attributes_as_defaults", False)
 

--- a/client/ayon_maya/plugins/create/create_animation_pointcache.py
+++ b/client/ayon_maya/plugins/create/create_animation_pointcache.py
@@ -8,9 +8,9 @@ from ayon_core.lib import (
 )
 
 
-def _get_animation_attr_defs():
+def _get_animation_attr_defs(create_context):
     """Get Animation generic definitions."""
-    defs = lib.collect_animation_defs()
+    defs = lib.collect_animation_defs(create_context=create_context)
     defs.extend(
         [
             BoolDef("farm", label="Submit to Farm"),
@@ -99,7 +99,7 @@ class CreateAnimation(plugin.MayaHiddenCreator):
         return node_data
 
     def get_instance_attr_defs(self):
-        return _get_animation_attr_defs()
+        return _get_animation_attr_defs(self.create_context)
 
 
 class CreatePointCache(plugin.MayaCreator):
@@ -121,7 +121,7 @@ class CreatePointCache(plugin.MayaCreator):
         return node_data
 
     def get_instance_attr_defs(self):
-        return _get_animation_attr_defs()
+        return _get_animation_attr_defs(self.create_context)
 
     def create(self, product_name, instance_data, pre_create_data):
         instance = super(CreatePointCache, self).create(

--- a/client/ayon_maya/plugins/create/create_arnold_scene_source.py
+++ b/client/ayon_maya/plugins/create/create_arnold_scene_source.py
@@ -44,7 +44,7 @@ class CreateArnoldSceneSource(plugin.MayaCreator):
 
     def get_instance_attr_defs(self):
 
-        defs = lib.collect_animation_defs()
+        defs = lib.collect_animation_defs(create_context=self.create_context)
 
         defs.extend([
             BoolDef("motionBlur",

--- a/client/ayon_maya/plugins/create/create_camera.py
+++ b/client/ayon_maya/plugins/create/create_camera.py
@@ -15,7 +15,7 @@ class CreateCamera(plugin.MayaCreator):
 
     def get_instance_attr_defs(self):
 
-        defs = lib.collect_animation_defs()
+        defs = lib.collect_animation_defs(create_context=self.create_context)
 
         defs.extend([
             BoolDef("bakeToWorldSpace",

--- a/client/ayon_maya/plugins/create/create_maya_usd.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd.py
@@ -51,7 +51,8 @@ class CreateMayaUsd(plugin.MayaCreator):
                             "static export frame.",
                     default=True)
         ]
-        defs.extend(lib.collect_animation_defs())
+        defs.extend(lib.collect_animation_defs(
+            create_context=self.create_context))
         defs.extend([
             EnumDef("defaultUSDFormat",
                     label="File format",

--- a/client/ayon_maya/plugins/create/create_multiverse_usd.py
+++ b/client/ayon_maya/plugins/create/create_multiverse_usd.py
@@ -21,7 +21,8 @@ class CreateMultiverseUsd(plugin.MayaCreator):
 
     def get_instance_attr_defs(self):
 
-        defs = lib.collect_animation_defs(fps=True)
+        defs = lib.collect_animation_defs(
+            fps=True, create_context=self.create_context)
         defs.extend([
             EnumDef("fileFormat",
                     label="File format",

--- a/client/ayon_maya/plugins/create/create_multiverse_usd_comp.py
+++ b/client/ayon_maya/plugins/create/create_multiverse_usd_comp.py
@@ -16,7 +16,8 @@ class CreateMultiverseUsdComp(plugin.MayaCreator):
 
     def get_instance_attr_defs(self):
 
-        defs = lib.collect_animation_defs(fps=True)
+        defs = lib.collect_animation_defs(
+            fps=True, create_context=self.create_context)
         defs.extend([
             EnumDef("fileFormat",
                     label="File format",

--- a/client/ayon_maya/plugins/create/create_multiverse_usd_over.py
+++ b/client/ayon_maya/plugins/create/create_multiverse_usd_over.py
@@ -15,7 +15,8 @@ class CreateMultiverseUsdOver(plugin.MayaCreator):
     icon = "cubes"
 
     def get_instance_attr_defs(self):
-        defs = lib.collect_animation_defs(fps=True)
+        defs = lib.collect_animation_defs(
+            fps=True, create_context=self.create_context)
         defs.extend([
             EnumDef("fileFormat",
                     label="File format",

--- a/client/ayon_maya/plugins/create/create_ornatrix_cache.py
+++ b/client/ayon_maya/plugins/create/create_ornatrix_cache.py
@@ -19,8 +19,11 @@ class CreateOxCache(plugin.MayaCreator):
 
         # Add animation data without step and handles
         remove = {"handleStart", "handleEnd"}
-        defs = [attr_def for attr_def in lib.collect_animation_defs()
-                if attr_def.key not in remove]
+        defs = [
+            attr_def for attr_def in lib.collect_animation_defs(
+                create_context=self.create_context)
+            if attr_def.key not in remove
+        ]
         defs.extend(
             [
                 EnumDef("format",

--- a/client/ayon_maya/plugins/create/create_redshift_proxy.py
+++ b/client/ayon_maya/plugins/create/create_redshift_proxy.py
@@ -21,5 +21,6 @@ class CreateRedshiftProxy(plugin.MayaCreator):
                     default=False)
         ]
 
-        defs.extend(lib.collect_animation_defs())
+        defs.extend(lib.collect_animation_defs(
+            create_context=self.create_context))
         return defs

--- a/client/ayon_maya/plugins/create/create_review.py
+++ b/client/ayon_maya/plugins/create/create_review.py
@@ -94,7 +94,7 @@ class CreateReview(plugin.MayaCreator):
 
     def get_instance_attr_defs(self):
 
-        defs = lib.collect_animation_defs()
+        defs = lib.collect_animation_defs(create_context=self.create_context)
 
         # Option for using Maya or folder frame range in settings.
         if not self.useMayaTimeline:

--- a/client/ayon_maya/plugins/create/create_unreal_yeticache.py
+++ b/client/ayon_maya/plugins/create/create_unreal_yeticache.py
@@ -24,7 +24,8 @@ class CreateUnrealYetiCache(plugin.MayaCreator):
         ]
 
         # Add animation data without step and handles
-        defs.extend(lib.collect_animation_defs())
+        defs.extend(lib.collect_animation_defs(
+            create_context=self.create_context))
         remove = {"step", "handleStart", "handleEnd"}
         defs = [attr_def for attr_def in defs if attr_def.key not in remove]
 

--- a/client/ayon_maya/plugins/create/create_vrayproxy.py
+++ b/client/ayon_maya/plugins/create/create_vrayproxy.py
@@ -26,7 +26,8 @@ class CreateVrayProxy(plugin.MayaCreator):
 
         # Add time range attributes but remove some attributes
         # which this instance actually doesn't use
-        defs.extend(lib.collect_animation_defs())
+        defs.extend(lib.collect_animation_defs(
+            create_context=self.create_context))
         remove = {"handleStart", "handleEnd", "step"}
         defs = [attr_def for attr_def in defs if attr_def.key not in remove]
 

--- a/client/ayon_maya/plugins/create/create_yeti_cache.py
+++ b/client/ayon_maya/plugins/create/create_yeti_cache.py
@@ -24,7 +24,8 @@ class CreateYetiCache(plugin.MayaCreator):
         ]
 
         # Add animation data without step and handles
-        defs.extend(lib.collect_animation_defs())
+        defs.extend(lib.collect_animation_defs(
+            create_context=self.create_context))
         remove = {"step", "handleStart", "handleEnd"}
         defs = [attr_def for attr_def in defs if attr_def.key not in remove]
 

--- a/server/settings/creators.py
+++ b/server/settings/creators.py
@@ -147,6 +147,16 @@ class CreateMultishotLayout(BasicCreatorModel):
 
 
 class CreatorsModel(BaseSettingsModel):
+    use_entity_attributes_as_defaults: bool = SettingsField(
+        False,
+        title="Use current context entity attributes as frame range defaults",
+        description=(
+            "For frame range attributes on the created instances, use the "
+            "current context's task entity as the default value. When "
+            "disabled it will default to Maya's current timeline."
+        )
+    )
+
     CreateLook: CreateLookModel = SettingsField(
         default_factory=CreateLookModel,
         title="Create Look"
@@ -256,6 +266,7 @@ class CreatorsModel(BaseSettingsModel):
 
 
 DEFAULT_CREATORS_SETTINGS = {
+    "use_entity_attributes_as_defaults": False,
     "CreateLook": {
         "enabled": True,
         "make_tx": True,


### PR DESCRIPTION
## Changelog Description

Allow frame range defaults for instances to be based on current task entity attributes

## Additional info

Enable the setting: `ayon+settings://maya/create/use_entity_attributes_as_defaults`
![image](https://github.com/user-attachments/assets/dd64dc67-3ad9-42fc-a42f-b9aa5f070f15)

## Testing notes:

1. Enable/disable the setting `ayon+settings://maya/create/use_entity_attributes_as_defaults`
2. Set your maya timeline different than current task entity.
3. When the setting is enabled, newly created instances should default to frame range of current context task entity.
4. When the setting is disabled (default for backwards compatibility), the frame range will by default be based off of the timeline.

_This will be the case for all Creators using the `collect_animation_defs` function. Which is as far as I know all the product types with frame ranges exposed in the publisher UI currently, e.g.  `pointcache`, `animation`, `yeticache`, etc._
