### PR TITLE
Improve validation reports for look validations

### DIFF
--- a/client/ayon_maya/plugins/publish/help/validate_node_ids.xml
+++ b/client/ayon_maya/plugins/publish/help/validate_node_ids.xml
@@ -15,11 +15,6 @@ save your scene again.
 After that restart publishing with Reload button.
 </description>
 <detail>
-### Invalid nodes
-
-{nodes}
-
-
 ### How could this happen?
 
 This often happens if you've generated new nodes but haven't saved your scene

--- a/client/ayon_maya/plugins/publish/validate_look_id_reference_edits.py
+++ b/client/ayon_maya/plugins/publish/validate_look_id_reference_edits.py
@@ -93,7 +93,7 @@ class ValidateLookIdReferenceEdits(plugin.MayaInstancePlugin):
         for ref, nodes in references.items():
             for node in nodes:
 
-                # Somehow this only works if you run the the removal
+                # Somehow this only works if you run the removal
                 # per edit command.
                 for command in ["addAttr",
                                 "connectAttr",

--- a/client/ayon_maya/plugins/publish/validate_look_shading_group.py
+++ b/client/ayon_maya/plugins/publish/validate_look_shading_group.py
@@ -1,3 +1,5 @@
+import inspect
+
 import ayon_maya.api.action
 from ayon_core.pipeline.publish import (
     OptionalPyblishPluginMixin,
@@ -31,34 +33,53 @@ class ValidateShadingEngine(plugin.MayaInstancePlugin,
 
         invalid = self.get_invalid(instance)
         if invalid:
+            node_list = "\n".join(f"- {node}" for node in invalid)
             raise PublishValidationError(
-                "Found shading engines with incorrect naming:"
-                "\n{}".format(invalid)
+                "Found assigned shaders with incorrect names:"
+                "\n{}".format(node_list),
+                description=self.get_description()
             )
 
     @classmethod
     def get_invalid(cls, instance):
         shapes = cmds.ls(instance, type=["nurbsSurface", "mesh"], long=True)
+        if not shapes:
+            return []
+
+        ignored_default_nodes = set(cmds.ls(defaultNodes=True))
+        shading_engines = set(cmds.listConnections(
+            shapes, destination=True, type="shadingEngine"
+        ) or [])
         invalid = []
-        for shape in shapes:
-            shading_engines = cmds.listConnections(
-                shape, destination=True, type="shadingEngine"
-            ) or []
-            for shading_engine in shading_engines:
-                materials = cmds.listConnections(
-                    shading_engine + ".surfaceShader",
-                    source=True, destination=False
-                )
-                if not materials:
+        for shading_engine in sorted(shading_engines):
+            materials = cmds.listConnections(
+                shading_engine + ".surfaceShader",
+                source=True, destination=False
+            )
+            if not materials:
+                cls.log.warning(
+                    "Shading engine '{}' has no material connected to its "
+                    ".surfaceShader attribute.".format(shading_engine))
+                continue
+
+            material = materials[0]  # there should only ever be one input
+            name = material + "SG"
+            if shading_engine != name:
+                # Ignore referenced or read-only shading engines
+
+                if cmds.referenceQuery(shading_engine,
+                                       isNodeReferenced=True):
                     cls.log.warning(
-                        "Shading engine '{}' has no material connected to its "
-                        ".surfaceShader attribute.".format(shading_engine))
+                        "Ignoring referenced shading engine "
+                        f"with invalid name: {shading_engine}")
+
+                if shading_engine in ignored_default_nodes:
+                    cls.log.warning(
+                        "Ignoring default shading engine "
+                        f"with invalid name: {shading_engine}")
                     continue
 
-                material = materials[0]  # there should only ever be one input
-                name = material + "SG"
-                if shading_engine != name:
-                    invalid.append(shading_engine)
+                invalid.append(shading_engine)
 
         return list(set(invalid))
 
@@ -71,3 +92,16 @@ class ValidateShadingEngine(plugin.MayaInstancePlugin,
                 + "SG"
             )
             cmds.rename(shading_engine, name)
+
+    @staticmethod
+    def get_description():
+        return inspect.cleandoc("""
+            ### Shaders found with incorrect names
+            
+            The shading engine of a shader should be named after the connected
+            material to its `.surfaceShader` attribute. The name should be
+            `"{material}SG"`.
+            
+            Use the repair action to rename the shading engine to the correct
+            names automatically.
+        """)

--- a/client/ayon_maya/plugins/publish/validate_look_shading_group.py
+++ b/client/ayon_maya/plugins/publish/validate_look_shading_group.py
@@ -66,7 +66,6 @@ class ValidateShadingEngine(plugin.MayaInstancePlugin,
             name = material + "SG"
             if shading_engine != name:
                 # Ignore referenced or read-only shading engines
-
                 if cmds.referenceQuery(shading_engine,
                                        isNodeReferenced=True):
                     cls.log.warning(

--- a/client/ayon_maya/plugins/publish/validate_node_ids.py
+++ b/client/ayon_maya/plugins/publish/validate_node_ids.py
@@ -47,8 +47,7 @@ class ValidateNodeIDs(plugin.MayaInstancePlugin):
             )
             raise PublishXmlValidationError(
                 plugin=self,
-                message="Nodes found without IDs:\n{}".format(names),
-                formatting_data={"nodes": names}
+                message="Nodes found without IDs:\n{}".format(names)
             )
 
     @classmethod

--- a/client/ayon_maya/plugins/publish/validate_node_ids.py
+++ b/client/ayon_maya/plugins/publish/validate_node_ids.py
@@ -43,11 +43,11 @@ class ValidateNodeIDs(plugin.MayaInstancePlugin):
         invalid = self.get_invalid(instance)
         if invalid:
             names = "\n".join(
-                "- {}".format(node) for node in invalid
+                "- {}".format(node) for node in sorted(invalid)
             )
             raise PublishXmlValidationError(
                 plugin=self,
-                message="Nodes found without IDs: {}".format(invalid),
+                message="Nodes found without IDs:\n{}".format(names),
                 formatting_data={"nodes": names}
             )
 


### PR DESCRIPTION
## Changelog Description

Improve validation reports for look validations

## Additional review information

See the commit messages for more details.

Some examples:

![image](https://github.com/user-attachments/assets/154452e1-507a-4ea8-9a5b-92db24351770)
![image](https://github.com/user-attachments/assets/4a4d1c58-ff8a-4e22-aff8-5571fc223cf1)
![image](https://github.com/user-attachments/assets/2fcd3c74-df83-48ba-8d20-df4bf991bdab)

## Testing notes:

1. Create a Maya look and publish should work
2. When assigning a new material without saving (no cbId) the validation message should be nice.
3. When publishing look where a mesh has default material, it should be disallowed and easy for artist to solve.
4. When publishing a look with texture where no filepath is set (or files are missing) validation message should be clear.