### PR TITLE
USD Export: Workaround default prim bug in Maya 2025.3 with Maya USD 0.30.0

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -343,6 +343,23 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                 )
                 del options[key]
 
+        # Fix default prim bug in Maya USD 0.30.0 where prefixed `|` remains
+        # See: https://github.com/Autodesk/maya-usd/issues/3991
+        if (
+                False and
+                options.get("exportRoots")          # only if roots are defined
+                and not "defaultPrim" in options    # ignore if already set
+                and not "rootPrim" in options       # ignore if root is created
+                and maya_usd_version == (0, 30, 0)  # only for Maya USD 0.30.0
+        ):
+            # Define the default prim name as it will end up in the USD file
+            # from the first export root node
+            first_root = options["exportRoots"][0]
+            default_prim = first_root.rsplit("|", 1)[-1]
+            if options["stripNamespaces"]:
+                default_prim = default_prim.rsplit(":", 1)[-1]
+            options["defaultPrim"] = default_prim
+
         self.log.debug('Exporting USD: {} / {}'.format(file_path, members))
         with maintained_time():
             with maintained_selection():

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -346,7 +346,6 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
         # Fix default prim bug in Maya USD 0.30.0 where prefixed `|` remains
         # See: https://github.com/Autodesk/maya-usd/issues/3991
         if (
-                False and
                 options.get("exportRoots")          # only if roots are defined
                 and "defaultPrim" not in options    # ignore if already set
                 and "rootPrim" not in options       # ignore if root is created

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -258,7 +258,6 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
         # Parse export options
         options = self.default_options
         options = self.parse_overrides(instance, options)
-        self.log.debug("Export options: {0}".format(options))
 
         # Perform extraction
         self.log.debug("Performing extraction ...")
@@ -359,6 +358,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                 default_prim = default_prim.rsplit(":", 1)[-1]
             options["defaultPrim"] = default_prim
 
+        self.log.debug("Export options: {0}".format(options))
         self.log.debug('Exporting USD: {} / {}'.format(file_path, members))
         with maintained_time():
             with maintained_selection():

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -348,8 +348,8 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
         if (
                 False and
                 options.get("exportRoots")          # only if roots are defined
-                and not "defaultPrim" in options    # ignore if already set
-                and not "rootPrim" in options       # ignore if root is created
+                and "defaultPrim" not in options    # ignore if already set
+                and "rootPrim" not in options       # ignore if root is created
                 and maya_usd_version == (0, 30, 0)  # only for Maya USD 0.30.0
         ):
             # Define the default prim name as it will end up in the USD file


### PR DESCRIPTION
## Changelog Description

Workaround default prim bug in Maya 2025.3 with Maya USD 0.30.0

See: https://github.com/Autodesk/maya-usd/issues/3991

## Additional review information

Without this fix the published USD file will not be loaded correctly when referenced. This is e.g. noticable when using the AYON USD contribution workflow and the model is 'missing' when loading the asset USD file. This is because the generated file itself lacks correct default prim metadata due to the Maya USD regression/bug.

## Testing notes:

1. Publish a Maya USD file from different versions of Maya (to confirm they all still work).
2. The generated USD asset files (with contribution workflow) should work.

Or simpler, but maybe more technical for some. Confirm the actual written `defaultPrim` value in the written USD file is not prefixed with a `|`.