### PR TITLE
Allow loading published rig that has no `out_SET` and no `controls_SET`

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -83,6 +83,15 @@ DISPLAY_LIGHTS_ENUM = [
 ]
 
 
+class RigSetsNotExistError(RuntimeError):
+    """Raised when required rig sets for animation instance are missing.
+
+    This is raised from `create_rig_animation_instance` when the required
+    `out_SET` or `controls_SET` are missing.
+    """
+    pass
+
+
 def get_main_window():
     """Acquire Maya's main window"""
     from qtpy import QtWidgets
@@ -4168,8 +4177,14 @@ def create_rig_animation_instance(
     controls = next((node for node in nodes if
                      node.endswith("controls_SET")), None)
     if name != "fbx":
-        assert output, "No out_SET in rig, this is a bug."
-        assert controls, "No controls_SET in rig, this is a bug."
+        if not output:
+            raise RigSetsNotExistError(
+                "No out_SET in rig. The loaded rig publish is lacking the "
+                "out_SET required for animation instances.")
+        if not controls:
+            raise RigSetsNotExistError(
+                "No controls_SET in rig. The loaded rig publish is lacking "
+                "the controls_SET required for animation instances.")
 
     anim_skeleton = next((node for node in nodes if
                           node.endswith("skeletonAnim_SET")), None)

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -5,6 +5,7 @@ import qargparse
 from ayon_core.settings import get_project_settings
 from ayon_maya.api import plugin
 from ayon_maya.api.lib import (
+    RigSetsNotExistError,
     create_rig_animation_instance,
     get_container_members,
     maintained_selection,
@@ -241,9 +242,13 @@ class ReferenceLoader(plugin.ReferenceLoader):
     def _post_process_rig(self, namespace, context, options):
 
         nodes = self[:]
-        create_rig_animation_instance(
-            nodes, context, namespace, options=options, log=self.log
-        )
+        try:
+            create_rig_animation_instance(
+                nodes, context, namespace, options=options, log=self.log
+            )
+        except RigSetsNotExistError as exc:
+            self.log.warning(
+                "Missing rig sets for animation instance creation: %s", exc)
 
     def _lock_camera_transforms(self, nodes):
         cameras = cmds.ls(nodes, type="camera")


### PR DESCRIPTION
## Changelog Description

Allow loading published rig that has no `out_SET` and no `controls_SET` but then skip creating the animation instance automatically, with a warning

## Additional review information

There may be edge cases where a rig was published without those sets without validation errors (the validators are disabled by default) but then being unable to load them is very annoying. So this allows them to be loaded, but with a warning logged instead.

Fixes https://github.com/ynput/ayon-maya/issues/168

## Testing notes:

1. Create rig instance
2. Remove the `out_SET` and `controls_SET` from the instance
3. (Make sure the validate rig contents validator is disabled; it's disabled by default)
4. Publish rig
5. Load the rig

