### PR TITLE
Fix paths passed to MEL matchmove script loader

### DIFF
--- a/client/ayon_maya/plugins/load/load_matchmove.py
+++ b/client/ayon_maya/plugins/load/load_matchmove.py
@@ -1,4 +1,6 @@
 import runpy
+from pathlib import Path
+from typing import Optional
 
 from ayon_maya.api import plugin
 from maya import mel
@@ -19,15 +21,18 @@ class MatchmoveLoader(plugin.Loader):
     icon = "empire"
     color = "orange"
 
-    def load(self, context, name, namespace, data):
-        path = self.filepath_from_context(context)
-        if path.lower().endswith(".py"):
-            runpy.run_path(path, run_name="__main__")
+    def load(self,
+             context: dict,
+             name: Optional[str] = None,
+             namespace: Optional[str] = None,
+             options: Optional[dict] = None) -> None:
+        """Load the matchmove script."""
+        path = Path(self.filepath_from_context(context))
+        if path.suffix.lower() == ".py":
+            runpy.run_path(path.as_posix(), run_name="__main__")
 
-        elif path.lower().endswith(".mel"):
-            mel.eval('source "{}"'.format(path))
+        elif path.suffix.lower() == ".mel":
+            mel.eval(f'source "{path.as_posix()}"')
 
         else:
-            self.log.error("Unsupported script type")
-
-        return True
+            self.log.error("Unsupported script type %s", path.suffix)


### PR DESCRIPTION
## Changelog Description
Wrong slashes caused `mel.eval` to fail to load and execute published MatchMove MEL file.

## Testing notes:
Publish Matchmove as MEL and load it it Maya