### PR TITLE
Load File: Do not set the <UDIM> token explicitly

### DIFF
--- a/client/ayon_maya/plugins/load/load_image.py
+++ b/client/ayon_maya/plugins/load/load_image.py
@@ -309,7 +309,11 @@ class FileNodeLoader(plugin.Loader):
         # with our own data
         tokens = {
             "frame": "<f>",
-            "udim": "<UDIM>"
+            # We do not enforce the UDIM token in the filepath because it
+            # generates the issue that Maya does not detect the file correctly
+            # in e.g. the File Path Editor. Instead, we set the regular
+            # filepath and allow Maya to 'compute' the UDIM token.
+            # "udim": "<UDIM>"
         }
         has_tokens = False
         repre_context = representation["context"]


### PR DESCRIPTION
## Changelog Description

Load File: Do not set the `<UDIM>` token explicitly.

## Additional review information

Fixes images to be listed unresolved by Maya:
![image](https://github.com/user-attachments/assets/6110bf69-cb11-4e6d-ac4c-3bd90ca0f2a1)

Also fixes "asset dependencies" for Deadline submissions.

## Testing notes:

1. Load a published UDIM sequence (from substance painter)
2. List the file node in the Maya File Path Editor, it should appear green and not red.
3. Publish scene render to deadline with "asset dependencies" enabled - the file asset dependency should be computed correctly.