### PR TITLE
Update handle start and handle end on instances on task change

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -3243,6 +3243,8 @@ def update_content_on_context_change():
     creator_attribute_values = {
         "frameStart": float(task_entity["attrib"]["frameStart"]),
         "frameEnd": float(task_entity["attrib"]["frameEnd"]),
+        "handleStart": float(task_entity["attrib"]["handleStart"]),
+        "handleEnd": float(task_entity["attrib"]["handleEnd"]),
     }
 
     has_changes = False


### PR DESCRIPTION
## Changelog Description

Update handle start and handle end on instances on task change when updating to match the context

## Additional info

Fixes #76 

## Testing notes:

1. Set up workfile with publish instances that have handle start and handle end, e.g. pointcache instances.
2. Save workfile to different context.
3. A popup dialog shows, asking to update instances, etc. Apply it.
3. The instance's frame range should for handle start and handle end should now be updated to that of the new task entity.
