### PR TITLE
Support assigning maya look to multiple separate assets inside an Arnold `aiStandin` with alembic files.

### DIFF
--- a/client/ayon_maya/tools/mayalookassigner/alembic.py
+++ b/client/ayon_maya/tools/mayalookassigner/alembic.py
@@ -71,8 +71,14 @@ def get_alembic_paths_by_property(filename, attr, verbose=False):
         if not _property.isConstant():
             log.warning("Id not constant on: {0}".format(name))
 
-        # Get first value sample
-        value = _property.getValue()[0]
+        # Maya alembic export seems to export `cbId` string as array property
+        # whereas Houdini primitive `cbId` attribute comes through as a
+        # scalar property (which still holds the string?)
+        if isinstance(_property, alembic.Abc.IArrayProperty):
+            # Get first value sample
+            value = _property.getValue()[0]
+        else:
+            value = _property.getValue()
 
         obj_ids[name] = value
 

--- a/client/ayon_maya/tools/mayalookassigner/app.py
+++ b/client/ayon_maya/tools/mayalookassigner/app.py
@@ -268,7 +268,14 @@ class MayaLookAssignerWindow(QtWidgets.QWidget):
 
             # Assign Arnold Standin look.
             if cmds.pluginInfo("mtoa", query=True, loaded=True):
-                arnold_standins = cmds.ls(nodes, type="aiStandIn", long=True)
+                # If the current renderer is Arnold we also allow assigning
+                # to gpuCache nodes. If not, then we skip it because Arnold may
+                # be loaded even if unused as renderer in current project.
+                types = ["aiStandIn"]
+                renderer = cmds.getAttr("defaultRenderGlobals.currentRenderer")
+                if renderer == "arnold":
+                    types.append("gpuCache")
+                arnold_standins = cmds.ls(nodes, type=types, long=True)
                 for standin in arnold_standins:
                     arnold_standin.assign_look_by_version(
                         standin, version_id=version_entity["id"])

--- a/client/ayon_maya/tools/mayalookassigner/app.py
+++ b/client/ayon_maya/tools/mayalookassigner/app.py
@@ -268,11 +268,10 @@ class MayaLookAssignerWindow(QtWidgets.QWidget):
 
             # Assign Arnold Standin look.
             if cmds.pluginInfo("mtoa", query=True, loaded=True):
-                arnold_standins = set(cmds.ls(type="aiStandIn", long=True))
-
+                arnold_standins = cmds.ls(nodes, type="aiStandIn", long=True)
                 for standin in arnold_standins:
-                    if standin in nodes:
-                        arnold_standin.assign_look(standin, product_name)
+                    arnold_standin.assign_look_by_version(
+                        standin, version_id=version_entity["id"])
 
                 nodes = list(set(nodes).difference(arnold_standins))
             else:

--- a/client/ayon_maya/tools/mayalookassigner/arnold_standin.py
+++ b/client/ayon_maya/tools/mayalookassigner/arnold_standin.py
@@ -54,8 +54,8 @@ def calculate_visibility_mask(attributes):
         "aiVisibleInSpecularReflection": 64
     }
     mask = 255
-    for attr, value in mapping.items():
-        if attributes.get(attr, True):
+    for attr_name, value in mapping.items():
+        if attributes.get(attr_name, True):
             continue
 
         mask -= value

--- a/client/ayon_maya/tools/mayalookassigner/arnold_standin.py
+++ b/client/ayon_maya/tools/mayalookassigner/arnold_standin.py
@@ -175,7 +175,7 @@ class SetParameter:
     def create(self, name=None) -> str:
         operator: str = cmds.createNode("aiSetParameter",
                                         skipSelect=True,
-                                         name=name)
+                                        name=name)
         self.node = operator
         self.update()
         return operator

--- a/client/ayon_maya/tools/mayalookassigner/arnold_standin.py
+++ b/client/ayon_maya/tools/mayalookassigner/arnold_standin.py
@@ -74,7 +74,7 @@ def get_nodes_by_id(standin):
     """
 
     # Transform to shape if not shape
-    if not cmds.nodeType(standin, isAType="shape"):
+    if not cmds.objectType(standin, isAType="shape"):
         shapes = cmds.listRelatives(
             standin,
             shapes=True,

--- a/client/ayon_maya/tools/mayalookassigner/arnold_standin.py
+++ b/client/ayon_maya/tools/mayalookassigner/arnold_standin.py
@@ -325,8 +325,14 @@ def assign_look_by_version(
             consider a subset of the nodes using e.g. 
             `get_nodes_by_id_filtered`.
     """
-    if not nodes_by_id:
+    if nodes_by_id is None:
         nodes_by_id = get_nodes_by_id(standin)
+
+    if not nodes_by_id:
+        # Nothing to do - opt out early
+        log.debug(f"No ids found in standin '{standin}'. "
+                  "Skipping assignment...")
+        return
 
     # Get current active operators
     operators = get_current_set_parameter_operators(standin)

