### PR TITLE
Fix including of containers with e.g. `layout` products

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_maya_scene_raw.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_scene_raw.py
@@ -126,8 +126,8 @@ class ExtractMayaSceneRaw(plugin.MayaExtractorPlugin, AYONPyblishPluginMixin):
         self.log.debug("Extracted instance '%s' to: %s" % (instance.name,
                                                            path))
 
-    @classmethod
-    def _get_loaded_containers(cls, members):
+    @staticmethod
+    def _get_loaded_containers(members):
         # type: (list[str]) -> list[str]
         refs_to_include = {
             cmds.referenceQuery(node, referenceNode=True)

--- a/client/ayon_maya/plugins/publish/extract_maya_scene_raw.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_scene_raw.py
@@ -75,11 +75,19 @@ class ExtractMayaSceneRaw(plugin.MayaExtractorPlugin, AYONPyblishPluginMixin):
         else:
             members = instance[:]
 
-        selection = members
+        # For some families, like `layout` we collect the containers so we
+        # maintain the containers of the members in the resulting product.
+        # However, if `exactSetMembersOnly` is true (which it is for layouts)
+        # searching the exact set members for containers doesn't make much
+        # sense. We must always search the full hierarchy to actually find
+        # the relevant containers
+        selection = list(members)  # make a copy to not affect input list
         if set(self.add_for_families).intersection(
                 set(instance.data.get("families", []))) or \
                 instance.data.get("productType") in self.add_for_families:
-            selection += self._get_loaded_containers(members)
+            containers = self._get_loaded_containers(instance[:])
+            self.log.debug(f"Collected containers: {containers}")
+            selection.extend(containers)
 
         # Perform extraction
         self.log.debug("Performing extraction ...")
@@ -118,9 +126,9 @@ class ExtractMayaSceneRaw(plugin.MayaExtractorPlugin, AYONPyblishPluginMixin):
         self.log.debug("Extracted instance '%s' to: %s" % (instance.name,
                                                            path))
 
-    @staticmethod
-    def _get_loaded_containers(members):
-        # type: (list) -> list
+    @classmethod
+    def _get_loaded_containers(cls, members):
+        # type: (list[str]) -> list[str]
         refs_to_include = {
             cmds.referenceQuery(node, referenceNode=True)
             for node in members


### PR DESCRIPTION
## Changelog Description

With this fix the `layout` product now contains the `containers` of the exported assets again. So that, upon loading, the assets inside the layout also appear in the scene inventory.

## Additional info

This being broken was a regression - so this restores the original behavior.

## Testing notes:

1. Publishing and loading the layout again should preserve the containers
