### PR TITLE
Create plugins: Apply settings correctly

### DIFF
--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -1,10 +1,8 @@
 import json
 import os
-from abc import ABCMeta
 
 import ayon_api
 import qargparse
-import six
 
 from ayon_core.lib import BoolDef, Logger
 from ayon_core.pipeline import (
@@ -110,9 +108,7 @@ def get_ayon_entity_uri_from_representation_context(context: dict) -> str:
     return uris[0]["uri"]
 
 
-@six.add_metaclass(ABCMeta)
-class MayaCreatorBase(object):
-
+class MayaCreatorBase:
     @staticmethod
     def cache_instance_data(shared_data):
         """Cache instances for Creators to shared data.
@@ -297,7 +293,6 @@ class MayaCreatorBase(object):
             self._remove_instance_from_context(instance)
 
 
-@six.add_metaclass(ABCMeta)
 class MayaCreator(Creator, MayaCreatorBase):
 
     settings_category = "maya"

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -416,7 +416,7 @@ class RenderlayerCreator(Creator, MayaCreatorBase):
     an instance per renderlayer.
 
     """
-
+    settings_category = "maya"
     # These are required to be overridden in subclass
     singleton_node_name = ""
 

--- a/client/ayon_maya/plugins/create/create_render.py
+++ b/client/ayon_maya/plugins/create/create_render.py
@@ -33,9 +33,9 @@ class CreateRenderlayer(plugin.RenderlayerCreator):
 
     render_settings = {}
 
-    @classmethod
-    def apply_settings(cls, project_settings):
-        cls.render_settings = project_settings["maya"]["render_settings"]
+    def apply_settings(self, project_settings):
+        super().apply_settings(project_settings)
+        self.render_settings = project_settings["maya"]["render_settings"]
 
     def create(self, product_name, instance_data, pre_create_data):
         # Only allow a single render instance to exist

--- a/client/ayon_maya/plugins/create/create_vrayscene.py
+++ b/client/ayon_maya/plugins/create/create_vrayscene.py
@@ -21,9 +21,9 @@ class CreateVRayScene(plugin.RenderlayerCreator):
     render_settings = {}
     singleton_node_name = "vraysceneMain"
 
-    @classmethod
-    def apply_settings(cls, project_settings):
-        cls.render_settings = project_settings["maya"]["render_settings"]
+    def apply_settings(self, project_settings):
+        super().apply_settings(project_settings)
+        self.render_settings = project_settings["maya"]["render_settings"]
 
     def create(self, product_name, instance_data, pre_create_data):
         # Only allow a single render instance to exist


### PR DESCRIPTION
## Changelog Description
Create Render and Vray Scene are propagating settings.

## Additional info
The plugins did not propagate their settings because were collecting only `render_settings`. Also change the classmethods to methods.

## Testing notes:
1. Change of `enabled` state in settings on both create plugins should be propagated.

Resolves https://github.com/ynput/ayon-maya/issues/162