### PR TITLE
Alembic Exports: Do not force a preroll starting at frame 0

### DIFF
--- a/client/ayon_maya/api/alembic.py
+++ b/client/ayon_maya/api/alembic.py
@@ -57,7 +57,7 @@ def extract_alembic(
     melPostJobCallback=None,
     noNormals=False,
     preRoll=False,
-    preRollStartFrame=0,
+    preRollStartFrame=None,
     pythonPerFrameCallback=None,
     pythonPostJobCallback=None,
     renderableOnly=False,
@@ -119,10 +119,11 @@ def extract_alembic(
         preRoll (bool): This frame range will not be sampled.
             Defaults to False.
 
-        preRollStartFrame (float): The frame to start scene
+        preRollStartFrame (Optional[float]): The frame to start scene
             evaluation at.  This is used to set the starting frame for time
             dependent translations and can be used to evaluate run-up that
-            isn't actually translated. Defaults to 0.
+            isn't actually translated. Defaults to None, meaning no pre-roll
+            start frame will be used to roll from.
 
         pythonPerFrameCallback (Optional[str]): Python callback run per frame.
 

--- a/client/ayon_maya/api/alembic.py
+++ b/client/ayon_maya/api/alembic.py
@@ -34,7 +34,6 @@ ALEMBIC_ARGS = {
     "userAttrPrefix": (list, tuple),
     "uvWrite": bool,
     "uvsOnly": bool,
-    "verbose": bool,
     "wholeFrameGeo": bool,
     "worldSpace": bool,
     "writeColorSets": bool,
@@ -259,7 +258,6 @@ def extract_alembic(
         "userAttr": userAttr,
         "userAttrPrefix": userAttrPrefix,
         "stripNamespaces": stripNamespaces,
-        "verbose": verbose
     }
 
     # Validate options

--- a/client/ayon_maya/plugins/publish/extract_pointcache.py
+++ b/client/ayon_maya/plugins/publish/extract_pointcache.py
@@ -215,6 +215,29 @@ class ExtractAlembic(plugin.MayaExtractorPlugin,
                 iter_visible_nodes_in_range(nodes, start=start, end=end)
             )
 
+        # Our logic is that `preroll` means:
+        # - True: include a preroll from `preRollStartFrame` to the start
+        #  frame that is not included in the exported file. Just 'roll up'
+        #  the export from there.
+        # - False: do not roll up from `preRollStartFrame`.
+        # `AbcExport` however approaches this very differently.
+        # A call to `AbcExport` allows to export multiple "jobs" of frame
+        # ranges in one go. Using `-preroll` argument there means: this one
+        # job in the full list of jobs SKIP writing these frames into the
+        # Alembic. In short, marking that job as just preroll.
+        # Then additionally, separate from `-preroll` the `AbcExport` command
+        # allows to supply `preRollStartFrame` which, when not None, means
+        # always RUN UP from that start frame. Since our `preRollStartFrame`
+        # is always an integer attribute we will convert the attributes so
+        # they behave like how we intended them initially
+        if kwargs["preRoll"]:
+            # Never mark `preRoll` as True because it would basically end up
+            # writing no samples at all. We just use this to leave
+            # `preRollStartFrame` as a number value.
+            kwargs["preRoll"] = False
+        else:
+            kwargs["preRollStartFrame"] = None
+
         shapes = self.get_members_shapes(instance)
 
         suspend = not instance.data.get("refresh", False)


### PR DESCRIPTION
## Changelog Description

Fixes Alembic Exports always defaulting to include a preroll run-up to the export from the `preRollStartFrame`, which defaulted to `0`.

Also fixes this warning always being logged:
```
# Warning: Ignoring unsupported flag: -verbose
```

## Additional info

The "pre roll" was not included in the exported data - but it did mean that for EVERY alembic export we basically ended up stepping through the frame ranges from frame 0 up to the start frame of the Alembic to export.

I'd say this is actually quite an inconvenience for scenes that happen to also be heavy to step through time before the start frame because it'd heavily influence the time taken if you actually did not care about pre roll at all.

The bug was introduced around April/May via these PRs:
- https://github.com/ynput/ayon-core/pull/478 This PR just fixed the argument signature to the maya commands and "activated" the bug.
- https://github.com/ynput/ayon-core/pull/336 This PR initially tried to use the `preRollStartFrame` argument this way.
- Which all originated from this OpenPype PR initially: https://github.com/ynput/OpenPype/pull/5173

I believe it all came from a misconception about what the `preRoll` argument on the `AbcExport` command was supposed to do. To explain that I'll just quote what I wrote as comment in the code for this PR:

> Our logic is that `preroll` means:
> - True: include a preroll from `preRollStartFrame` to the start
>  frame that is not included in the exported file. Just 'roll up'
>  the export from there.
> - False: do not roll up from `preRollStartFrame`.
> 
> `AbcExport` however approaches this very differently.
> 
> A call to `AbcExport` allows to export multiple "jobs" of frame ranges in one go. Using `-preroll` argument there means: this one job in the full list of jobs SKIP writing these frames into the Alembic. 
> 
> In short, marking that job as just preroll.
> 
> Then additionally, separate from `-preroll` the `AbcExport` command allows to supply `preRollStartFrame` which, when not None, means always RUN UP from that start frame. Since our `preRollStartFrame` is always an integer attribute we will convert the attributes so they behave like how we intended them initially

## Testing notes:

### How to debug

The easiest way to test this is to enable "Verbose" in settings: `ayon+settings://maya/publish/ExtractAlembic/verbose`
![image](https://github.com/user-attachments/assets/e3929254-48e0-42cc-bf14-8975c4c62ba8)

You will then end up seeing the frame numbers printed by the Alembic Exporter - e.g. this:
![image](https://github.com/user-attachments/assets/e9cfbded-1ce4-4fc2-9c0d-b4965ed3ee9d)

Going all the way from frame zero.

### What to test

1. Alembic Exports should not default to prerolling from frame 0.
2. Enabling preroll on Alembic export for settings should still allow enabling the preroll.

Others that would be affected also calling `extract_alembic` and should now also NOT preroll from frame 0 but they did before this PR:
- Extract Assembly
- Extract Proxy ABC
- Extract Unreal SkeletalMesh Abc
- XGEN extractions with a Render (it was called [here](https://github.com/ynput/ayon-maya/blob/06aa2445b4df511225b6795b283dd974040c0b5f/client/ayon_maya/plugins/publish/extract_workfile_xgen.py#L116-L124).
