### PR TITLE
Fix logged error with open file post initialization enabled if no workfile exists yet

### DIFF
--- a/client/ayon_maya/hooks/pre_open_workfile_post_initialization.py
+++ b/client/ayon_maya/hooks/pre_open_workfile_post_initialization.py
@@ -1,3 +1,5 @@
+import os
+
 from ayon_applications import PreLaunchHook, LaunchTypes
 
 
@@ -10,17 +12,25 @@ class MayaPreOpenWorkfilePostInitialization(PreLaunchHook):
     launch_types = {LaunchTypes.local}
 
     def execute(self):
-
-        # Ignore if there's no last workfile to start.
-        if not self.data.get("start_last_workfile"):
+        # Do nothing if post workfile initialization is disabled.
+        maya_settings = self.data["project_settings"]["maya"]
+        if not maya_settings["open_workfile_post_initialization"]:
             return
 
-        maya_settings = self.data["project_settings"]["maya"]
-        enabled = maya_settings["open_workfile_post_initialization"]
-        if enabled:
-            # Force disable the `AddLastWorkfileToLaunchArgs`.
-            self.data.pop("start_last_workfile")
+        # Force disable the `AddLastWorkfileToLaunchArgs`.
+        start_last_workfile = self.data.pop("start_last_workfile")
 
-            self.log.debug("Opening workfile post initialization.")
-            key = "AYON_OPEN_WORKFILE_POST_INITIALIZATION"
-            self.launch_context.env[key] = "1"
+        # Ignore if there's no last workfile to start.
+        if not start_last_workfile:
+            return
+
+        # Ignore if the last workfile path does not exist, this may be the case
+        # when starting a context that has no workfiles yet.
+        last_workfile_path: str = self.data.get("last_workfile_path")
+        if not last_workfile_path or not os.path.exists(last_workfile_path):
+            self.log.info("Current context does not have any workfile yet.")
+            return
+
+        self.log.debug("Opening workfile post initialization.")
+        key = "AYON_OPEN_WORKFILE_POST_INITIALIZATION"
+        self.launch_context.env[key] = "1"


### PR DESCRIPTION
## Changelog Description

Fix logged error with open file post initialization enabled if no workfile exists yet

## Additional review information

Fix #143

## Testing notes:
1. Have setting enabled: `ayon+settings://maya/open_workfile_post_initialization`
2. Launch Maya in a task context that has no workfiles yet.
3. There should be no logged error in Maya script editor after startup like:
```
# Error: RuntimeError: file ./startup/userSetup.py line 43: File not found: "path/to/workfile.ma" #
```

4. If a workfile does exist - it should still be opened "post init" as intende.
5. If the setting is disabled, it should also still work, but open the file directly as added 'argument' to the maya executable on launch.
