### PR TITLE
Clean-up and fix Alembic creator attributes

### DIFF
--- a/client/ayon_maya/plugins/create/create_animation_pointcache.py
+++ b/client/ayon_maya/plugins/create/create_animation_pointcache.py
@@ -8,7 +8,10 @@ from ayon_core.lib import (
 )
 
 
-def _get_animation_attr_defs(create_context):
+def _get_animation_attr_defs(
+        create_context,
+        include_user_defined_attributes,
+        include_parent_hierarchy=False):
     """Get Animation generic definitions."""
     defs = lib.collect_animation_defs(create_context=create_context)
     defs.extend(
@@ -22,7 +25,8 @@ def _get_animation_attr_defs(create_context):
                 tooltip=(
                     "Whether to include parent hierarchy of nodes in the "
                     "publish instance."
-                )
+                ),
+                default=include_parent_hierarchy
             ),
             BoolDef(
                 "includeUserDefinedAttributes",
@@ -30,7 +34,8 @@ def _get_animation_attr_defs(create_context):
                 tooltip=(
                     "Whether to include all custom maya attributes found "
                     "on nodes as attributes in the Alembic data."
-                )
+                ),
+                default=include_user_defined_attributes
             ),
         ]
     )
@@ -97,7 +102,9 @@ class CreateAnimation(plugin.MayaHiddenCreator):
         return node_data
 
     def get_instance_attr_defs(self):
-        return _get_animation_attr_defs(self.create_context)
+        return _get_animation_attr_defs(self.create_context,
+                                        self.include_user_defined_attributes,
+                                        self.include_parent_hierarchy)
 
 
 class CreatePointCache(plugin.MayaCreator):
@@ -117,7 +124,8 @@ class CreatePointCache(plugin.MayaCreator):
         return node_data
 
     def get_instance_attr_defs(self):
-        return _get_animation_attr_defs(self.create_context)
+        return _get_animation_attr_defs(self.create_context,
+                                        self.include_user_defined_attributes)
 
     def create(self, product_name, instance_data, pre_create_data):
         instance = super(CreatePointCache, self).create(

--- a/client/ayon_maya/plugins/create/create_animation_pointcache.py
+++ b/client/ayon_maya/plugins/create/create_animation_pointcache.py
@@ -86,8 +86,6 @@ class CreateAnimation(plugin.MayaHiddenCreator):
     product_type = "animation"
     icon = "male"
 
-    write_color_sets = False
-    write_face_sets = False
     include_parent_hierarchy = False
     include_user_defined_attributes = False
 
@@ -109,8 +107,6 @@ class CreatePointCache(plugin.MayaCreator):
     label = "Pointcache"
     product_type = "pointcache"
     icon = "gears"
-    write_color_sets = False
-    write_face_sets = False
     include_user_defined_attributes = False
 
     def read_instance_node(self, node):

--- a/client/ayon_maya/plugins/create/create_model.py
+++ b/client/ayon_maya/plugins/create/create_model.py
@@ -40,4 +40,20 @@ class CreateModel(plugin.MayaCreator):
                     label="Include Shaders",
                     tooltip="Include shaders in the geometry export.",
                     default=self.include_shaders),
+            # TODO: Remove these `attr` and `attrPrefix` attributes to avoid
+            #  confusion. This currently does NOT influence the model product
+            #  `mayaScene` nor `Alembic` output. It only influences the Maya
+            #  USD exported output. Which is confusing, because the attr def
+            #  is ALSO exposed in the Alembic export plugin as attr defs.
+            #  Preferably we unify them or clean it up some way so they are
+            #  not duplicated.
+            TextDef("attr",
+                    label="Custom Attributes",
+                    tooltip="Relevant to Maya USD Export only",
+                    default="",
+                    placeholder="attr1, attr2"),
+            TextDef("attrPrefix",
+                    label="Custom Attributes Prefix",
+                    tooltip="Relevant to Maya USD Export only",
+                    placeholder="prefix1, prefix2"),
         ]

--- a/client/ayon_maya/plugins/create/create_model.py
+++ b/client/ayon_maya/plugins/create/create_model.py
@@ -14,17 +14,12 @@ class CreateModel(plugin.MayaCreator):
     icon = "cube"
     default_variants = ["Main", "Proxy", "_MD", "_HD", "_LD"]
 
