### PR TITLE
Extract Playblast settings profiles: Allow to fallback to legacy capture settings if no matching profile

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4047,7 +4047,7 @@ def get_capture_preset(
             plugin_settings["profiles"],
             filtering_criteria,
             logger=log
-        )
+        ) or {}
         capture_preset = profile.get("capture_preset")
     else:
         log.warning("No profiles present for Extract Playblast")

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4057,7 +4057,8 @@ def get_capture_preset(
     if capture_preset is None:
         log.debug(
             "Falling back to deprecated Extract Playblast capture preset "
-            "because no new style playblast profiles are defined."
+            "because no new style playblast profiles are defined or no "
+            "profile matches for your current context."
         )
         capture_preset = plugin_settings.get("capture_preset")
 


### PR DESCRIPTION
## Changelog Description

Allow to fallback to legacy capture settings if no matching profile for current context but other profiles are defined

## Additional review information

```
Traceback (most recent call last):
  File "/home/ralph/.local/share/AYON/addons/core_1.1.3+AM.0.2/ayon_core/pipeline/create/context.py", line 2165, in _create_with_unified_error
    result = creator.create(*args, **kwargs)
  File "/home/ralph/.local/share/AYON/addons/maya_0.4.4+AM.0.2/ayon_maya/plugins/create/create_review.py", line 54, in create
    preset = lib.get_capture_preset(
  File "/home/ralph/.local/share/AYON/addons/maya_0.4.4+AM.0.2/ayon_maya/api/lib.py", line 4051, in get_capture_preset
    capture_preset = profile.get("capture_preset")
AttributeError: 'NoneType' object has no attribute 'get'
```

See [reported here](https://discord.com/channels/517362899170230292/563751989075378201/1347497417137852436).

## Testing notes:

1. Create a profile in `ayon+settings://maya/publish/ExtractPlayblast/profiles`
2. Match it only to a certain task type not valid for your current context (e.g. one that does not exist)
3. Creating new review instances should work
4. Publishing review should work
5. It should fall back to the legacy deprecated profile instead of an error occurring.
6. Now set the profile task type to one that does match your current context.
7. Creating and publishing review instances should work.