### PR TITLE
Fix validate unit settings

### DIFF
--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -16,22 +16,22 @@ from .publish_playblast import (
 def linear_unit_enum():
     """Get linear units enumerator."""
     return [
-        {"label": "mm", "value": "millimeter"},
-        {"label": "cm", "value": "centimeter"},
-        {"label": "m", "value": "meter"},
-        {"label": "km", "value": "kilometer"},
-        {"label": "in", "value": "inch"},
-        {"label": "ft", "value": "foot"},
-        {"label": "yd", "value": "yard"},
-        {"label": "mi", "value": "mile"}
+        {"label": "millimeter", "value": "mm"},
+        {"label": "centimeter", "value": "cm"},
+        {"label": "meter", "value": "m"},
+        {"label": "kilometer", "value": "km"},
+        {"label": "inch", "value": "in"},
+        {"label": "foot", "value": "ft"},
+        {"label": "yard", "value": "yd"},
+        {"label": "mile", "value": "mi"}
     ]
 
 
 def angular_unit_enum():
     """Get angular units enumerator."""
     return [
-        {"label": "deg", "value": "degree"},
-        {"label": "rad", "value": "radian"},
+        {"label": "degree", "value": "deg"},
+        {"label": "radian", "value": "rad"},
     ]
 
 


### PR DESCRIPTION
## Changelog Description

Fixes the validate units configuration when any setting for it was overridden.

## Additional info

Apparently the labels and values were reversed.
Came up on discord [here](https://discord.com/channels/517362899170230292/1286380990171713606)

## Testing notes:

1. Create addon
2. Upload to bundle
3. Set custom validate unit settings
4. It should validate accordingly.
