### PR TITLE
AY-7798 - Allow load image plane to load by file extension instead of representation name

### DIFF
--- a/client/ayon_maya/plugins/load/load_image_plane.py
+++ b/client/ayon_maya/plugins/load/load_image_plane.py
@@ -85,7 +85,8 @@ class ImagePlaneLoader(plugin.Loader):
 
     product_types = {"image", "plate", "render"}
     label = "Load imagePlane"
-    representations = {"mov", "exr", "preview", "png", "jpg", "jpeg"}
+    representations = {"*"}
+    extensions = {"mov", "mp4", "exr", "preview", "png", "jpg", "jpeg"}
     icon = "image"
     color = "orange"
 

--- a/client/ayon_maya/plugins/load/load_image_plane.py
+++ b/client/ayon_maya/plugins/load/load_image_plane.py
@@ -86,7 +86,7 @@ class ImagePlaneLoader(plugin.Loader):
     product_types = {"image", "plate", "render"}
     label = "Load imagePlane"
     representations = {"*"}
-    extensions = {"mov", "mp4", "exr", "preview", "png", "jpg", "jpeg"}
+    extensions = {"mov", "mp4", "exr", "png", "jpg", "jpeg"}
     icon = "image"
     color = "orange"
 


### PR DESCRIPTION
## Changelog Description

Allow load image plane to load by file ext instead of repre name

## Additional review information

Transcoded plate with representation `jpg_jpeg` can now be loaded.

Fix https://github.com/ynput/ayon-maya/issues/277

## Testing notes:

Integrate plate with transcoding set like:
![image](https://github.com/user-attachments/assets/b78ba25d-27f6-4fca-97a8-adecab3aef33)

The transcoded jpeg may now turn to be e.g. `h264_jpeg` or `jpg_jpeg`, but can now actually be loaded as image plane.

---

AY-7798
