### PR TITLE
Fix PreLaunchHooks if both explicit load plugins and open workfile post initialization is enabled.

### DIFF
--- a/client/ayon_maya/hooks/pre_auto_load_plugins.py
+++ b/client/ayon_maya/hooks/pre_auto_load_plugins.py
@@ -19,7 +19,7 @@ class MayaPreAutoLoadPlugins(PreLaunchHook):
         enabled = maya_settings["explicit_plugins_loading"]["enabled"]
         if enabled:
             # Force disable the `AddLastWorkfileToLaunchArgs`.
-            self.data.pop("start_last_workfile")
+            self.data.pop("start_last_workfile", None)
 
             # Force post initialization so our dedicated plug-in load can run
             # prior to Maya opening a scene file.

--- a/client/ayon_maya/hooks/pre_open_workfile_post_initialization.py
+++ b/client/ayon_maya/hooks/pre_open_workfile_post_initialization.py
@@ -18,7 +18,7 @@ class MayaPreOpenWorkfilePostInitialization(PreLaunchHook):
             return
 
         # Force disable the `AddLastWorkfileToLaunchArgs`.
-        start_last_workfile = self.data.pop("start_last_workfile")
+        start_last_workfile = self.data.pop("start_last_workfile", None)
 
         # Ignore if there's no last workfile to start.
         if not start_last_workfile:


### PR DESCRIPTION
## Changelog Description

Fix PreLaunchHooks if both explicit load plugins and open workfile post initialization is enabled.

## Additional review information

Ignore if key does exist, e.g. may already be popped from the other hook

Fix #256

## Testing notes:

1. Enable both Explicit Load Plugins and Open Workfile Post Initialization in settings
2. Launching with and without startup file should work fine.
3. It should also work with workfile templates.
