### PR TITLE
Maya USD: Expose `defaultMeshScheme` (Subdivision Method) for USD exports

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -3,7 +3,7 @@ import json
 import os
 
 from ayon_core.pipeline import publish
-from ayon_core.lib import BoolDef, UILabelDef, UISeparatorDef
+from ayon_core.lib import BoolDef, EnumDef, UILabelDef, UISeparatorDef
 from ayon_maya.api.lib import maintained_selection, maintained_time
 from ayon_maya.api import plugin
 
@@ -167,6 +167,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
             "chaser": (list, None),  # optional list
             "chaserArgs": (list, None),  # optional list
             "defaultUSDFormat": str,
+            "defaultMeshScheme": str,
             "stripNamespaces": bool,
             "mergeTransformAndShape": bool,
             "exportDisplayColor": bool,
@@ -195,6 +196,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
             "chaser": None,
             "chaserArgs": None,
             "defaultUSDFormat": "usdc",
+            "defaultMeshScheme": "catmullClark",
             "stripNamespaces": True,
             "mergeTransformAndShape": True,
             "exportDisplayColor": False,
@@ -514,6 +516,23 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                     ),
                     visible=visible,
                     default=True),
+            EnumDef("defaultMeshScheme",
+                    label="Default Subdivision Method",
+                    items=[
+                        {"value": "catmullClark", "label": "Catmull Clark"},
+                        {"value": "loop", "label": "Loop"},
+                        {"value": "bilinear", "label": "Bilinear"},
+                        {"value": "none", "label": "None"},
+                    ],
+                    tooltip=(
+                        "Default subdivision method for meshes.\n"
+                        "Options are: catmullClark, loop, bilinear, none."
+                        "\n\n"
+                        "To specify per mesh subdivision schemes add a "
+                        "USD_ATTR_subdivisionScheme attribute."
+                    ),
+                    default="catmullClark"
+            )
         ]
 
 


### PR DESCRIPTION
## Changelog Description

Maya USD: Expose `defaultMeshScheme` (Subdivision Method) for USD exports

## Additional review information

Allow setting default mesh scheme

Came up on Discord [here](https://discord.com/channels/517362899170230292/563751989075378201/1356274008311464187).

## Testing notes:

1. Exporting maya usd, pointcache or animation should allow toggling default mesh scheme
