### PR TITLE
Skip invalid containers with a warning

### DIFF
--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -347,10 +347,17 @@ def parse_container(container):
         container (str): A container node name.
 
     Returns:
-        dict: The container schema data for this container node.
+        dict[str, Any]: The container schema data for this container node.
 
     """
     data = lib.read(container)
+
+    required = ["id", "name", "namespace", "loader", "representation"]
+    missing = [key for key in required if key not in data]
+    if missing:
+        log.warning("Container '%s' is missing required keys: %s",
+                    container, missing)
+        return {}
 
     # Backwards compatibility pre-schemas for containers
     data["schema"] = data.get("schema", "openpype:container-1.0")
@@ -411,12 +418,14 @@ def ls():
     they are called 'containers'
 
     Yields:
-        dict: container
+        dict[str, Any]: container
 
     """
     container_names = _ls()
     for container in sorted(container_names):
-        yield parse_container(container)
+        container_data = parse_container(container)
+        if container_data:
+            yield container_data
 
 
 def containerise(name,

--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -368,7 +368,8 @@ def parse_container(container):
         container (str): A container node name.
 
     Returns:
-        dict[str, Any]: The container schema data for this container node.
+        Optional[dict[str, Any]]: The container schema data for this container
+         if it meets all the required metadata.
 
     """
     data = lib.read(container)
@@ -378,7 +379,7 @@ def parse_container(container):
     if missing:
         log.warning("Container '%s' is missing required keys: %s",
                     container, missing)
-        return {}
+        return
 
     # Backwards compatibility pre-schemas for containers
     data["schema"] = data.get("schema", "openpype:container-1.0")

--- a/client/ayon_maya/api/setdress.py
+++ b/client/ayon_maya/api/setdress.py
@@ -262,6 +262,9 @@ def get_contained_containers(container):
     for node in cmds.ls(members, type="objectSet"):
         try:
             member_container = parse_container(node)
+            if not member_container:
+                # Skip invalid container (missing partial metadata)
+                continue
             containers.append(member_container)
         except schema.ValidationError:
             pass

--- a/client/ayon_maya/api/setdress.py
+++ b/client/ayon_maya/api/setdress.py
@@ -11,7 +11,6 @@ import ayon_api
 from maya import cmds
 
 from ayon_core.pipeline import (
-    schema,
     discover_loader_plugins,
     loaders_from_representation,
     load_container,
@@ -260,14 +259,11 @@ def get_contained_containers(container):
     containers = []
     members = cmds.sets(container['objectName'], query=True)
     for node in cmds.ls(members, type="objectSet"):
-        try:
-            member_container = parse_container(node)
-            if not member_container:
-                # Skip invalid container (missing partial metadata)
-                continue
-            containers.append(member_container)
-        except schema.ValidationError:
-            pass
+        member_container = parse_container(node)
+        if not member_container:
+            # Skip invalid container (missing partial metadata)
+            continue
+        containers.append(member_container)
 
     return containers
 

--- a/client/ayon_maya/plugins/publish/extract_layout.py
+++ b/client/ayon_maya/plugins/publish/extract_layout.py
@@ -5,7 +5,7 @@ import uuid
 from typing import List
 
 from ayon_api import get_representation_by_id
-from ayon_maya.api import plugin
+from ayon_maya.api import plugin, pipeline
 from ayon_maya.api.lib import get_highest_in_hierarchy, get_container_members
 from maya import cmds
 from maya.api import OpenMaya as om
@@ -80,7 +80,14 @@ class ExtractLayout(plugin.MayaExtractorPlugin):
                     grp_name = asset.split(':')[0]
             else:
                 grp_name = asset.split(':')[0]
+
             containers = cmds.ls("{}*_CON".format(grp_name))
+            containers = [
+                container for container in containers
+                # Make sure to include only valid containers
+                if pipeline.parse_container(container)
+            ]
+
             if len(containers) == 0:
                 self.log.warning("{} isn't from the loader".format(asset))
                 self.log.warning("It may not be properly loaded after published") # noqa


### PR DESCRIPTION
## Changelog Description

Skip invalid containers with a warning - instead of breaking publishi…ng, loader, inventory, etc.

## Additional review information

This avoids similar issues as #178 does - but is a 'fix' that would avoid the issue being problematic in existing scenes (instead of just on containerise) or if the container breaks in any other way.

The most likely case for these containers to become invalid was the issue #178 solves by 'bundling' undo so that users can't undo "half of the container creation" deleting only a few of its attributes. However, users can still break things in magical ways, time has shown us.

It would now log e.g. this if the container is incomplete and incomplete containers are not listed in the scene inventory either, because well they are incomplete:

```
// Warning: ayon_maya : Container 'char_hero_pointcacheMain_01__pointcacheMain_CON' is missing required keys: ['loader', 'representation']
```

## Testing notes:

1. Load a few products
2. In outliner, enable: Display > Ignore "Hidden in outliner"
3. Select the containers
4. Randomly delete attributes on these instances, like `loader`, `representation`, etc.

A warning should be logged if any of the required keys ends up missing. The required keys are considered to be `["id", "name", "namespace", "loader", "representation"]`
