### PR TITLE
AY-7454 Load Image Plane: Allow loading "jpeg" representation as image plane

### DIFF
--- a/client/ayon_maya/plugins/load/load_image_plane.py
+++ b/client/ayon_maya/plugins/load/load_image_plane.py
@@ -85,7 +85,7 @@ class ImagePlaneLoader(plugin.Loader):
 
     product_types = {"image", "plate", "render"}
     label = "Load imagePlane"
-    representations = {"mov", "exr", "preview", "png", "jpg"}
+    representations = {"mov", "exr", "preview", "png", "jpg", "jpeg"}
     icon = "image"
     color = "orange"
 


### PR DESCRIPTION
## Changelog Description

Load Image Plane: Allow loading "jpeg" representation as image plane

E.g. if you published as "jpeg" instead of "jpg" a render from Nuke or alike.

## Additional review information

Related to AY-7454

Fix: https://github.com/ynput/ayon-maya/issues/236

## Testing notes:

1. Load Image Plane should work with "jpeg" representation
