### PR TITLE
Allow update to switch between `ma` and `mb` representation

### DIFF
--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -1064,6 +1064,14 @@ class ReferenceLoader(Loader):
             }:
                 cmds.sets(node, forceElement=container)
 
+    def update_allowed_representation_switches(self):
+        return {
+            # Allow switching between `ma` and `mb` representations if new
+            # version happens to contain only the other representation
+            "ma": ["mb"],
+            "mb": ["ma"]
+        }
+
 
 class MayaLoader(LoaderPlugin):
     """Base class for loader plugins."""

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -1064,13 +1064,14 @@ class ReferenceLoader(Loader):
             }:
                 cmds.sets(node, forceElement=container)
 
-    def update_allowed_representation_switches(self):
+    @classmethod
+    def get_representation_name_aliases(cls, representation_name):
+        # Allow switching between `ma` and `mb` representations if new
+        # version happens to contain only the other representation
         return {
-            # Allow switching between `ma` and `mb` representations if new
-            # version happens to contain only the other representation
             "ma": ["mb"],
             "mb": ["ma"]
-        }
+        }.get(representation_name, [])
 
 
 class MayaLoader(LoaderPlugin):


### PR DESCRIPTION
## Changelog Description

Allow update to switch between `ma` and `mb` representation


## Additional info

Fixes #111
Requires https://github.com/ynput/ayon-core/pull/932

## Testing notes:

⚠️ Makes sure to test together with https://github.com/ynput/ayon-core/pull/932

1. Publish a product that generates a `.ma`
2. Change settings so that it now generates `.mb`
    - Tweak `ayon+settings://maya/ext_mapping`
4. Publish the `.mb`
5. Load the first version `.ma`
6. Update the version to the newer version and vice versa.

It should update without error.
