### PR TITLE
Remove `maya_` prefix from dirmap settings

### DIFF
--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -1039,9 +1039,7 @@ class ReferenceLoader(Loader):
             (str)
         """
         settings = get_project_settings(project_name)
-        use_env_var_as_root = (settings["maya"]
-                                       ["maya_dirmap"]
-                                       ["use_env_var_as_root"])
+        use_env_var_as_root = settings["maya"]["dirmap"]["use_env_var_as_root"]
         if use_env_var_as_root:
             anatomy = Anatomy(project_name)
             file_url = anatomy.replace_root_with_env_key(file_url, '${{{}}}')

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,7 +1,10 @@
 """Maya Addon Module"""
+from typing import Any
+
 from ayon_server.addons import BaseServerAddon
 
 from .settings.main import MayaSettings, DEFAULT_MAYA_SETTING
+from .settings.conversion import convert_settings_overrides
 
 
 class MayaAddon(BaseServerAddon):
@@ -10,3 +13,15 @@ class MayaAddon(BaseServerAddon):
     async def get_default_settings(self):
         settings_model_cls = self.get_settings_model()
         return settings_model_cls(**DEFAULT_MAYA_SETTING)
+
+    async def convert_settings_overrides(
+        self,
+        source_version: str,
+        overrides: dict[str, Any],
+    ) -> dict[str, Any]:
+        convert_settings_overrides(source_version, overrides)
+        # Use super conversion
+        return await super().convert_settings_overrides(
+            source_version, overrides
+        )
+

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+
+def _convert_dirmap_0_4_3(overrides):
+    """maya_dirmap key was renamed to dirmap in 0.4.3"""
+    if "maya_dirmap" not in overrides:
+        # Legacy settings not found
+        return
+
+    if "dirmap" in overrides:
+        # Already new settings
+        return
+
+    overrides["dirmap"] = overrides.pop("maya_dirmap")
+
+
+def convert_settings_overrides(
+    source_version: str,
+    overrides: dict[str, Any],
+) -> dict[str, Any]:
+    _convert_dirmap_0_4_3(overrides)
+    return overrides

--- a/server/settings/dirmap.py
+++ b/server/settings/dirmap.py
@@ -1,7 +1,7 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
 
-class MayaDirmapPathsSubmodel(BaseSettingsModel):
+class DirmapPathsSubmodel(BaseSettingsModel):
     _layout = "compact"
     source_path: list[str] = SettingsField(
         default_factory=list, title="Source Paths"
@@ -11,7 +11,7 @@ class MayaDirmapPathsSubmodel(BaseSettingsModel):
     )
 
 
-class MayaDirmapModel(BaseSettingsModel):
+class DirmapModel(BaseSettingsModel):
     """Maya dirmap settings."""
     # _layout = "expanded"
     _isGroup: bool = True
@@ -22,13 +22,13 @@ class MayaDirmapModel(BaseSettingsModel):
     use_env_var_as_root: bool = SettingsField(
         title="Use env var placeholder in referenced paths"
     )
-    paths: MayaDirmapPathsSubmodel = SettingsField(
-        default_factory=MayaDirmapPathsSubmodel,
+    paths: DirmapPathsSubmodel = SettingsField(
+        default_factory=DirmapPathsSubmodel,
         title="Dirmap Paths"
     )
 
 
-DEFAULT_MAYA_DIRMAP_SETTINGS = {
+DEFAULT_DIRMAP_SETTINGS = {
     "use_env_var_as_root": False,
     "enabled": False,
     "paths": {

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -5,7 +5,7 @@ from ayon_server.settings import (
     ensure_unique_names,
 )
 from .imageio import ImageIOSettings, DEFAULT_IMAGEIO_SETTINGS
-from .maya_dirmap import MayaDirmapModel, DEFAULT_MAYA_DIRMAP_SETTINGS
+from .dirmap import DirmapModel, DEFAULT_DIRMAP_SETTINGS
 from .include_handles import IncludeHandlesModel, DEFAULT_INCLUDE_HANDLES
 from .explicit_plugins_loading import (
     ExplicitPluginsLoadingModel, DEFAULT_EXPLITCIT_PLUGINS_LOADING_SETTINGS
@@ -51,8 +51,8 @@ class MayaSettings(BaseSettingsModel):
     )
     ext_mapping: list[ExtMappingItemModel] = SettingsField(
         default_factory=list, title="Extension Mapping")
-    maya_dirmap: MayaDirmapModel = SettingsField(
-        default_factory=MayaDirmapModel, title="Maya dirmap Settings")
+    dirmap: DirmapModel = SettingsField(
+        default_factory=DirmapModel, title="Maya dirmap Settings")
     include_handles: IncludeHandlesModel = SettingsField(
         default_factory=IncludeHandlesModel,
         title="Include/Exclude Handles in default playback & render range"
@@ -110,8 +110,8 @@ DEFAULT_MAYA_SETTING = {
         {"name": "workfile", "value": "ma"},
         {"name": "yetiRig", "value": "ma"}
     ],
-    # `maya_dirmap` was originally with dash - `maya-dirmap`
-    "maya_dirmap": DEFAULT_MAYA_DIRMAP_SETTINGS,
+    # `dirmap` was originally with dash - `maya-dirmap`
+    "dirmap": DEFAULT_DIRMAP_SETTINGS,
     "include_handles": DEFAULT_INCLUDE_HANDLES,
     "scriptsmenu": DEFAULT_SCRIPTSMENU_SETTINGS,
     "render_settings": DEFAULT_RENDER_SETTINGS,


### PR DESCRIPTION
## Changelog Description

Remove `maya_` prefix from dirmap settings.

## Additional review information

Should be tested together with https://github.com/ynput/ayon-core/pull/1061

Fix https://github.com/ynput/ayon-maya/issues/102

**Note:** Settings are not maintained with backwards compatibility! However, dirmapping didn't work anyway - so is that crucial? :)

## Testing notes:

1. Maya Dirmap should work
