### PR TITLE
Adds skeletal mesh extractors as configurable settings

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_unreal_skeletalmesh_abc.py
+++ b/client/ayon_maya/plugins/publish/extract_unreal_skeletalmesh_abc.py
@@ -5,10 +5,11 @@ import os
 from ayon_maya.api.alembic import extract_alembic
 from ayon_maya.api.lib import maintained_selection, suspended_refresh
 from ayon_maya.api import plugin
+from ayon_core.pipeline import publish
 from maya import cmds  # noqa
 
 
-class ExtractUnrealSkeletalMeshAbc(plugin.MayaExtractorPlugin):
+class ExtractUnrealSkeletalMeshAbc(plugin.MayaExtractorPlugin, publish.OptionalPyblishPluginMixin):
     """Extract Unreal Skeletal Mesh as FBX from Maya. """
 
     label = "Extract Unreal Skeletal Mesh - Alembic"
@@ -16,6 +17,8 @@ class ExtractUnrealSkeletalMeshAbc(plugin.MayaExtractorPlugin):
     optional = True
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
         self.log.debug("Extracting pointcache..")
 
         geo = cmds.listRelatives(

--- a/client/ayon_maya/plugins/publish/extract_unreal_skeletalmesh_fbx.py
+++ b/client/ayon_maya/plugins/publish/extract_unreal_skeletalmesh_fbx.py
@@ -4,6 +4,8 @@ import os
 from contextlib import contextmanager
 
 import pyblish.api
+
+from ayon_core.pipeline import publish
 from ayon_maya.api import fbx
 from ayon_maya.api import plugin
 from maya import cmds  # noqa
@@ -19,7 +21,7 @@ def renamed(original_name, renamed_name):
         cmds.rename(renamed_name, original_name)
 
 
-class ExtractUnrealSkeletalMeshFbx(plugin.MayaExtractorPlugin):
+class ExtractUnrealSkeletalMeshFbx(plugin.MayaExtractorPlugin, publish.OptionalPyblishPluginMixin):
     """Extract Unreal Skeletal Mesh as FBX from Maya. """
 
     order = pyblish.api.ExtractorOrder - 0.1
@@ -28,6 +30,9 @@ class ExtractUnrealSkeletalMeshFbx(plugin.MayaExtractorPlugin):
     optional = True
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
+
         fbx_exporter = fbx.FBXExtractor(log=self.log)
 
         # Define output path

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -543,6 +543,8 @@ class ExtractCameraAlembicModel(BaseSettingsModel):
                     "camera export. Needs to be written as a JSON list.",
     )
 
+
+
     @validator("bake_attributes")
     def validate_json_list(cls, value):
         if not value.strip():
@@ -597,6 +599,15 @@ class ExtractGPUCacheModel(BaseSettingsModel):
     writeMaterials: bool = SettingsField(title="Write Materials")
     useBaseTessellation: bool = SettingsField(title="User Based Tessellation")
 
+class ExtractSkeletalMeshAlembicModel(BaseSettingsModel):
+    enabled: bool = SettingsField(title="ExtractSkeletalMeshAlembic")
+    optional: bool = SettingsField(title="Optional")
+    active: bool = SettingsField(title="Active")
+
+class ExtractSkeletalMeshFbxModel(BaseSettingsModel):
+    enabled: bool = SettingsField(title="ExtractSkeletalMeshFbx")
+    optional: bool = SettingsField(title="Optional")
+    active: bool = SettingsField(title="Active")
 
 class PublishersModel(BaseSettingsModel):
     CollectMayaRender: CollectMayaRenderModel = SettingsField(
@@ -1051,7 +1062,14 @@ class PublishersModel(BaseSettingsModel):
         default_factory=ExtractMayaUsdAnimModel,
         title="Extract Maya USD with Animation"
     )
-
+    ExtractSkeletalMeshAlembic: ExtractSkeletalMeshAlembicModel = SettingsField(
+        default_factory=ExtractSkeletalMeshAlembicModel,
+        title="Extract Unreal Skeletal Mesh (Alembic)"
+    )
+    ExtractSkeletalMeshFbx: ExtractSkeletalMeshFbxModel = SettingsField(
+        default_factory=ExtractSkeletalMeshFbxModel,
+        title="Extract Unreal Skeletal Mesh (FBX)"
+    )
 
 DEFAULT_SUFFIX_NAMING = {
     "mesh": ["_GEO", "_GES", "_GEP", "_OSD"],
@@ -1694,5 +1712,15 @@ DEFAULT_PUBLISH_SETTINGS = {
         "enabled": True,
         "optional": True,
         "active": False,
+    },
+    "ExtractSkeletalMeshAlembic": {
+        "enabled": False,
+        "optional": True,
+        "active": True,
+    },
+    "ExtractSkeletalMeshFbx": {
+        "enabled": False,
+        "optional": True,
+        "active": True,
     }
 }


### PR DESCRIPTION
## Changelog Description
Adds options in the extractor settings to turn on or off the skeletal mesh abc and fbx extractors.

![image](https://github.com/user-attachments/assets/aeaa8ec7-a8a5-449e-aba6-d8c8a87e8fa7)


## Additional info
At Halon we don't typically use the Abc export for skeletal meshes and needed a way to disable to extractor. One thing to note about the ABC extractor is that either we're using it wrong or it has some issues with it. 

![image](https://github.com/user-attachments/assets/a10a67d1-e7de-43e2-a2b6-f7c063034b25)


## Testing notes:

1. Open a rig working file
2. In Create add a new `Unreal - Skeletal Mesh` publish instance.
3. Make sure to add your mesh and you joints to the  `geometry_SET` and the `joints_set`
4. Depending on your server settings you should see the following on the publish instance.
![image](https://github.com/user-attachments/assets/b565ed59-39fa-410e-9090-0f9bd574700f)
5. Click publish.

You should see that it only exports what ever options you have selected.

