### PR TITLE
Load: Containerize `project_name` on load to allow managing containers from different projects

### DIFF
--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -451,8 +451,8 @@ def containerise(name,
         ("namespace", namespace),
         ("loader", loader),
         ("representation", context["representation"]["id"]),
+        ("project_name", context["project"]["name"])
     ]
-
     for key, value in data:
         cmds.addAttr(container, longName=key, dataType="string")
         cmds.setAttr(container + "." + key, str(value), type="string")

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -947,7 +947,7 @@ class ReferenceLoader(Loader):
 
         # Update metadata
         for attr_name, value in {
-            "representation": repre_entity["_id"],
+            "representation": repre_entity["id"],
             "project_name": context["project"]["name"]
         }.items():
             lib.set_attribute(node=node, attribute=attr_name, value=value)

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -946,9 +946,11 @@ class ReferenceLoader(Loader):
             cmds.sets(invalid, remove=node)
 
         # Update metadata
-        cmds.setAttr("{}.representation".format(node),
-                     repre_entity["id"],
-                     type="string")
+        for attr_name, value in {
+            "representation": repre_entity["_id"],
+            "project_name": context["project"]["name"]
+        }.items():
+            lib.set_attribute(node=node, attribute=attr_name, value=value)
 
         # When an animation or pointcache gets connected to an Xgen container,
         # the compound attribute "xgenContainers" gets created. When animation

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -946,10 +946,10 @@ class ReferenceLoader(Loader):
             cmds.sets(invalid, remove=node)
 
         # Update metadata
-        for attr_name, value in {
-            "representation": repre_entity["id"],
-            "project_name": context["project"]["name"]
-        }.items():
+        for attr_name, value in [
+            ("representation", repre_entity["id"]),
+            ("project_name", context["project"]["name"]),
+        ]:
             lib.set_attribute(node=node, attribute=attr_name, value=value)
 
         # When an animation or pointcache gets connected to an Xgen container,


### PR DESCRIPTION
## Changelog Description

Maya imprint and update with `project_name` on `container` object.

## Additional review information

Should be tested together with PR https://github.com/ynput/ayon-core/pull/1005

**Note** that this would only set project name on update for `ReferenceLoader` plug-ins and not the other, so that would still be TODO. However, that'd only be relevant when opening a scene from another project OR when being able to 'switch asset' to another project.

## Testing notes:
1. Use with PR https://github.com/ynput/ayon-core/pull/1005
2. Load containers from library project into current project.
3. They should be manageable via the scene inventory.

OR alternatively:

1. Load containers from current project.
2. Save workfile.
3. Launch maya from another project - secretly open the file from the first project.
4. It should list and manage the containers just fine in the scene inventory because it now knows about its project.