--- a/client/ayon_maya/tools/mayalookassigner/arnold_standin.py
+++ b/client/ayon_maya/tools/mayalookassigner/arnold_standin.py
@@ -72,7 +72,24 @@ def get_nodes_by_id(standin):
     Returns:
         (dict): Dictionary with node full name/path and id.
     """
-    path = cmds.getAttr(standin + ".dso")
+
+    # Transform to shape if not shape
+    if not cmds.nodeType(standin, isAType="shape"):
+        shapes = cmds.listRelatives(
+            standin,
+            shapes=True,
+            noIntermediate=True,
+            type=("aiStandIn", "gpuCache"),
+            fullPath=True)
+        if not shapes:
+            return {}
+        standin = shapes[0]
+
+    attr = "dso"  # aiStandIn
+    if cmds.nodeType(standin) == "gpuCache":
+        attr = "cacheFileName"
+
+    path = cmds.getAttr(f"{standin}.{attr}")
 
     if path.endswith(".abc"):
         # Support alembic files directly
@@ -187,10 +204,10 @@ class SetParameter:
 
 
 def get_current_set_parameter_operators(standin: str) -> List[SetParameter]:
-    """Return SetParameter operators for a aiStandin node.
+    """Return SetParameter operators for a aiStandIn node.
 
     Args:
-        standin: The `aiStandin` node to get the assignments from.
+        standin: The `aiStandIn` node to get the assignments from.
 
     Returns:
         The list of `SetParameter` objects that represent the assignments.
@@ -232,7 +249,7 @@ def get_current_set_parameter_operators(standin: str) -> List[SetParameter]:
 
 
 def get_nodes_by_id_filtered(standin, include_selection_prefixes):
-    """Get aiStandin object paths by `cbId` via Alembic or JSON sidecar.
+    """Get aiStandIn object paths by `cbId` via Alembic or JSON sidecar.
 
     Args:
         standin (string): aiStandIn node.
@@ -267,7 +284,7 @@ def assign_look(
     """Assign a look to an aiStandIn node.
 
     Arguments:
-        standin (str): The aiStandin proxy shape.
+        standin (str): The aiStandIn proxy shape.
         product_name (str): The product name to load.
         include_selection_prefixes (Optional[List[str]]): If provided,
             only children to these object path prefixes will be considered.
@@ -318,7 +335,7 @@ def assign_look_by_version(
     """Assign a look to an aiStandIn node by look version id.
     
     Args:
-        standin (str): aiStandin node. 
+        standin (str): aiStandIn node.
         version_id (str): Look product version id. 
         nodes_by_id (Optional[Dict[str, List[str]]]): Pre-computed dictionary 
             with node ids and paths, as optimization or as filter to only

--- a/client/ayon_maya/tools/mayalookassigner/arnold_standin.py
+++ b/client/ayon_maya/tools/mayalookassigner/arnold_standin.py
@@ -325,23 +325,23 @@ def assign_look(
 
             if edit["action"] == "setattr":
                 visibility = False
-                for attr, value in edit["attributes"].items():
-                    if attr not in ATTRIBUTE_MAPPING:
+                for attr_name, value in edit["attributes"].items():
+                    if attr_name not in ATTRIBUTE_MAPPING:
                         log.warning(
                             "Skipping setting attribute {} on {} because it is"
-                            " not recognized.".format(attr, edit["nodes"])
+                            " not recognized.".format(attr_name, edit["nodes"])
                         )
                         continue
 
                     if isinstance(value, str):
                         value = "'{}'".format(value)
 
-                    if ATTRIBUTE_MAPPING[attr] == "visibility":
+                    mapped_attr_name = ATTRIBUTE_MAPPING[attr_name]
+                    if mapped_attr_name == "visibility":
                         visibility = True
                         continue
 
-                    assignment = "{}={}".format(ATTRIBUTE_MAPPING[attr], value)
-
+                    assignment = f"{mapped_attr_name}={value}"
                     for node in edit["nodes"]:
                         node_assignments[node].append(assignment)
 

--- a/client/ayon_maya/tools/mayalookassigner/commands.py
+++ b/client/ayon_maya/tools/mayalookassigner/commands.py
@@ -87,7 +87,7 @@ def create_folder_id_hash(nodes):
             for k, _ in ids.items():
                 id = k.split(":")[0]
                 node_id_hash[id].append(node)
-        elif cmds.nodeType(node) == "aiStandIn":
+        elif cmds.nodeType(node) in {"aiStandIn", "gpuCache"}:
             for id, _ in arnold_standin.get_nodes_by_id(node).items():
                 id = id.split(":")[0]
                 node_id_hash[id].append(node)


### PR DESCRIPTION
## Changelog Description

1. Do not force remove assignments on aiStandin look assignments, but allow updating/adding assingments so that assigning looks of multiple assets inside one `aiStandin` shape is supported.

2. This also fixes a bug where `cbId` attribute exported from Houdini was not detected correctly and its value was incorrectly interpreted from the alembic property.
- Maya seems to export as `alembic.Abc.IArrayProperty`
- Houdini seems to export as `alembic.Abc.IScalarProperty`

3. You can now also list assets and assign look to `gpuCache` if `mtoa` (Arnold) renderer is loaded and is set as the current renderer.

4. This also fixes a bug where ALL assets inside an `aiStandin` are assigned even if only one of them was picked from the asset list in the look assigner.

We now support both.

## Additional info

Fixes #160 

## Testing notes:

1. Create a pointcache containing geometry from multiple folders (assets)
2. Load the Alembic pointcache via AYON to `aiStandin`.
3. Assign the look.

It should detect the multiple assets inside the `aiStandin` and allow assigning each of them without applying only the last asset.
