### PR TITLE
Input connections set to False when export animation in fbx

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_fbx_animation.py
+++ b/client/ayon_maya/plugins/publish/extract_fbx_animation.py
@@ -35,6 +35,7 @@ class ExtractFBXAnimation(plugin.MayaExtractorPlugin):
         # the flags they intended to export
         instance.data["skeletonDefinitions"] = True
         instance.data["referencedAssetsContent"] = True
+        instance.data["inputConnections"] = False
         fbx_exporter.set_options_from_instance(instance)
 
         # Export relative only to the first level of the namespace,


### PR DESCRIPTION
## Changelog Description
This PR is to make sure the input connections are not included before exporting animation in fbx.
Resolve https://github.com/ynput/ayon-maya/issues/146

## Additional review information
Try to include `skeletalAnim_SET` with both geometry and rig, and the current workflow we have for unreal(with just control rigs).

## Testing notes:
1. Launch Maya
2. Load Rig
3. Put your control rig(and curve) into the `skeletalAnim_SET`
4. Publish