### PR TITLE
Load Matchmove: Fix load mel script with backslashes paths

### DIFF
--- a/client/ayon_maya/plugins/load/load_matchmove.py
+++ b/client/ayon_maya/plugins/load/load_matchmove.py
@@ -25,6 +25,8 @@ class MatchmoveLoader(plugin.Loader):
             runpy.run_path(path, run_name="__main__")
 
         elif path.lower().endswith(".mel"):
+            # Force forward slashes to avoid issues with backslashes in paths
+            path = path.replace("\\", "/")
             mel.eval('source "{}"'.format(path))
 
         else:


### PR DESCRIPTION
## Changelog Description

Load Matchmove: Fix load mel script with backslashes paths

## Additional review information

Fixes potential issue with backslashes in paths.

Related to [(private) internal conversation](https://discord.com/channels/517362899170230292/1356203288659230831).

## Testing notes:

1. Load matchmove script (.mel) should work
