### PR TITLE
Validate Maya Units: Support optional toggle in settings

### DIFF
--- a/client/ayon_maya/plugins/publish/validate_maya_units.py
+++ b/client/ayon_maya/plugins/publish/validate_maya_units.py
@@ -35,21 +35,6 @@ class ValidateMayaUnits(plugin.MayaContextPlugin,
     )
     optional = False
 
-    @classmethod
-    def apply_settings(cls, project_settings):
-        """Apply project settings to creator"""
-        settings = (
-            project_settings["maya"]["publish"]["ValidateMayaUnits"]
-        )
-
-        cls.validate_linear_units = settings.get("validate_linear_units",
-                                                 cls.validate_linear_units)
-        cls.linear_units = settings.get("linear_units", cls.linear_units)
-        cls.validate_angular_units = settings.get("validate_angular_units",
-                                                  cls.validate_angular_units)
-        cls.angular_units = settings.get("angular_units", cls.angular_units)
-        cls.validate_fps = settings.get("validate_fps", cls.validate_fps)
-
     def process(self, context):
         if not self.is_active(context.data):
             return


### PR DESCRIPTION
## Changelog Description

Support `optional` state in settings for Validate Maya Units: `ayon+settings://maya/publish/ValidateMayaUnits/optional`

## Additional review information

Setting are automatically applied because it inherits from `MayaContextPlugin` which sets the `settings_category`
I suspect this may also _fix_ the "Enabled" state for the plug-in which likely previously didn't actually work to disable it.

## Testing notes:

1. All overrides for `ayon+settings://maya/publish/ValidateMayaUnits` should still work
2. Optional toggle should now also appear on "Context" entry in Publisher UI when setting is enabled.
