### PR TITLE
Replace <br> in validator reports for new lines

### DIFF
--- a/client/ayon_maya/plugins/publish/validate_mesh_has_uv.py
+++ b/client/ayon_maya/plugins/publish/validate_mesh_has_uv.py
@@ -75,13 +75,13 @@ class ValidateMeshHasUVs(plugin.MayaInstancePlugin,
         invalid = self.get_invalid(instance)
         if invalid:
 
-            names = "<br>".join(
+            names = "\n".join(
                 " - {}".format(node) for node in invalid
             )
 
             raise PublishValidationError(
                 title="Mesh has missing UVs",
-                message="Model meshes are required to have UVs.<br><br>"
-                        "Meshes detected with invalid or missing UVs:<br>"
+                message="Model meshes are required to have UVs.\n\n"
+                        "Meshes detected with invalid or missing UVs:\n"
                         "{0}".format(names)
             )

--- a/client/ayon_maya/plugins/publish/validate_transform_naming_suffix.py
+++ b/client/ayon_maya/plugins/publish/validate_transform_naming_suffix.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Plugin for validating naming conventions."""
-import copy
-import inspect
 import json
 
 import ayon_maya.api.action

--- a/client/ayon_maya/plugins/publish/validate_transform_naming_suffix.py
+++ b/client/ayon_maya/plugins/publish/validate_transform_naming_suffix.py
@@ -53,10 +53,10 @@ class ValidateTransformNamingSuffix(plugin.MayaInstancePlugin,
     def get_table_for_invalid(cls):
         suffix_naming_table = json.loads(cls.SUFFIX_NAMING_TABLE)
         ss = [
-            " - <b>{}</b>: {}".format(k, ", ".join(v))
+            " - *{}*: {}".format(k, ", ".join(v))
             for k, v in suffix_naming_table.items()
         ]
-        return "<br>".join(ss)
+        return "\n".join(ss)
 
     @staticmethod
     def is_valid_name(
@@ -133,13 +133,12 @@ class ValidateTransformNamingSuffix(plugin.MayaInstancePlugin,
         if invalid:
             valid = self.get_table_for_invalid()
 
-            names = "<br>".join(
+            names = "\n".join(
                 " - {}".format(node) for node in invalid
             )
-            valid = valid.replace("\n", "<br>")
 
             raise PublishValidationError(
                 title="Invalid naming suffix",
-                message="Valid suffixes are:<br>{0}<br><br>"
-                        "Incorrectly named geometry transforms:<br>{1}"
+                message="Valid suffixes are:\n{0}\n\n"
+                        "Incorrectly named geometry transforms:\n{1}"
                         "".format(valid, names))

--- a/client/ayon_maya/plugins/publish/validate_transform_naming_suffix.py
+++ b/client/ayon_maya/plugins/publish/validate_transform_naming_suffix.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """Plugin for validating naming conventions."""
+import copy
+import inspect
 import json
 
 import ayon_maya.api.action
@@ -50,12 +52,18 @@ class ValidateTransformNamingSuffix(plugin.MayaInstancePlugin,
     ALLOW_IF_NOT_IN_SUFFIX_TABLE = True
 
     @classmethod
-    def get_table_for_invalid(cls):
+    def get_table_for_invalid(cls, markdown=False):
         suffix_naming_table = json.loads(cls.SUFFIX_NAMING_TABLE)
-        ss = [
-            " - *{}*: {}".format(k, ", ".join(v))
-            for k, v in suffix_naming_table.items()
-        ]
+        if markdown:
+            ss = [
+                "- **{}**: {}".format(k, ", ".join(v))
+                for k, v in suffix_naming_table.items()
+            ]
+        else:
+            ss = [
+                "- {}: {}".format(k, ", ".join(v))
+                for k, v in suffix_naming_table.items()
+            ]
         return "\n".join(ss)
 
     @staticmethod
@@ -141,4 +149,16 @@ class ValidateTransformNamingSuffix(plugin.MayaInstancePlugin,
                 title="Invalid naming suffix",
                 message="Valid suffixes are:\n{0}\n\n"
                         "Incorrectly named geometry transforms:\n{1}"
-                        "".format(valid, names))
+                        "".format(valid, names),
+                description=self.get_description())
+
+    def get_description(self) -> str:
+        """Get description for the plugin."""
+        table = self.get_table_for_invalid(markdown=True)
+        return (
+            "### Invalid naming suffix\n"
+            "Valid suffixes are:\n"
+            f"{table}\n"
+            "\n\\\n"  # force extra line breaks in the resulting markdown
+            "Use the *Select Invalid* action to identify the invalid nodes."
+        )

--- a/client/ayon_maya/plugins/publish/validate_transform_zero.py
+++ b/client/ayon_maya/plugins/publish/validate_transform_zero.py
@@ -68,7 +68,7 @@ class ValidateTransformZero(plugin.MayaInstancePlugin,
             return
         invalid = self.get_invalid(instance)
         if invalid:
-            names = "<br>".join(
+            names = "\n".join(
                 " - {}".format(node) for node in invalid
             )
 
@@ -76,8 +76,8 @@ class ValidateTransformZero(plugin.MayaInstancePlugin,
                 title="Transform Zero",
                 description=self.get_description(),
                 message="The model publish allows no transformations. You must"
-                        " <b>freeze transformations</b> to continue.<br><br>"
-                        "Nodes found with transform values:<br>"
+                        " 'freeze transformations'. to continue.\n\n"
+                        "Nodes found with transform values:\n"
                         "{0}".format(names))
 
     @staticmethod


### PR DESCRIPTION
## Changelog Description

Replace <br> in validator reports for new lines log reports

## Additional review information

Since https://github.com/ynput/ayon-core/pull/1104 the `<br>` would also display directly in the publisher UI report - which would appear cluttered. However, even without that PR the command line output would've also had the `<br>` in there so removing them is the correct fix.

![image](https://github.com/user-attachments/assets/e2dba372-029e-44f5-a76d-78fcaf149ed9)

![image](https://github.com/user-attachments/assets/31c88a49-8b6c-4f74-90a8-0eac09cc76f1)

![image](https://github.com/user-attachments/assets/80cf1b37-7f64-4ec6-82e4-17e8cf743be5)

## Testing notes:

1. Validate Mesh UV output should look good
2. Validate Transform Naming Suffix report should look good `ayon+settings://maya/publish/ValidateTransformNamingSuffix`
3. Validate Transform Zero report should look good. `ayon+settings://maya/publish/ValidateTransformZero`