-    write_color_sets = False
     write_face_sets = True
     include_shaders = False
 
     def get_instance_attr_defs(self):
 
         return [
-            BoolDef("writeColorSets",
-                    label="Write vertex colors",
-                    tooltip="Write vertex colors with the geometry",
-                    default=self.write_color_sets),
             BoolDef("writeFaceSets",
                     label="Write face sets",
                     tooltip="Write face sets with the geometry",
@@ -34,13 +29,6 @@ class CreateModel(plugin.MayaCreator):
                     tooltip="Whether to include parent hierarchy of nodes in "
                             "the publish instance",
                     default=False),
-            TextDef("attr",
-                    label="Custom Attributes",
-                    default="",
-                    placeholder="attr1, attr2"),
-            TextDef("attrPrefix",
-                    label="Custom Attributes Prefix",
-                    placeholder="prefix1, prefix2"),
             BoolDef("include_shaders",
                     label="Include Shaders",
                     tooltip="Include shaders in the geometry export.",

--- a/client/ayon_maya/plugins/create/create_model.py
+++ b/client/ayon_maya/plugins/create/create_model.py
@@ -20,6 +20,13 @@ class CreateModel(plugin.MayaCreator):
     def get_instance_attr_defs(self):
 
         return [
+            # TODO: Differentiate this more clearly from the exact Alembic
+            #  export feature to 'write face sets'
+            #  This particular toggle here implements an additional process
+            #  step for exports where ANY shader assignment is turned into an
+            #  explicit 'per face' assignment even if it was just a regular
+            #  full object material assignment in Maya.
+            #  See: https://github.com/ynput/ayon-maya/pull/37
             BoolDef("writeFaceSets",
                     label="Write face sets",
                     tooltip="Write face sets with the geometry",

--- a/server/settings/creators.py
+++ b/server/settings/creators.py
@@ -49,7 +49,6 @@ class CreateMultiverseLookModel(BaseSettingsModel):
 
 class BasicExportMeshModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="Enabled")
-    write_color_sets: bool = SettingsField(title="Write Color Sets")
     write_face_sets: bool = SettingsField(title="Write Face Sets")
     default_variants: list[str] = SettingsField(
         default_factory=list,
@@ -59,8 +58,6 @@ class BasicExportMeshModel(BaseSettingsModel):
 
 
 class CreateAnimationModel(BaseSettingsModel):
-    write_color_sets: bool = SettingsField(title="Write Color Sets")
-    write_face_sets: bool = SettingsField(title="Write Face Sets")
     include_parent_hierarchy: bool = SettingsField(
         title="Include Parent Hierarchy")
     include_user_defined_attributes: bool = SettingsField(
@@ -73,8 +70,6 @@ class CreateAnimationModel(BaseSettingsModel):
 
 class CreatePointCacheModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="Enabled")
-    write_color_sets: bool = SettingsField(title="Write Color Sets")
-    write_face_sets: bool = SettingsField(title="Write Face Sets")
     include_user_defined_attributes: bool = SettingsField(
         title="Include User Defined Attributes"
     )
@@ -307,8 +302,6 @@ DEFAULT_CREATORS_SETTINGS = {
         "publish_mip_map": True
     },
     "CreateAnimation": {
-        "write_color_sets": False,
-        "write_face_sets": False,
         "include_parent_hierarchy": False,
         "include_user_defined_attributes": False,
         "default_variants": [
@@ -317,7 +310,6 @@ DEFAULT_CREATORS_SETTINGS = {
     },
     "CreateModel": {
         "enabled": True,
-        "write_color_sets": False,
         "write_face_sets": True,
         "default_variants": [
             "Main",
@@ -328,8 +320,6 @@ DEFAULT_CREATORS_SETTINGS = {
     },
     "CreatePointCache": {
         "enabled": True,
-        "write_color_sets": False,
-        "write_face_sets": False,
         "include_user_defined_attributes": False,
         "default_variants": [
             "Main"


### PR DESCRIPTION
## Changelog Description

- Remove `write_color_sets` and `write_face_sets` from creators where relevant.
    - Note: For model creator these are maintained, see the **todo** in code because there is special logic surrounding the model product type's creator toggle for "Write Face Sets" since https://github.com/ynput/ayon-maya/pull/37 by @moonyuet however it overlaps heavily with the "write face sets" toggle on the actual Extractor which is a **completely separate toggle** and currently for this model instance's face sets logic to work it is required for BOTH toggles to be enabled.
- Fix Create Animation and Create Pointcache defaults from settings for Include Parent Hierarchy and Include User Defined Attributes creator attributes. Previously the settings would not define the defaults at all.
- Add tooltip (and TODO) for `attr` and `attrPrefix` creator attributes for model product type - because those are essentially defined by the Alembic extractor already and hence currently **only** influence the USD export of the model product type (which in essence is **disabled** by default)

## Additional review information

n/a

## Testing notes:

1. Writing color sets and writing face sets with model, pointcache and animation instances should still behave as intended.
2. Defaults in settings for Create animation and Create pointcache should be applied, in particular for "Include Parent Hierarchy" and "Include User Defined Attributes".
3. The Model product "attr" and "attrPrefix" should be somewhat clearer as to what it applies to. it should only apply to USD export, because Alembic export already exposes its own attribute definition for it.
4. The model product 'write face sets' should still behave as intended as per https://github.com/ynput/ayon-maya/pull/37