### PR TITLE
AY-7320 Skip meshes without faces in explicit face set member assignments

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4407,6 +4407,17 @@ def force_shader_assignments_to_faces(shapes):
             if "." not in member:
                 # Convert to face assignments
                 member = f"{member}.f[*]"
+                if not cmds.objExists(member):
+                    # It is possible for a mesh to have no faces at all
+                    # for which we cannot convert to face assignments anyway.
+                    # It is a `mesh` node type - it just would error on
+                    # 'No object matches name' when trying to assign to the
+                    # faces. So we skip the conversion
+                    log.debug(
+                        "Skipping face assignment conversion because "
+                        f"no mesh faces were found: {member}")
+                    continue
+
                 has_conversions = True
             override_assignments[shading_engine].append(member)
 

--- a/client/ayon_maya/plugins/publish/extract_pointcache.py
+++ b/client/ayon_maya/plugins/publish/extract_pointcache.py
@@ -238,13 +238,12 @@ class ExtractAlembic(plugin.MayaExtractorPlugin,
         else:
             kwargs["preRollStartFrame"] = None
 
-        shapes = self.get_members_shapes(nodes)
-
         suspend = not instance.data.get("refresh", False)
         with contextlib.ExitStack() as stack:
             stack.enter_context(suspended_refresh(suspend=suspend))
             stack.enter_context(maintained_selection())
             if instance.data.get("writeFaceSets", True):
+                shapes = self.get_members_shapes(nodes)
                 stack.enter_context(force_shader_assignments_to_faces(shapes))
             cmds.select(nodes, noExpand=True)
             self.log.debug(

--- a/client/ayon_maya/plugins/publish/extract_pointcache.py
+++ b/client/ayon_maya/plugins/publish/extract_pointcache.py
@@ -238,7 +238,7 @@ class ExtractAlembic(plugin.MayaExtractorPlugin,
         else:
             kwargs["preRollStartFrame"] = None
 
-        shapes = self.get_members_shapes(instance)
+        shapes = self.get_members_shapes(nodes)
 
         suspend = not instance.data.get("refresh", False)
         with contextlib.ExitStack() as stack:
@@ -298,8 +298,7 @@ class ExtractAlembic(plugin.MayaExtractorPlugin,
     def get_members_and_roots(self, instance):
         return instance[:], instance.data.get("setMembers")
 
-    def get_members_shapes(self, instance):
-        nodes = list(instance[:])
+    def get_members_shapes(self, nodes: "list[str]") -> "list[str]":
         return cmds.ls(nodes, type=("mesh", "nurbsCurve"), long=True)
 
     @classmethod

--- a/client/ayon_maya/plugins/publish/extract_pointcache.py
+++ b/client/ayon_maya/plugins/publish/extract_pointcache.py
@@ -243,8 +243,8 @@ class ExtractAlembic(plugin.MayaExtractorPlugin,
             stack.enter_context(suspended_refresh(suspend=suspend))
             stack.enter_context(maintained_selection())
             if instance.data.get("writeFaceSets", True):
-                shapes = self.get_members_shapes(nodes)
-                stack.enter_context(force_shader_assignments_to_faces(shapes))
+                meshes = cmds.ls(nodes, type="mesh", long=True)
+                stack.enter_context(force_shader_assignments_to_faces(meshes))
             cmds.select(nodes, noExpand=True)
             self.log.debug(
                 "Running `extract_alembic` with the keyword arguments: "
@@ -296,9 +296,6 @@ class ExtractAlembic(plugin.MayaExtractorPlugin,
 
     def get_members_and_roots(self, instance):
         return instance[:], instance.data.get("setMembers")
-
-    def get_members_shapes(self, nodes: "list[str]") -> "list[str]":
-        return cmds.ls(nodes, type=("mesh", "nurbsCurve"), long=True)
 
     @classmethod
     def get_attribute_defs(cls):


### PR DESCRIPTION
## Changelog Description

1. Skip meshes without faces in explicit face set member assignments
2. Consider only doing the face assignment conversion on meshes actually in the export, instead of all that happen to be in the `instance`

## Additional review information

- Avoids a `No object matches name` error when trying to force face shader assignments for Write Face Sets if a mesh has no faces at all.
- Also fixes the forced face set assignments to process all meshes in the instance, now it only includes e.g. meshes that are inside the `out_SET` for animation instances.

## Testing notes:

1. Export a mesh without faces (yeah, that'd still be a problem!) with Write Face Sets with this conversion enabled.
2. It should not error on our code.
