### PR TITLE
Alembic exports: Fix parenting/ancestor relationship errors when include parent hierarchy is off

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_pointcache.py
+++ b/client/ayon_maya/plugins/publish/extract_pointcache.py
@@ -15,6 +15,7 @@ from ayon_core.pipeline.publish import OptionalPyblishPluginMixin
 from ayon_maya.api.alembic import extract_alembic
 from ayon_maya.api.lib import (
     get_all_children,
+    get_highest_in_hierarchy,
     iter_visible_nodes_in_range,
     maintained_selection,
     suspended_refresh,
@@ -129,7 +130,10 @@ class ExtractAlembic(plugin.MayaExtractorPlugin,
             # Set the root nodes if we don't want to include parents
             # The roots are to be considered the ones that are the actual
             # direct members of the set
-            root = roots
+            # We ignore members that are children of other members to avoid
+            # the parenting / ancestor relationship error on export and assume
+            # the user intended to export starting at the top of the two.
+            root = get_highest_in_hierarchy(roots)
 
         kwargs = {
             "file": path,


### PR DESCRIPTION
## Changelog Description

On alembic export fix error on parent and child members in object set with include parent hierarchy disabled.

## Additional info

Fixes error on extraction:
```
Traceback (most recent call last):
  File "C:\Users\User\AppData\Local\Ynput\AYON\dependency_packages\ayon_2406251801_windows.zip\dependencies\pyblish\plugin.py", line 528, in __explicit_process
    runner(*args)
  File "E:\dev\ayon-maya\client\ayon_maya\plugins\publish\extract_pointcache.py", line 232, in process
    extract_alembic(**kwargs)
  File "E:\dev\ayon-maya\client\ayon_maya\api\alembic.py", line 341, in extract_alembic
    cmds.AbcExport(
  File "E:\dev\ayon-maya\client\ayon_maya\plugins\publish\extract_pointcache.py", line 2, in AbcExport
RuntimeError: |group1 and |group1|pCube1 have parenting relationships
|group1 and |group1|pCube1 have an ancestor relationship.
```

## Testing notes:

1. Create a mesh and group it (so there's parent child relationship)
2. Add both the mesh and group into a pointcache instance.
3. Make sure "Include parent hierarchy" is disabled on the instance.
4. Publish should succeed.

Without this PR this would generate an error.