### PR TITLE
AY-7271 Skip `worldspace` flag if not supported by Maya USD version

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -330,7 +330,8 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
         )
         for key, required_minimal_version in {
             "exportComponentTags": (0, 14, 0),
-            "jobContext": (0, 15, 0)
+            "jobContext": (0, 15, 0),
+            "worldspace": (0, 21, 0)
         }.items():
             if key in options and maya_usd_version < required_minimal_version:
                 self.log.warning(


### PR DESCRIPTION
## Changelog Description

Support Maya USD older than 0.21.0

## Additional review information

Avoids `invalid flag 'worldspace'` error.

The worldspace flag was added to Maya USD here: https://github.com/Autodesk/maya-usd/pull/1931 in november 2022
Which would mean it's available in Maya USD 0.21.0 and higher.

## Testing notes:

1. Create Maya USD Publish with Maya USD 0.13.0 should pass fine.