### PR TITLE
Allow importing MayaUSDReferenceLoader + do not show the "Import Reference" option on non-supported containers

### DIFF
--- a/client/ayon_maya/plugins/inventory/import_reference.py
+++ b/client/ayon_maya/plugins/inventory/import_reference.py
@@ -11,9 +11,11 @@ class ImportReference(InventoryAction):
     icon = "download"
     color = "#d8d8d8"
 
+    supported_loaders = {"ReferenceLoader", "MayaUSDReferenceLoader"}
+
     def process(self, containers):
         for container in containers:
-            if container["loader"] != "ReferenceLoader":
+            if container["loader"] not in self.supported_loaders:
                 print("Not a reference, skipping")
                 continue
 
@@ -25,3 +27,7 @@ class ImportReference(InventoryAction):
             cmds.file(ref_file, importReference=True)
 
         return True  # return anything to trigger model refresh
+
+    @classmethod
+    def is_compatible(cls, container):
+        return container.get("loader") in cls.supported_loaders


### PR DESCRIPTION
## Changelog Description

Allow importing MayaUSDReferenceLoader + do not show the "Import Reference" option on non-supported containers

## Additional review information

Load like:

![image](https://github.com/user-attachments/assets/9a965e36-8dc6-4604-85cf-8a557fc3664e)

Now also shows on Maya USD Reference:

![image](https://github.com/user-attachments/assets/ad17e374-bcbc-4267-8f36-09086525f594)

Does not show on non-references:

![image](https://github.com/user-attachments/assets/0c687957-b7a5-4d6b-a9c6-d5dff050f0f1)

Still shows for e.g. referenced alembics:

![image](https://github.com/user-attachments/assets/2ef98005-3e71-4742-9f58-68b291ab3f72)


## Testing notes:
1. In Scene Inventory Maya USD Reference can now be "imported" as inventory action.
2. Non-reference loader containers now also should not show the "Import Reference" action.
