### PR TITLE
Maya USD Proxy Loader: Do not use AYON Entity URI by default

### DIFF
--- a/server/settings/loaders.py
+++ b/server/settings/loaders.py
@@ -304,7 +304,7 @@ DEFAULT_LOADERS_SETTING = {
     "MatchmoveLoader": {"enabled": True},
     "MayaUsdLoader": {
         "enabled": True,
-        "use_ayon_entity_uri": True
+        "use_ayon_entity_uri": False
     },
     "MultiverseUsdLoader": {"enabled": True},
     "MultiverseUsdOverLoader": {"enabled": True},


### PR DESCRIPTION
## Changelog Description

Disable using the AYON Entity URI by default for Load Maya USD proxy loader.

## Additional info

It should be up to the studio to enable it if they are using the asset resolver.

## Testing notes:

1. Using default settings loading with Maya USD Proxy Loader it should not use the AYON Entity URI.