### PR TITLE
Support underscore delimiter for yeti UDIM textures

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4364,9 +4364,13 @@ def get_sequence(filepath, pattern="%04d"):
         # multiple image search paths.
         return
 
+    # clique.PATTERNS["frames"] supports only `.1001.exr` not `_1001.exr` so
+    # we use a customized pattern.
+    pattern = "[_.](?P<index>(?P<padding>0*)\\d+)\\.\\D+\\d?$"
+    patterns = [pattern]
     collections, _remainder = clique.assemble(
         files,
-        patterns=[clique.PATTERNS["frames"]],
+        patterns=patterns,
         minimum_items=1)
 
     if len(collections) > 1:

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4311,21 +4311,19 @@ def search_textures(filepath):
     filename = os.path.basename(filepath)
 
     # Collect full sequence if it matches a sequence pattern
-    if len(filename.split(".")) > 2:
+    # For UDIM based textures (tiles)
+    if "<UDIM>" in filename:
+        sequences = get_sequence(filepath,
+                                 pattern="<UDIM>")
+        if sequences:
+            return sequences
 
-        # For UDIM based textures (tiles)
-        if "<UDIM>" in filename:
-            sequences = get_sequence(filepath,
-                                     pattern="<UDIM>")
-            if sequences:
-                return sequences
-
-        # Frame/time - Based textures (animated masks f.e)
-        elif "%04d" in filename:
-            sequences = get_sequence(filepath,
-                                     pattern="%04d")
-            if sequences:
-                return sequences
+    # Frame/time - Based textures (animated masks f.e)
+    elif "%04d" in filename:
+        sequences = get_sequence(filepath,
+                                 pattern="%04d")
+        if sequences:
+            return sequences
 
     # Assuming it is a fixed name (single file)
     if os.path.exists(filepath):


### PR DESCRIPTION
## Changelog Description

Correctly collect sequences with `_1001.exr` instead of only delimited by `.` like `.1001.exr`. 

## Additional info

Fixes #117

This same function is also used for collecting Ornatrix textures - so it may be worth running a check of publishing ornatrix textures along as well.

## Testing notes:

1. Load a texture file in Yeti with `_` delimiter, like: `C:/projects/ayontest/asset/char_hero/publish/image/textureMain.Diffuse/v002/ynts_char_hero_textureMain.Diffuse_v002_<UDIM>.png`

![image](https://github.com/user-attachments/assets/49e9c015-ee7a-469b-a5dd-80502960d2fb)
![image](https://github.com/user-attachments/assets/54e93130-5523-43de-86c8-8f5432bbe818)
