### PR TITLE
Create Maya USD: Do not error on context attribute value change

### DIFF
--- a/client/ayon_maya/plugins/create/create_maya_usd.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd.py
@@ -27,6 +27,10 @@ class CreateMayaUsd(plugin.MayaCreator):
         for instance_change in event["changes"]:
             # First check if there's a change we want to respond to
             instance = instance_change["instance"]
+            if not instance:
+                # Change is on context
+                continue
+
             if instance["creator_identifier"] != self.identifier:
                 continue
 

--- a/client/ayon_maya/plugins/create/create_maya_usd.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd.py
@@ -27,7 +27,7 @@ class CreateMayaUsd(plugin.MayaCreator):
         for instance_change in event["changes"]:
             # First check if there's a change we want to respond to
             instance = instance_change["instance"]
-            if not instance:
+            if instance is None:
                 # Change is on context
                 continue
 


### PR DESCRIPTION
## Changelog Description

Create Maya USD: Do not error on context attribute value change

## Additional review information

Should fix error posted [here](https://github.com/ynput/ayon-core/pull/982#pullrequestreview-2414976747)

> Works nicely, the only occasion which throw some traceback is when trying to switch settings for `context` and `Validate outdated containers`
> 
> ![Screenshot 2024-11-05 094409](https://private-user-images.githubusercontent.com/112623825/383070330-71084694-429a-48ff-8e2c-f2f2fe779f8a.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzA3OTcxNzQsIm5iZiI6MTczMDc5Njg3NCwicGF0aCI6Ii8xMTI2MjM4MjUvMzgzMDcwMzMwLTcxMDg0Njk0LTQyOWEtNDhmZi04ZTJjLWYyZjJmZTc3OWY4YS5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQxMTA1JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MTEwNVQwODU0MzRaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0yOGRlMzI4YmVkZjA2YmEyOGY0OWU5YTc4NjExMTQ2MDNjYzgxZGE3YjhmNDBjMWI2NjkwYTNmMDNmMzVjZjAxJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.lW0X6tmV7ZEWYRp3SNYI_5kZl8kCTtGin53X7MDqrSk)
> 
> resulting in
> 
> ```
> // Traceback (most recent call last):
> //   File "C:\Work\REPO\ayon-core\client\ayon_core\lib\events.py", line 332, in process_event
> //     callback(event)
> //   File "c:\Work\REPO\ayon-maya\client\ayon_maya\plugins\create\create_maya_usd.py", line 30, in on_values_changed
> //     if instance["creator_identifier"] != self.identifier:
> // TypeError: 'NoneType' object is not subscriptable
> ```
> 
> Not failing but worth mentioning imho....


## Testing notes:

1. Create maya usd instance
2. Trigger context attribute change
3. No error should occur
