### PR TITLE
Render Settings: Refactor setting of Redshift GI engine - do not ever set value of `0`

### DIFF
--- a/client/ayon_maya/api/lib_rendersettings.py
+++ b/client/ayon_maya/api/lib_rendersettings.py
@@ -197,22 +197,22 @@ class RenderSettings(object):
         # update the AOV list
         mel.eval("redshiftUpdateActiveAovList")
 
-        rs_p_engine = redshift_render_presets["primary_gi_engine"]
-        rs_s_engine = redshift_render_presets["secondary_gi_engine"]
+        # Irradiance Point cloud: 2 (only available for secondary GI engine)
+        # Irradiance Cache: 3 (only available for primary GI engine)
+        # Brute Force: 4
+        rs_p_engine = int(redshift_render_presets["primary_gi_engine"])
+        rs_s_engine = int(redshift_render_presets["secondary_gi_engine"])
+        if rs_p_engine == 0:
+            # reset the primary GI Engine as default: Brute Force
+            rs_p_engine = 4
+        if rs_s_engine == 0:
+            # reset the secondary GI Engine as default: Irradiance Point cloud
+            rs_s_engine = 2
 
-        if int(rs_p_engine) or int(rs_s_engine) != 0:
-            cmds.setAttr("redshiftOptions.GIEnabled", 1)
-            if int(rs_p_engine) == 0:
-                # reset the primary GI Engine as default
-                cmds.setAttr("redshiftOptions.primaryGIEngine", 4)
-            if int(rs_s_engine) == 0:
-                # reset the secondary GI Engine as default
-                cmds.setAttr("redshiftOptions.secondaryGIEngine", 2)
-        else:
-            cmds.setAttr("redshiftOptions.GIEnabled", 0)
-
-        cmds.setAttr("redshiftOptions.primaryGIEngine", int(rs_p_engine))
-        cmds.setAttr("redshiftOptions.secondaryGIEngine", int(rs_s_engine))
+        gi_enabled: bool = bool(rs_p_engine or rs_s_engine)
+        cmds.setAttr("redshiftOptions.GIEnabled", gi_enabled)
+        cmds.setAttr("redshiftOptions.primaryGIEngine", rs_p_engine)
+        cmds.setAttr("redshiftOptions.secondaryGIEngine", rs_s_engine)
 
         additional_options = redshift_render_presets["additional_options"]
         ext = redshift_render_presets["image_format"]


### PR DESCRIPTION
## Changelog Description

Refactor setting of Redshift GI engine - do not ever set value of `0`

(which would've previously happened if any of the entries was set to "None" in settings). Currently "None" would set it to the Redshift default values where it is:

- None for Primary Engine is: Brute Force
- None for Secondary GI Engine is: Irradiance Point Cloud

## Additional review information

Which leaves the question: Why do we still need the `None` field? Or should the `None` field be applied as "Do not set it at all?"

## Testing notes:

1. Settings Primary GI Engine "None" and Secondary GI Engine "Irradiance Point Cloud" should not give unexpected results.
2. There was a report that saving the scene with the render settings set like that and reopening it, that Redshift would display the settings differently with the "Irradiance Cache" section under the GI settings in Redshift settings appearing greyed out (as if it's currently set to an invalid value)