### PR TITLE
Load Redshift Proxy: Support Alembic (abc) and USD files.

### DIFF
--- a/client/ayon_maya/plugins/load/load_redshift_proxy.py
+++ b/client/ayon_maya/plugins/load/load_redshift_proxy.py
@@ -15,8 +15,9 @@ from ayon_maya.api.plugin import get_load_color_for_product_type
 class RedshiftProxyLoader(plugin.Loader):
     """Load Redshift proxy"""
 
-    product_types = {"redshiftproxy"}
-    representations = {"rs"}
+    product_types = {"*"}
+    representations = {"*"}
+    extensions = {"rs", "usd", "usda", "usdc", "abc"}
 
     label = "Import Redshift Proxy"
     order = -10
@@ -42,6 +43,9 @@ class RedshiftProxyLoader(plugin.Loader):
             cmds.namespace(addNamespace=namespace)
             with namespaced(namespace, new=False):
                 nodes, group_node = self.create_rs_proxy(name, path)
+
+        proxy = nodes[0]  # RedshiftProxyMesh
+        self._set_rs_proxy_file_type(proxy, path)
 
         self[:] = nodes
         if not nodes:
@@ -80,6 +84,7 @@ class RedshiftProxyLoader(plugin.Loader):
             cmds.setAttr("{}.fileName".format(rs_mesh),
                          filename,
                          type="string")
+            self._set_rs_proxy_file_type(rs_mesh, path)
 
         # Update metadata
         cmds.setAttr("{}.representation".format(node),
@@ -148,3 +153,40 @@ class RedshiftProxyLoader(plugin.Loader):
             cmds.setAttr("{}.useFrameExtension".format(rs_mesh), 1)
 
         return nodes, group_node
+
+    def _set_rs_proxy_file_type(self, proxy: str, path: str):
+        """Set Redshift Proxy file type attribute based on input file."""
+
+        extension = os.path.splitext(path)[1].lower()
+        file_type = {
+            ".rs": 0,
+            ".usd": 1,
+            ".abc": 2
+        }.get(extension, None)
+
+        # If file type is not recognized, log a warning
+        if file_type is None:
+            self.log.warning("Unknown file type: %s. "
+                             "File Type may be set incorrectly", extension)
+            return
+
+        # If this redshift release (prior to 2025.4.0+) does not have the
+        # `proxyFileType` attribute and the file type is not 0 (rsproxy), then
+        # log a warning
+        if not cmds.attributeQuery("proxyFileType", node=proxy, exists=True):
+            if file_type != 0:
+                self.log.warning(
+                    "Redshift Proxy file type attribute not found. File Type"
+                    " may be set incorrectly. You may need a newer Redshift"
+                    " release (2025.4.0+) to support USD and Alembic in"
+                    " Redshift Proxies. ")
+            return
+
+        cmds.setAttr(proxy + ".proxyFileType", file_type)
+
+    @classmethod
+    def get_representation_name_aliases(cls, representation_name):
+        # Allow switching between the different supported representations
+        # automatically if a newer version does not have the currently used
+        # representation
+        return ["rs", "usd", "abc"]


### PR DESCRIPTION
## Changelog Description

Add support for Redshift Proxy to load `usd` and `abc` files as support has been added in recent Redshift releases 2025.4.0+

## Additional review information

The file type toggle on `RedshiftProxyMesh` appears at the top of the attribute editor:
![image](https://github.com/user-attachments/assets/8f381a52-2013-4955-a481-1f57016f1604)

With this change, the attribute will set as needed so that USD and Alembic files read as intended.

## Testing notes:

1. Loading of RedshiftProxy should work in Redshift 2025.4.0+
2. Updating should also work.
3. In older releases the load option will appear but a warning will be logged in the script editor instead that it's not supported due to the redshift version.
