### PR TITLE
Ignore invalid audio filepaths with a warning instead of erroring during Extraction

### DIFF
--- a/client/ayon_maya/plugins/publish/collect_review.py
+++ b/client/ayon_maya/plugins/publish/collect_review.py
@@ -1,3 +1,5 @@
+import os
+
 import ayon_api
 import pyblish.api
 from ayon_core.pipeline import KnownPublishError
@@ -166,5 +168,18 @@ class CollectReview(plugin.MayaInstancePlugin):
 
                     if start_audio <= end_frame and end_audio > start_frame:
                         audio_data.append(get_audio_node_data(node))
+
+            # Exclude audio data with filenames that can't be found with a
+            # warning to avoid a harder error on e.g. Extract Review
+            valid_audio_data = []
+            for audio in audio_data:
+                if not os.path.exists(audio["filename"]):
+                    self.log.warning(
+                        "Timeline audio file not found on disk: '{}'. "
+                        "Ignoring audio.".format(audio["filename"])
+                    )
+                    continue
+                valid_audio_data.append(audio)
+            audio_data = valid_audio_data
 
             instance.data["audio"] = audio_data


### PR DESCRIPTION
## Changelog Description

Allow to publish if for whatever reason the timeline is referencing an audio file that the machine can't find.

## Additional review information

This would log a warning during collect, instead of failing during extraction.

**One may argue that instead of doing this that it _may_ make more sense to instead use a dedicated "validator" to validate the files exist and disallow it and warn the user.** A choice may need to be made about which makes more sense from a pipeline perspective.

Not sure what the preference is?

Currently it would allow publishing, but would show this logged message:
```
Timeline audio file not found on disk: '/path/to/nonexisting/file.wav'. Ignoring audio.
```
![image](https://github.com/user-attachments/assets/685427ba-0473-4c98-bcf9-b90879a4f417)


Fix https://github.com/ynput/ayon-maya/issues/231 for missing files.

## Testing notes:
1. start with this step
2. follow this step
