### PR TITLE
Store the render file directory as `stagingDir`

### DIFF
--- a/client/ayon_maya/plugins/publish/collect_render.py
+++ b/client/ayon_maya/plugins/publish/collect_render.py
@@ -257,6 +257,7 @@ class CollectMayaRender(plugin.MayaInstancePlugin):
             "source": filepath,
             "expectedFiles": full_exp_files,
             "publishRenderMetadataFolder": common_publish_meta_path,
+            "stagingDir": common_publish_meta_path,
             "renderProducts": layer_render_products,
             "resolutionWidth": lib.get_attr_in_layer(
                 "defaultResolution.width", layer=layer_name

--- a/client/ayon_maya/plugins/publish/collect_render.py
+++ b/client/ayon_maya/plugins/publish/collect_render.py
@@ -257,7 +257,6 @@ class CollectMayaRender(plugin.MayaInstancePlugin):
             "source": filepath,
             "expectedFiles": full_exp_files,
             "publishRenderMetadataFolder": common_publish_meta_path,
-            "stagingDir": common_publish_meta_path,
             "renderProducts": layer_render_products,
             "resolutionWidth": lib.get_attr_in_layer(
                 "defaultResolution.width", layer=layer_name

--- a/client/ayon_maya/plugins/publish/validate_render_image_rule.py
+++ b/client/ayon_maya/plugins/publish/validate_render_image_rule.py
@@ -57,7 +57,7 @@ class ValidateRenderImageRule(plugin.MayaInstancePlugin,
     def get_default_render_image_folder(cls, instance):
         # Allow custom staging dir to override the expected output directory
         # of the renders
-        if instance.data.get("stagingDir_custom", True):
+        if instance.data.get("stagingDir_custom", False):
             staging_dir = instance.data.get("stagingDir")
             if staging_dir:
                 cls.log.debug(

--- a/client/ayon_maya/plugins/publish/validate_render_image_rule.py
+++ b/client/ayon_maya/plugins/publish/validate_render_image_rule.py
@@ -55,14 +55,17 @@ class ValidateRenderImageRule(plugin.MayaInstancePlugin,
 
     @classmethod
     def get_default_render_image_folder(cls, instance):
-        staging_dir = instance.data.get("stagingDir")
-        if staging_dir:
-            cls.log.debug(
-                "Staging dir found: \"{}\". Ignoring setting from "
-                "`project_settings/maya/render_settings/"
-                "default_render_image_folder`.".format(staging_dir)
-            )
-            return staging_dir
+        # Allow custom staging dir to override the expected output directory
+        # of the renders
+        if instance.data.get("stagingDir_custom", True):
+            staging_dir = instance.data.get("stagingDir")
+            if staging_dir:
+                cls.log.debug(
+                    "Staging dir found: \"{}\". Ignoring setting from "
+                    "`project_settings/maya/render_settings/"
+                    "default_render_image_folder`.".format(staging_dir)
+                )
+                return staging_dir
 
         return (
             instance.context.data


### PR DESCRIPTION
## Changelog Description
Store the render file directory as `stagingDir`

## Additional review information

Fix #194

## Testing notes:

1. Test with PR https://github.com/ynput/ayon-core/pull/1066
2. With `ValidateRenderImageRule` plug-in enabled publishing renders should work fine.
3. Submitting renders should work as intended with both custom staging dir set and when disabled.