### PR TITLE
Maya USD: Support `mergeTransformAndShape` attribute for animation, pointcache and model product types

### DIFF
--- a/client/ayon_maya/plugins/create/create_maya_usd.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd.py
@@ -107,17 +107,6 @@ class CreateMayaUsd(plugin.MayaCreator):
                         "following format: nameSpaceExample_pPlatonic1"
                     ),
                     default=True),
-            BoolDef("mergeTransformAndShape",
-                    label="Merge Transform and Shape",
-                    tooltip=(
-                        "Combine Maya transform and shape into a single USD"
-                        "prim that has transform and geometry, for all"
-                        " \"geometric primitives\" (gprims).\n"
-                        "This results in smaller and faster scenes. Gprims "
-                        "will be \"unpacked\" back into transform and shape "
-                        "nodes when imported into Maya from USD."
-                    ),
-                    default=True),
             BoolDef("includeUserDefinedAttributes",
                     label="Include User Defined Attributes",
                     tooltip=(

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -454,9 +454,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
         return attr_defs
 
     @classmethod
-    def convert_attribute_values(
-        cls, create_context: "CreateContext", instance: "CreatedInstance"
-    ):
+    def convert_attribute_values(cls, create_context, instance):
         # Convert creator attribute 'mergeTransformAndShape' to
         # plugin attribute, because this attribute has moved from
         # the `io.openpype.creators.maya.mayausd` creator to this extractor

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -214,15 +214,15 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
             "worldspace": False
         }
 
-    def parse_overrides(self, instance, options):
+    def parse_overrides(self, overrides, options):
         """Inspect data of instance to determine overridden options"""
 
-        for key in instance.data:
+        for key in overrides:
             if key not in self.options:
                 continue
 
             # Ensure the data is of correct type
-            value = instance.data[key]
+            value = overrides[key]
             if isinstance(value, str):
                 value = str(value)
             if not isinstance(value, self.options[key]):
@@ -265,7 +265,8 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
 
         # Parse export options
         options = self.default_options
-        options = self.parse_overrides(instance, options)
+        options = self.parse_overrides(instance.data, options)
+        options = self.parse_overrides(attr_values, options)
 
         # Perform extraction
         self.log.debug("Performing extraction ...")

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -195,7 +195,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
             "chaser": None,
             "chaserArgs": None,
             "defaultUSDFormat": "usdc",
-            "stripNamespaces": False,
+            "stripNamespaces": True,
             "mergeTransformAndShape": True,
             "exportDisplayColor": False,
             "exportColorSets": True,
@@ -211,7 +211,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
             "jobContext": None,
             "filterTypes": None,
             "staticSingleSample": True,
-            "worldspace": False
+            "worldspace": True
         }
 
     def parse_overrides(self, overrides, options):
@@ -294,11 +294,6 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                                              long=True)
         else:
             options["selection"] = True
-
-        options["stripNamespaces"] = attr_values.get("stripNamespaces", True)
-        options["exportComponentTags"] = attr_values.get("exportComponentTags",
-                                                         False)
-        options["worldspace"] = attr_values.get("worldspace", True)
 
         # TODO: Remove hardcoded filterTypes
         # We always filter constraint types because they serve no valuable


### PR DESCRIPTION
## Changelog Description

Move `mergeTransformAndShape` from creator attributes to publish attributes on the Extractor so it can be set also for other creators generating maya usd outputs

## Additional review information

The **Merge Transform and Shape** attribute should now appear right-hand side in the publisher UI instead of left-hand side and it should also appear for pointcache, model and animation instances if they are set to publish USD files.

Additionally, the USD attributes are now grouped together visually and they will be hidden if the instance's "optional" attribute is checked off to avoid cluttering the UI.

![image](https://github.com/user-attachments/assets/52c1c201-5c60-4039-99ea-c715186fe55f)

![image](https://github.com/user-attachments/assets/3eba9ffa-787f-4a07-8f88-1506a5ae0f08)

Fix https://github.com/ynput/ayon-maya/issues/255

## Testing notes:

1. The attribute definitions for World-Space, Strip Namespaces and Merge Transform and shapes should still work
2. The attribute value from Merge Transform And Shapes on the Maya USD creator (from before this PR) should automatically be converted to the value on the publisher attribtues. The user's choice should hence be preserved.
3. The Merge Transform And Shapes option should also be exposed on pointcache, model and animation instances (if those are set to publish USD files) and the attributes should work to influence the exported file.