### PR TITLE
Extract FBX: Export only once

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_fbx.py
+++ b/client/ayon_maya/plugins/publish/extract_fbx.py
@@ -43,8 +43,6 @@ class ExtractFBX(plugin.MayaExtractorPlugin):
         # Export
         with maintained_selection():
             fbx_exporter.export(members, path)
-            cmds.select(members, r=1, noExpand=True)
-            mel.eval('FBXExport -f "{}" -s'.format(path))
 
         if "representations" not in instance.data:
             instance.data["representations"] = []


### PR DESCRIPTION
## Changelog Description

Extract FBX: Export only once

## Additional review information

Seems like somehow we were exporting twice?

## Testing notes:

1. Exporting FBX `model` or `camera` (if enabled in settings) should still work as intended
