### PR TITLE
Settings Extension Mapping: Change to `ma` and `mb` enum

### DIFF
--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -21,10 +21,19 @@ from .templated_workfile_settings import (
 )
 
 
+def maya_file_extensions_enum():
+    return [
+        {"value": "ma", "label": "Maya Ascii (.ma)"},
+        {"value": "mb", "label": "Maya Binary (.mb)"}
+    ]
+
+
 class ExtMappingItemModel(BaseSettingsModel):
     _layout = "compact"
     name: str = SettingsField(title="Product type")
-    value: str = SettingsField(title="Extension")
+    value: str = SettingsField(
+        title="Extension", enum_resolver=maya_file_extensions_enum
+    )
 
 
 class MayaSettings(BaseSettingsModel):


### PR DESCRIPTION
## Changelog Description

Settings Extension Mapping: Change to `ma` and `mb` enum

## Additional review information

Fix https://github.com/ynput/ayon-maya/issues/246

![image](https://github.com/user-attachments/assets/68b2a839-1b58-4eff-943a-a2b91aaa639a)

## Testing notes:

1. Extension mapping should still work
