### PR TITLE
Support deleting workfile instances

### DIFF
--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -278,6 +278,7 @@ class MayaCreatorBase:
 
             self.imprint_instance_node(node, data)
 
+    @lib.undo_chunk()
     def _default_remove_instances(self, instances):
         """Remove specified instance from the scene.
 

--- a/client/ayon_maya/plugins/create/create_workfile.py
+++ b/client/ayon_maya/plugins/create/create_workfile.py
@@ -86,6 +86,9 @@ class CreateWorkfile(plugin.MayaCreatorBase, AutoCreator):
             created_instance = CreatedInstance.from_existing(node_data, self)
             self._add_instance_to_context(created_instance)
 
+    def remove_instances(self, instances):
+        self._default_remove_instances(instances)
+
     def update_instances(self, update_list):
         for created_inst, _changes in update_list:
             data = created_inst.data_to_store()


### PR DESCRIPTION
## Changelog Description

Support deleting workfile instances

+ Use undo chunk so that multiple instances being deleted are just a single undo instead of one per instance

## Additional review information

Supporting this removal (even though it is an auto creator) is helpful for cases where through whatever reason multiple workfile object sets ended up in your workfile, e.g. by accidentally importing from another scene, copy/pasting or duplicating it somehow. This way the user can actually try to remove it through the publisher UI instead of it "remaining" there without a hint that it's not working.

See [discord thread](https://discord.com/channels/517362899170230292/1344665784281989200)

## Testing notes:
1. Save with publisher UI once so that you have a workfile instance.
2. In outliner, enable Display > Ignore "Hidden in Outliner"
3. Duplicate the `workfileMain` object set a few times.
4. Reset the publisher UI - you know suddenly have multiple workfile main entries.

Without this PR, you are unable to delete those through the publisher UI. With this PR you can.
