### PR TITLE
Fix thumbnail extension to png

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_maya/plugins/publish/extract_thumbnail.py
@@ -74,7 +74,7 @@ class ExtractThumbnail(plugin.MayaExtractorPlugin):
 
         representation = {
             "name": "thumbnail",
-            "ext": "png",
+            "ext": os.path.splitext(thumbnail)[-1].lstrip(".").lower(),
             "files": thumbnail,
             "stagingDir": dst_staging,
             "thumbnail": True

--- a/client/ayon_maya/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_maya/plugins/publish/extract_thumbnail.py
@@ -74,7 +74,7 @@ class ExtractThumbnail(plugin.MayaExtractorPlugin):
 
         representation = {
             "name": "thumbnail",
-            "ext": "jpg",
+            "ext": "png",
             "files": thumbnail,
             "stagingDir": dst_staging,
             "thumbnail": True


### PR DESCRIPTION
## Changelog Description
Change representation extension to `png` because the thumbnail is actually a png

## Additional review information

This fixes thumbnail uploading for AYON server 1.5.5

Related PRs on server:

- This overlaps with PR https://github.com/ynput/ayon-backend/pull/433 which changes the server to report a warning instead of raising an error 
- which originally turned into an error with: https://github.com/ynput/ayon-backend/pull/432

Related PRs on ayon-python-api:

- https://github.com/ynput/ayon-python-api/pull/204

## Testing notes:

1. Publishing review with AYON server 1.5.5+ should work
