### PR TITLE
Fix writing redshift proxy filenames with number at end of filename (e.g. variant `env050`)

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_redshift_proxy.py
+++ b/client/ayon_maya/plugins/publish/extract_redshift_proxy.py
@@ -25,7 +25,6 @@ class ExtractRedshiftProxy(plugin.MayaExtractorPlugin):
         cmds.loadPlugin("redshift4maya", quiet=True)
 
         staging_dir = self.staging_dir(instance)
-
         file_name = "{}.####.rs".format(instance.name)
         file_path = os.path.join(staging_dir, file_name)
 

--- a/client/ayon_maya/plugins/publish/extract_redshift_proxy.py
+++ b/client/ayon_maya/plugins/publish/extract_redshift_proxy.py
@@ -98,5 +98,6 @@ class ExtractRedshiftProxy(plugin.MayaExtractorPlugin):
         }
         instance.data["representations"].append(representation)
 
-        self.log.debug("Extracted instance '%s' to: %s"
-                       % (instance.name, staging_dir))
+        self.log.debug(
+            f"Extracted instance '{instance.name}' to: {staging_dir}"
+        )

--- a/client/ayon_maya/plugins/publish/extract_redshift_proxy.py
+++ b/client/ayon_maya/plugins/publish/extract_redshift_proxy.py
@@ -24,14 +24,18 @@ class ExtractRedshiftProxy(plugin.MayaExtractorPlugin):
         # Make sure Redshift is loaded
         cmds.loadPlugin("redshift4maya", quiet=True)
 
+        anim_on: bool = instance.data["animation"]
+        if anim_on:
+            # Add frame number #### placeholder for animated exports
+            file_name = "{}.####.rs".format(instance.name)
+        else:
+            file_name = "{}.rs".format(instance.name)
+
         staging_dir = self.staging_dir(instance)
-        file_name = "{}.####.rs".format(instance.name)
         file_path = os.path.join(staging_dir, file_name)
 
-        anim_on: bool = instance.data["animation"]
         rs_options = "exportConnectivity=0;enableCompression=1;keepUnused=0;"
         repr_files: Union[str, list[str]] = file_name
-
         if not anim_on:
             # Remove animation information because it is not required for
             # non-animated products
@@ -61,7 +65,6 @@ class ExtractRedshiftProxy(plugin.MayaExtractorPlugin):
                     ".####.rs", f".{frame_padded}.rs"
                 )
                 repr_files.append(frame_filename)
-        # vertex_colors = instance.data.get("vertexColors", False)
 
         # Write out rs file
         self.log.debug("Writing: '%s'", file_path)


### PR DESCRIPTION
## Changelog Description

Fix writing redshift proxy filenames with number at end of filename, e.g. instance name had `env050` as variant). Redshift would use the 050 as the frame number instead of appending the `.####` frame digits. We now write with `####` in the filepath which Redshift uses to write the frame number to as was intended.

## Additional review information

Fix #114

## Testing notes:

1. Create redshift proxy instance with variant name `env050` (or anything that ends with digits)
2. Publishing should work.
