### PR TITLE
Supports to have imagePrefixes for mayahardware

### DIFF
--- a/client/ayon_maya/api/lib_rendersettings.py
+++ b/client/ayon_maya/api/lib_rendersettings.py
@@ -48,7 +48,8 @@ class RenderSettings(object):
             "vray": render_settings["vray_renderer"]["image_prefix"],
             "arnold": render_settings["arnold_renderer"]["image_prefix"],
             "renderman": render_settings["renderman_renderer"]["image_prefix"],
-            "redshift": render_settings["redshift_renderer"]["image_prefix"]
+            "redshift": render_settings["redshift_renderer"]["image_prefix"],
+            "mayahardware2": render_settings["mayahardware_renderer"]["image_prefix"],
         }
 
         # TODO probably should be stored to more explicit attribute

--- a/client/ayon_maya/api/lib_rendersettings.py
+++ b/client/ayon_maya/api/lib_rendersettings.py
@@ -90,7 +90,7 @@ class RenderSettings(object):
             start_frame = cmds.getAttr("defaultRenderGlobals.startFrame")
             cmds.currentTime(start_frame, edit=True)
 
-        if renderer in self._image_prefix_nodess:
+        if renderer in self._image_prefix_nodes:
             prefix = self._image_prefixes[renderer]
             prefix = prefix.replace("{aov_separator}", aov_separator)
             cmds.setAttr(self._image_prefix_nodes[renderer],

--- a/client/ayon_maya/api/lib_rendersettings.py
+++ b/client/ayon_maya/api/lib_rendersettings.py
@@ -49,7 +49,7 @@ class RenderSettings(object):
             "arnold": render_settings["arnold_renderer"]["image_prefix"],
             "renderman": render_settings["renderman_renderer"]["image_prefix"],
             "redshift": render_settings["redshift_renderer"]["image_prefix"],
-            "mayahardware2": render_settings["mayahardware_renderer"]["image_prefix"],
+            "mayahardware2": render_settings["mayahardware2_renderer"]["image_prefix"],
         }
 
         # TODO probably should be stored to more explicit attribute
@@ -90,7 +90,7 @@ class RenderSettings(object):
             start_frame = cmds.getAttr("defaultRenderGlobals.startFrame")
             cmds.currentTime(start_frame, edit=True)
 
-        if renderer in self._image_prefix_nodes:
+        if renderer in self._image_prefix_nodess:
             prefix = self._image_prefixes[renderer]
             prefix = prefix.replace("{aov_separator}", aov_separator)
             cmds.setAttr(self._image_prefix_nodes[renderer],

--- a/server/settings/render_settings.py
+++ b/server/settings/render_settings.py
@@ -287,6 +287,10 @@ class AdditionalOptionsModel(BaseSettingsModel):
     value: str = SettingsField("", title="Value")
 
 
+class MayaHardwareSettingsModel(BaseSettingsModel):
+    image_prefix: str = SettingsField(title="Image prefix template")
+
+
 class ArnoldSettingsModel(BaseSettingsModel):
     image_prefix: str = SettingsField(title="Image prefix template")
     image_format: str = SettingsField(
@@ -467,6 +471,10 @@ class RenderSettingsModel(BaseSettingsModel):
     renderman_renderer: RendermanSettingsModel = SettingsField(
         default_factory=RendermanSettingsModel,
         title="Renderman Renderer")
+    mayahardware_renderer: MayaHardwareSettingsModel = SettingsField(
+        default_factory=MayaHardwareSettingsModel,
+        title="MayaHardware 2.0 Renderer"
+    )
 
 
 DEFAULT_RENDER_SETTINGS = {
@@ -511,5 +519,8 @@ DEFAULT_RENDER_SETTINGS = {
         "cryptomatte_dir": "<imagedir>/<layer>{aov_separator}cryptomatte.<f4>.<ext>",
         "watermark_dir": "<imagedir>/<layer>{aov_separator}watermarkFilter.<f4>.<ext>",
         "additional_options": []
+    },
+    "mayahardware_renderer":{
+        "image_prefix": "<Scene>/<RenderLayer>/<RenderLayer>",
     }
 }

--- a/server/settings/render_settings.py
+++ b/server/settings/render_settings.py
@@ -473,7 +473,7 @@ class RenderSettingsModel(BaseSettingsModel):
         title="Renderman Renderer")
     mayahardware2_renderer: MayaHardwareSettingsModel = SettingsField(
         default_factory=MayaHardwareSettingsModel,
-        title="MayaHardware 2.0 Renderer"
+        title="Maya Hardware 2.0 Renderer"
     )
 
 

--- a/server/settings/render_settings.py
+++ b/server/settings/render_settings.py
@@ -471,7 +471,7 @@ class RenderSettingsModel(BaseSettingsModel):
     renderman_renderer: RendermanSettingsModel = SettingsField(
         default_factory=RendermanSettingsModel,
         title="Renderman Renderer")
-    mayahardware_renderer: MayaHardwareSettingsModel = SettingsField(
+    mayahardware2_renderer: MayaHardwareSettingsModel = SettingsField(
         default_factory=MayaHardwareSettingsModel,
         title="MayaHardware 2.0 Renderer"
     )
@@ -520,7 +520,7 @@ DEFAULT_RENDER_SETTINGS = {
         "watermark_dir": "<imagedir>/<layer>{aov_separator}watermarkFilter.<f4>.<ext>",
         "additional_options": []
     },
-    "mayahardware_renderer":{
+    "mayahardware2_renderer":{
         "image_prefix": "<Scene>/<RenderLayer>/<RenderLayer>",
     }
 }


### PR DESCRIPTION
## Changelog Description
This PR is to add the options for imagePrefix for mayahardware to allow users customizing their outputs.
This also fixes the bug encountered during creating render instance

## Additional review information
n/a
## Testing notes:
1. Make sure you set to Maya Hardware in your render setting(as well as your render camera)
2. Create Render Instance
3. Publish
