### PR TITLE
Expose Maya USD creator that creates a static `model` product type

### DIFF
--- a/client/ayon_maya/plugins/create/create_maya_usd.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd.py
@@ -264,3 +264,5 @@ class CreateMayaUsdModel(CreateMayaUsd):
         for attr_def in attr_defs:
             if attr_def.key == "createAssetTemplateHierarchy":
                 attr_def.default = True
+
+        return attr_defs

--- a/client/ayon_maya/plugins/create/create_maya_usd.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd.py
@@ -252,7 +252,7 @@ class CreateMayaUsdModel(CreateMayaUsd):
     identifier = "io.ayon.creators.maya.mayausd.model"
     label = "Maya USD: Model"
     product_type = "model"
-    icon = "cubes"
+    icon = "cube"
     description = "Create Model with Maya USD Export"
 
     allow_animation = False

--- a/client/ayon_maya/plugins/create/create_maya_usd.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd.py
@@ -18,6 +18,8 @@ class CreateMayaUsd(plugin.MayaCreator):
     description = "Create Maya USD Export"
     cache = {}
 
+    allow_animation = True
+
     def register_callbacks(self):
         self.create_context.add_value_changed_callback(self.on_values_changed)
 
@@ -70,16 +72,18 @@ class CreateMayaUsd(plugin.MayaCreator):
 
             self.cache["jobContextItems"] = job_context_items
 
-        defs = [
-            BoolDef("exportAnimationData",
-                    label="Export Animation Data",
-                    tooltip="When disabled no frame range is exported and "
-                            "only the start frame is used to define the "
-                            "static export frame.",
-                    default=True)
-        ]
-        defs.extend(lib.collect_animation_defs(
-            create_context=self.create_context))
+        defs = []
+        if self.allow_animation:
+            defs.append(
+                BoolDef("exportAnimationData",
+                        label="Export Animation Data",
+                        tooltip="When disabled no frame range is exported and "
+                                "only the start frame is used to define the "
+                                "static export frame.",
+                        default=True)
+            )
+            defs.extend(lib.collect_animation_defs(
+                create_context=self.create_context))
         defs.extend([
             EnumDef("defaultUSDFormat",
                     label="File format",
@@ -242,3 +246,21 @@ class CreateMayaUsd(plugin.MayaCreator):
             cmds.select(root, replace=True, noExpand=True)
 
         super().create(product_name, instance_data, pre_create_data)
+
+
+class CreateMayaUsdModel(CreateMayaUsd):
+    identifier = "io.ayon.creators.maya.mayausd.model"
+    label = "Maya USD: Model"
+    product_type = "model"
+    icon = "cubes"
+    description = "Create Model with Maya USD Export"
+
+    allow_animation = False
+
+    def get_pre_create_attr_defs(self):
+        attr_defs = super().get_pre_create_attr_defs()
+
+        # Enable by default
+        for attr_def in attr_defs:
+            if attr_def.key == "createAssetTemplateHierarchy":
+                attr_def.default = True

--- a/client/ayon_maya/plugins/publish/collect_model.py
+++ b/client/ayon_maya/plugins/publish/collect_model.py
@@ -27,3 +27,9 @@ class CollectModelData(plugin.MayaInstancePlugin):
         frame = cmds.currentTime(query=True)
         instance.data["frameStart"] = frame
         instance.data["frameEnd"] = frame
+
+        # Explicitly set no handles at all
+        instance.data["handleStart"] = 0
+        instance.data["handleEnd"] = 0
+        instance.data["frameStartHandle"] = frame
+        instance.data["frameEndHandle"] = frame


### PR DESCRIPTION
## Changelog Description

Exposes a dedicated creator that exports a Maya USD export as a "model" product type.

## Additional review information

### TL;DR

We have a long history of a `model` product type creator in Maya, focused on exporting static geometry to Maya Scene and Alembic. Now we also want to include USD exports, _but_ also allow the Maya USD contribution workflow to trigger, etc.

This is one potential approach to do so.

### Detailed

This now allows to publish USD products with USD contributions as a "model" product type, e.g. a `modelMain` as part of the `usdAsset`'s model layer **and** also have it trigger the `model` product type validations.

It's good to know however that a few validators will need to be disabled in settings for this product type to make sense (otherwise it wouldn't pass the model validations).

In particular **disable**:
```
ayon+settings://maya/publish/ValidateNoNamespace
ayon+settings://maya/publish/ValidateTransformNamingSuffix
```

This is because the top group should be the asset name without suffix (so it should not be e.g. `_GRP`  suffix) and the creators' "asset template hierarchy" it creates starts with a namespace to allow publishing multiple model asset contributions separately from the one scene (without having a group name conflict between the two groups in the scene).

Also, if ONLY the USD should be exported from this product type instead of also the Maya Scene and Alembic, then disable the extractors:
```
ayon+settings://maya/publish/ExtractModel
ayon+settings://maya/publish/ExtractAlembic/families <- remove the model family
```

There happened to also be a way to export a USD previously from the `model` family which should also be disabled:
```
ayon+settings://maya/publish/ExtractMayaUsdModel
```

That behavior where the existing `model` creator would export USD however had the issue that:
- The USD Contribution workflow wouldn't trigger, because it triggers on `usd` family - not on `model` product type.
- The creator doesn't expose the "Create Asset Template Hierarchy" pre-create feature to simplify creating the correct USD asset structure in the scene outliner (correct grouping)
- The creator doesn't expose all relevant MayaUSD export settings toggles - however, one could argue that maybe those shouldn't have been Creator attributes to begin with.

## Testing notes:

1. Publish the special Maya USD Model product type with asset contribution workflow, etc.