### PR TITLE
Extract FBX Animation: Strip off only first level namespace

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_fbx_animation.py
+++ b/client/ayon_maya/plugins/publish/extract_fbx_animation.py
@@ -37,7 +37,10 @@ class ExtractFBXAnimation(plugin.MayaExtractorPlugin):
         instance.data["referencedAssetsContent"] = True
         fbx_exporter.set_options_from_instance(instance)
 
-        namespace = get_namespace(out_members[0])
+        # Export relative only to the first level of the namespace,
+        # keeping any nested namespaces intact. Fix #147
+        # So `root:sublevel:mesh` becomes `sublevel:mesh`
+        namespace = get_namespace(out_members[0]).split(":", 1)[0]
         relative_out_members = [
             strip_namespace(node, namespace) for node in out_members
         ]
@@ -45,7 +48,7 @@ class ExtractFBXAnimation(plugin.MayaExtractorPlugin):
             ":" + namespace,
             new=False,
             relative_names=True
-        ) as namespace:
+        ) as _namespace:
             fbx_exporter.export(relative_out_members, path)
 
         representations = instance.data.setdefault("representations", [])


### PR DESCRIPTION
## Changelog Description

Extract FBX Animation: Strip off only first level namespace

## Additional review information

Fix #147

## Testing notes:

1. Set up a rig ready for FBX export (with skeletalAnim, etc.) that in the rig itself has namespaces
2. Load the rig
    - You'd now have the extra rig namespace, like `rig_namespace:other_namespace:mesh`
3. Publish FBX animation

It should export the `other_namespace:mesh` whereas without this PR it would export `mesh`