### PR TITLE
Extract Playblast: Task types settings show dropdown instead of text field

### DIFF
--- a/server/settings/publish_playblast.py
+++ b/server/settings/publish_playblast.py
@@ -252,7 +252,7 @@ class CapturePresetSetting(BaseSettingsModel):
         title="Camera Options")
 
 
-class ProfilesModel(BaseSettingsModel):
+class PlayblastProfilesModel(BaseSettingsModel):
     _layout = "expanded"
     task_types: list[str] = SettingsField(
         default_factory=list,
@@ -276,7 +276,7 @@ class ExtractPlayblastSetting(BaseSettingsModel):
         default_factory=CapturePresetSetting,
         title="DEPRECATED! Please use \"Profiles\" below. Capture Preset"
     )
-    profiles: list[ProfilesModel] = SettingsField(
+    profiles: list[PlayblastProfilesModel] = SettingsField(
         default_factory=list,
         title="Profiles"
     )


### PR DESCRIPTION
## Changelog Description

Fix `task_types: list[str]` not appearing as multiselection dropdown

## Additional review information

No idea why this fixes it - there may be some schema lookup clash on `ProfilesModel`?

It seems there may have been a clash in model type name with another object name, [likely this one](https://github.com/ynput/ayon-maya/blob/67abf92300497839ef1239f02d57df89b76a3eeb/server/settings/workfile_build_settings.py#L37)... and for whatever reason that made it so that the frontend stopped displaying the correct dropdown for it.

This is related to https://github.com/ynput/ayon-frontend/issues/1057

---

Before:

![Image](https://github.com/user-attachments/assets/3b18e7c3-9673-4be0-b175-3d67ae3703c9)

After:

![image](https://github.com/user-attachments/assets/ba50f737-2981-48c7-8681-932967947b3c)

## Testing notes:
1. Upload addon
2. Setting `ayon+settings://maya/publish/ExtractPlayblast/profiles/0/task_types` should display as multiselection dropdown.

