### PR TITLE
Avoid being able to undo a part of containerisation

### DIFF
--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -419,6 +419,7 @@ def ls():
         yield parse_container(container)
 
 
+@lib.undo_chunk()
 def containerise(name,
                  namespace,
                  nodes,


### PR DESCRIPTION
## Changelog Description

Containerise will now happen inside an undo chunk, disallowing to undo a part of the command.

## Additional review information

Without this there is a bug if the user were to Load something and they would press UNDO a few times that they may have undo'ed a part of the containerisation. In particular, they may have undo'ed to JUST a state where the container is recognized but it lacks the representation attribute - meaning it will break anything that tries to get the `container["representation"]` value from the containers in the scene - e.g. loader, publishing from the scene (on collect input versions), etc.

This makes it so that if the user were to undo - it undoes the full creation of the container.

Technically we could ALSO add the same undo chunk decorator on all the maya loader plug-in methods to ensure they all operate in a single undo chunk.

## Testing notes:

1. Loading in Maya should work.
2. Undoing should not undo 'parts of the container' like e.g. the creation of attributes on it but the full creation of it in one go.

TIP: To see containers in the outliner enable "Ignore hidden in outliner":
![image](https://github.com/user-attachments/assets/3f8e83c5-fa66-4443-bde8-e9064f217876)


