### PR TITLE
Implement Maya USD Export Chaser to Filter Properties

### DIFF
--- a/client/ayon_maya/api/chasers/README.md
+++ b/client/ayon_maya/api/chasers/README.md
@@ -1,0 +1,14 @@
+# AYON Maya USD Chasers
+
+This folder contains AYON Maya USD python import and export chasers to be
+registered on Maya startup. These chasers have the ability to influence how
+USD data is imported and exported in Maya.
+
+For example, the Filter Properties export chaser allows to filter properties
+in the exported USD file to only those that match by the specified pattern
+using a SideFX Houdini style pattern matching.
+
+The chasers are registered in the `MayaHost.install` method on Maya launch.
+
+See also the [Maya USD Import Chaser documentation](https://github.com/Autodesk/maya-usd/blob/dev/lib/mayaUsd/commands/Readme.md#import-chasers) 
+and [Maya USD Export Chaser documentation](https://github.com/Autodesk/maya-usd/blob/dev/lib/mayaUsd/commands/Readme.md#export-chasers-advanced).

--- a/client/ayon_maya/api/chasers/export_filter_properties.py
+++ b/client/ayon_maya/api/chasers/export_filter_properties.py
@@ -1,0 +1,138 @@
+import re
+import fnmatch
+import logging
+from typing import List
+
+import mayaUsd.lib as mayaUsdLib
+from pxr import Sdf
+
+
+def log_errors(fn):
+    """Decorator to log errors on error"""
+
+    def wrap(*args, **kwargs):
+
+        try:
+            return fn(*args, **kwargs)
+        except Exception as exc:
+            logging.error(exc, exc_info=True)
+            raise
+
+    return wrap
+
+
+def remove_spec(spec: Sdf.Spec):
+    """Remove Sdf.Spec authored opinion."""
+    if spec.expired:
+        return
+
+    if isinstance(spec, Sdf.PrimSpec):
+        # PrimSpec
+        parent = spec.nameParent
+        if parent:
+            view = parent.nameChildren
+        else:
+            # Assume PrimSpec is root prim
+            view = spec.layer.rootPrims
+        del view[spec.name]
+
+    elif isinstance(spec, Sdf.PropertySpec):
+        # Relationship and Attribute specs
+        del spec.owner.properties[spec.name]
+
+    elif isinstance(spec, Sdf.VariantSetSpec):
+        # Owner is Sdf.PrimSpec (or can also be Sdf.VariantSpec)
+        del spec.owner.variantSets[spec.name]
+
+    elif isinstance(spec, Sdf.VariantSpec):
+        # Owner is Sdf.VariantSetSpec
+        spec.owner.RemoveVariant(spec)
+
+    else:
+        raise TypeError(f"Unsupported spec type: {spec}")
+
+
+def remove_layer_specs(layer: Sdf.Layer, spec_paths: List[Sdf.Path]):
+    # Iterate in reverse so we iterate the highest paths
+    # first, so when removing a spec the children specs
+    # are already removed
+    for spec_path in reversed(spec_paths):
+        spec = layer.GetObjectAtPath(spec_path)
+        if not spec or spec.expired:
+            continue
+        remove_spec(spec)
+
+
+def match_pattern(name: str, text_pattern: str) -> bool:
+    """SideFX Houdini like pattern matching"""
+    patterns = text_pattern.split(" ")
+    is_match = False
+    for pattern in patterns:
+        # * means any character
+        # ? means any single character
+        # [abc] means a, b, or c
+        pattern = pattern.strip(" ")
+        if not pattern:
+            continue
+
+        excludes = pattern[0] == "^"
+
+        # If name is already matched against earlier pattern in the text
+        # pattern, then we can skip the pattern if it is not an exclude pattern
+        if is_match and not excludes:
+            continue
+
+        if excludes:
+            pattern = pattern[1:]
+
+        regex = fnmatch.translate(pattern)
+        match = re.match(regex, name)
+        if match:
+            is_match = not excludes
+    return is_match
+
+
+
+class FilterPropertiesExportChaser(mayaUsdLib.ExportChaser):
+    """Remove property specs based on pattern"""
+
+    name = "AYON_filterProperties"
+
+    def __init__(self, factoryContext, *args, **kwargs):
+        super().__init__(factoryContext, *args, **kwargs)
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.stage = factoryContext.GetStage()
+        self.job_args = factoryContext.GetJobArgs()
+
+    @log_errors
+    def PostExport(self):
+
+        chaser_args = self.job_args.allChaserArgs[self.name]
+        # strip all or use user-specified pattern
+        pattern = chaser_args.get("pattern", "*")
+        for layer in self.stage.GetLayerStack():
+
+            specs_to_remove = []
+
+            def find_attribute_specs_to_remove(path: Sdf.Path):
+                if not path.IsPropertyPath():
+                    return
+
+                spec = layer.GetObjectAtPath(path)
+                if not spec:
+                    return
+
+                if not isinstance(spec, Sdf.PropertySpec):
+                    return
+
+                if not match_pattern(spec.name, pattern):
+                    self.log.debug(f"Removing spec: %s", path)
+                    specs_to_remove.append(path)
+                else:
+                    self.log.debug(f"Keeping spec: %s", path)
+
+            layer.Traverse("/", find_attribute_specs_to_remove)
+
+            remove_layer_specs(layer, specs_to_remove)
+
+        return True

--- a/client/ayon_maya/api/chasers/export_filter_properties.py
+++ b/client/ayon_maya/api/chasers/export_filter_properties.py
@@ -126,10 +126,10 @@ class FilterPropertiesExportChaser(mayaUsdLib.ExportChaser):
                     return
 
                 if not match_pattern(spec.name, pattern):
-                    self.log.debug(f"Removing spec: %s", path)
+                    self.log.debug("Removing spec: %s", path)
                     specs_to_remove.append(path)
                 else:
-                    self.log.debug(f"Keeping spec: %s", path)
+                    self.log.debug("Keeping spec: %s", path)
 
             layer.Traverse("/", find_attribute_specs_to_remove)
 

--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -129,6 +129,8 @@ class MayaHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         )
         register_event_callback("workfile.save.after", after_workfile_save)
 
+        self._register_maya_usd_chasers()
+
     def open_workfile(self, filepath):
         return open_file(filepath)
 
@@ -238,6 +240,25 @@ class MayaHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         self.log.info("Installed event handler _on_scene_open..")
         self.log.info("Installed event handler _check_lock_file..")
         self.log.info("Installed event handler _before_close_maya..")
+
+    def _register_maya_usd_chasers(self):
+        """Register Maya USD chasers if Maya USD libraries are available."""
+
+        try:
+            import mayaUsd.lib  # noqa
+        except ImportError:
+            # Do not register if Maya USD is not available
+            return
+
+        self.log.info("Installing AYON Maya USD chasers..")
+
+        from .chasers import export_filter_properties  # noqa
+
+        for export_chaser in [
+            export_filter_properties.FilterPropertiesExportChaser
+        ]:
+            mayaUsd.lib.ExportChaser.Register(export_chaser,
+                                              export_chaser.name)
 
 
 def _set_project():

--- a/client/ayon_maya/plugins/publish/collect_maya_usd_export_filter_properties.py
+++ b/client/ayon_maya/plugins/publish/collect_maya_usd_export_filter_properties.py
@@ -5,12 +5,14 @@ from ayon_core.pipeline.publish import AYONPyblishPluginMixin
 from ayon_maya.api import plugin
 
 
-class CollectMayaUsdFilterProperties(plugin.InstancePlugin,
+class CollectMayaUsdFilterProperties(plugin.MayaInstancePlugin,
                                      AYONPyblishPluginMixin):
 
     order = pyblish.api.CollectorOrder
     label = "Maya USD Export Chaser: Filter Properties"
     families = ["mayaUsd"]
+
+    default_filter = ""
 
     @classmethod
     def get_attribute_defs(cls):
@@ -21,7 +23,8 @@ class CollectMayaUsdFilterProperties(plugin.InstancePlugin,
                 tooltip=(
                     "Filter USD properties to export."
                 ),
-                placeholder="* ^xformOp* ^points"
+                placeholder="* ^xformOp* ^points",
+                default=cls.default_filter
             )
         ]
 

--- a/client/ayon_maya/plugins/publish/collect_maya_usd_export_filter_properties.py
+++ b/client/ayon_maya/plugins/publish/collect_maya_usd_export_filter_properties.py
@@ -21,7 +21,13 @@ class CollectMayaUsdFilterProperties(plugin.MayaInstancePlugin,
                 "filter_properties",
                 label="USD Filter Properties",
                 tooltip=(
-                    "Filter USD properties to export."
+                    "Filter USD properties using a pattern:\n"
+                    "- Only include xforms: xformOp*\n"
+                    "- All but xforms: * ^xformOp*\n"
+                    "- All but mesh point data: * ^extent ^points "
+                    "^faceVertex* ^primvars*\n\n"
+                    "The pattern matching is very similar to SideFX Houdini's "
+                    "Pattern Matching in Parameters."
                 ),
                 placeholder="* ^xformOp* ^points",
                 default=cls.default_filter

--- a/client/ayon_maya/plugins/publish/collect_maya_usd_export_filter_properties.py
+++ b/client/ayon_maya/plugins/publish/collect_maya_usd_export_filter_properties.py
@@ -1,0 +1,41 @@
+import pyblish.api
+
+from ayon_core.lib import TextDef
+from ayon_core.pipeline.publish import AYONPyblishPluginMixin
+from ayon_maya.api import plugin
+
+
+class CollectMayaUsdFilterProperties(plugin.InstancePlugin,
+                                     AYONPyblishPluginMixin):
+
+    order = pyblish.api.CollectorOrder
+    label = "Maya USD Export Chaser: Filter Properties"
+    families = ["mayaUsd"]
+
+    @classmethod
+    def get_attribute_defs(cls):
+        return [
+            TextDef(
+                "filter_properties",
+                label="USD Filter Properties",
+                tooltip=(
+                    "Filter USD properties to export."
+                ),
+                placeholder="* ^xformOp* ^points"
+            )
+        ]
+
+    def process(self, instance):
+        attr_values = self.get_attr_values_from_data(instance.data)
+        filter_pattern = attr_values.get("filter_properties")
+        if not filter_pattern:
+            return
+
+        self.log.debug(
+            "Enabling USD filter properties chaser "
+            f"with pattern {filter_pattern}"
+        )
+        instance.data.setdefault("chaser", []).append("AYON_filterProperties")
+        instance.data.setdefault("chaserArgs", []).append(
+            ("AYON_filterProperties", "pattern", filter_pattern)
+        )

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -238,6 +238,11 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
 
             options[key] = value
 
+        # Do not pass None values
+        for key, value in options.copy().items():
+            if value is None:
+                del options[key]
+
         return options
 
     def filter_members(self, members):

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -165,6 +165,8 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
 
         # TODO: Support more `mayaUSDExport` parameters
         return {
+            "chaser": (list, None),  # optional list
+            "chaserArgs": (list, None),  # optional list
             "defaultUSDFormat": str,
             "stripNamespaces": bool,
             "mergeTransformAndShape": bool,
@@ -191,6 +193,8 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
 
         # TODO: Support more `mayaUSDExport` parameters
         return {
+            "chaser": None,
+            "chaserArgs": None,
             "defaultUSDFormat": "usdc",
             "stripNamespaces": False,
             "mergeTransformAndShape": True,

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -265,7 +265,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
         file_path = file_path.replace('\\', '/')
 
         # Parse export options
-        options = self.default_options.copy()
+        options = self.default_options
         options = self.parse_overrides(instance, options)
 
         # Perform extraction

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -265,7 +265,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
         file_path = file_path.replace('\\', '/')
 
         # Parse export options
-        options = self.default_options
+        options = self.default_options.copy()
         options = self.parse_overrides(instance, options)
 
         # Perform extraction

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -309,7 +309,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
         options["filterTypes"] = ["constraint"]
 
         def parse_attr_str(attr_str):
-            """Return list of strings from `a,b,c,,d` to `[a, b, c, d]`.
+            """Return list of strings from `a,b,c,d` to `[a, b, c, d]`.
 
             Args:
                 attr_str (str): Concatenated attributes by comma

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -1108,7 +1108,7 @@ DEFAULT_PUBLISH_SETTINGS = {
         "enabled": False
     },
     "CollectMayaUsdFilterProperties": {
-        "enabled": True,
+        "enabled": False,
         "default_filter": ""
     },
     "ValidateInstanceInContext": {

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -157,6 +157,24 @@ class CollectGLTFModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="CollectGLTF")
 
 
+class CollectMayaUsdFilterPropertiesModel(BaseSettingsModel):
+    enabled: bool = SettingsField(title="Maya USD Export Chaser: Filter Properties")
+    default_filter: str = SettingsField(
+        title="Default Filter",
+        description=(
+            "Set the default filter for USD properties to export. It uses"
+            " [SideFX Houdini Pattern Matching in Parameters]"
+            "(https://www.sidefx.com/docs/houdini/network/patterns.html)."
+            "\nSome examples would include:\n"
+            "- Only include xforms: `xformOp*`\n"
+            "- Everything but xforms: `* ^xformOp*`\n"
+            "- Everything but mesh point data: `* ^extent ^points"
+            " ^faceVertexCounts ^faceVertexIndices ^primvars*`"
+        ),
+        default=""
+    )
+
+
 class ValidateFrameRangeModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="ValidateFrameRange")
     optional: bool = SettingsField(title="Optional")
@@ -620,6 +638,12 @@ class PublishersModel(BaseSettingsModel):
         default_factory=CollectGLTFModel,
         title="Collect Assets for GLB/GLTF export"
     )
+    CollectMayaUsdFilterProperties: CollectMayaUsdFilterPropertiesModel = (
+        SettingsField(
+            default_factory=CollectMayaUsdFilterPropertiesModel,
+            title="Maya USD Export Chaser: Filter Properties"
+        )
+    )
     ValidateInstanceInContext: BasicValidateModel = SettingsField(
         default_factory=BasicValidateModel,
         title="Validate Instance In Context",
@@ -1082,6 +1106,10 @@ DEFAULT_PUBLISH_SETTINGS = {
     },
     "CollectGLTF": {
         "enabled": False
+    },
+    "CollectMayaUsdFilterProperties": {
+        "enabled": True,
+        "default_filter": ""
     },
     "ValidateInstanceInContext": {
         "enabled": True,


### PR DESCRIPTION
## Changelog Description

Implement Maya USD Export Chaser to Filter Properties using a SideFX Houdini style pattern matching for all prim properties

## Additional review information

For explanation on how the pattern works, see [SideFX Houdini Pattern Matching in Parameters](https://www.sidefx.com/docs/houdini/network/patterns.html) which it is loosely based on.

![image](https://github.com/user-attachments/assets/88e00a5f-f1ea-4be7-a6d2-ba5438f259b8)

Results in:

![image](https://github.com/user-attachments/assets/c99ee4c6-0b82-48c3-9f81-4b8562657ef4)

```usda
#usda 1.0
(
    defaultPrim = "char_hero"
    metersPerUnit = 0.01
    upAxis = "Y"
)

def Xform "char_hero" (
    kind = "component"
)
{
    double3 xformOp:translate = (-0.4334395286605499, 0.8835878002001145, -0.6190157988997917)
    uniform token[] xformOpOrder = ["xformOp:translate"]

    def Mesh "pCube1"
    {
    }
}
```

Note how the mesh contains no properties at all - they are completely stripped from the written USD file.


### TODO

- [x] Improve attribute definition tooltip to describe the available pattern and maybe some examples.
- [x] Add to settings to enable/disable the plug-in and potentially set up a default value.

Added `ayon+settings://maya/publish/CollectMayaUsdFilterProperties`

![image](https://github.com/user-attachments/assets/ecf36fdb-8e27-4f65-b639-b4a6857d157f)

## Testing notes:

1. A new attribute "USD Filter Properties" should appear on Maya USD instances
2. When any pattern is entered, then only those properties would be exported into the output file. For example:

- Only include xforms: `xformOp*`
- Everything but xforms: `* ^xformOp*`
- Everything but mesh point data: `* ^extent ^points ^faceVertexCounts ^faceVertexIndices ^primvars*`