### PR TITLE
Look: Collect component assignment nodes as shapes

### DIFF
--- a/client/ayon_maya/plugins/publish/collect_look.py
+++ b/client/ayon_maya/plugins/publish/collect_look.py
@@ -486,8 +486,12 @@ class CollectLook(plugin.MayaInstancePlugin):
             dict
 
         """
-
         node, components = (member.rsplit(".", 1) + [None])[:2]
+        if components and not cmds.objectType(node, isAType="shape"):
+            # Components are always on shapes. When only a single shape is
+            # parented under a transform Maya returns it as e.g. `cube.f[0:4]`
+            # instead of `cubeShape.f[0:4]` so we expand that to the shape
+            node = cmds.listRelatives(node, shapes=True, fullPath=True)[0]
 
         # Only include valid members of the instance
         if node not in instance_members:


### PR DESCRIPTION
## Changelog Description

Fix nodes with component assignments not being collected as the shape but the transform instead

## Additional info

Fixes #106 

## Testing notes:

1. Select all faces of a mesh.
2. Assign a material
3. Publish

(This is just to make an easy reproducable; however, similar issues may arise on merging or separating meshes or other maya construction history)
