### PR TITLE
Reference Maya USD: Avoid automatic up-axis and unit conversions

### DIFF
--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -374,6 +374,10 @@ class MayaUSDReferenceLoader(ReferenceLoader):
             # "startTime=0",
             # "endTime=0",
             # "importUSDZTextures=0"
+            # Avoid any automatic up-axis and unit conversions
+            # TODO: Expose as optional options
+            "upAxis=0",
+            "unit=0"
         ])
         options["file_type"] = self.file_type
 


### PR DESCRIPTION
## Changelog Description

Reference Maya USD: Avoid automatic up-axis and unit conversions

## Additional review information

Maya 2026 comes with a new Maya USD release that supports converting Up-Axis and Unit sizes on USD Import, which also affects the Maya USD referencing that uses "USD Import" in its MPxFileTranslator.

This PR force disables this automatic conversion that Maya 2026 enables by default to have consistent behavior that also matches the older versions - and also because this matches what you see in e.g. Maya USD Proxies that also wouldn't show similar conversions. However, if needed, we could later make this behavior optional and allow users to customize whether they want this enabled or not, but for now this is a quick fix to keep things consistent.

**Note 1:** This only affects NEW loads/references. It doesn't enforce the `options` on "update".

_**Note 2:** that technically this wrong scaling is actually due to the `usdAsset` having unit metadata of 1.0 but the geometry file unit metadata of 0.01 - on reference with the scale conversion enabled maya sees this 1.0 unit, and sees that maya's current scene settings is set to `cm` and hence will convert it. When referencing the geometry file, this scale conversion hence does not occur. I'll create an issue about how we track USD asset units compared to the geometry files, etc._

## Testing notes:

1. Publish USD model from Maya 2026
2. Reference the USD asset.

Without this PR a simple cube for example would come back 100 times too big.