### PR TITLE
Layout: Do not error on extraction with renamed instance node

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_layout.py
+++ b/client/ayon_maya/plugins/publish/extract_layout.py
@@ -50,7 +50,8 @@ class ExtractLayout(plugin.MayaExtractorPlugin):
         # TODO representation queries can be refactored to be faster
         project_name = instance.context.data["projectName"]
 
-        for asset in cmds.sets(str(instance), query=True):
+        members = instance.data["setMembers"]
+        for asset in members:
             # Find the container
             project_container = self.project_container
             container_list = cmds.ls(project_container)


### PR DESCRIPTION
## Changelog Description

Do not error if `instance` does not match the actual node's name + re-use `setMembers` which was already collected anyway.

## Additional info

Quick fix.

## Testing notes:

1. Extract Layout should work as intended.
