### PR TITLE
Look Assigner: Fix aiStandIn assignment if gpuCache plug-in is unloaded

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4440,3 +4440,23 @@ def force_shader_assignments_to_faces(shapes):
         for shading_engine, original_members in original_assignments.items():
             cmds.sets(clear=shading_engine)
             cmds.sets(original_members, forceElement=shading_engine)
+
+
+def nodetype_exists(nodetype: str):
+    """Return whether node type exists in the current Maya session.
+
+    This returns whether it's registered as a node type to maya, it does not
+    check whether it exists in the current scene.
+
+    Args:
+        nodetype (str): The node type name to check for existence.
+
+    Returns:
+        bool: True if the node type exists, False otherwise.
+    """
+    # If the node type does not exist, Maya will raise a RuntimeError.
+    try:
+        cmds.nodeType(nodetype, isTypeName=True)
+        return True
+    except RuntimeError:
+        return False

--- a/client/ayon_maya/tools/mayalookassigner/app.py
+++ b/client/ayon_maya/tools/mayalookassigner/app.py
@@ -268,17 +268,21 @@ class MayaLookAssignerWindow(QtWidgets.QWidget):
 
             # Assign Arnold Standin look.
             if cmds.pluginInfo("mtoa", query=True, loaded=True):
+                types = arnold_standin.get_supported_node_types()
                 # If the current renderer is Arnold we also allow assigning
                 # to gpuCache nodes. If not, then we skip it because Arnold may
                 # be loaded even if unused as renderer in current project.
-                types = ["aiStandIn"]
                 renderer = cmds.getAttr("defaultRenderGlobals.currentRenderer")
-                if renderer == "arnold":
-                    types.append("gpuCache")
-                arnold_standins = cmds.ls(nodes, type=types, long=True)
-                for standin in arnold_standins:
-                    arnold_standin.assign_look_by_version(
-                        standin, version_id=version_entity["id"])
+                if renderer != "arnold":
+                    types.discard("gpuCache")
+
+                if types:
+                    arnold_standins = cmds.ls(
+                        nodes, type=list(types), long=True
+                    )
+                    for standin in arnold_standins:
+                        arnold_standin.assign_look_by_version(
+                            standin, version_id=version_entity["id"])
 
                 nodes = list(set(nodes).difference(arnold_standins))
             else:

--- a/client/ayon_maya/tools/mayalookassigner/lib.py
+++ b/client/ayon_maya/tools/mayalookassigner/lib.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import json
 import logging
 
@@ -17,8 +18,7 @@ from ayon_maya.api import lib
 log = logging.getLogger(__name__)
 
 
-def get_look_relationships(version_id):
-    # type: (str) -> dict
+def get_look_relationships(version_id: str) -> dict:
     """Get relations for the look.
 
     Args:
@@ -41,8 +41,7 @@ def get_look_relationships(version_id):
     return relationships
 
 
-def load_look(version_id):
-    # type: (str) -> list
+def load_look(version_id: str) -> tuple[list[str], str]:
     """Load look from version.
 
     Get look from version and invoke Loader for it.
@@ -51,7 +50,7 @@ def load_look(version_id):
         version_id (str): Version ID
 
     Returns:
-        list of shader nodes.
+        tuple[list[str], str]: List of loaded nodes and container node name.
 
     """
 


### PR DESCRIPTION
## Changelog Description

Fix bug where `aiStandIn` nodes could not be assigned a look if `gpuCache` plug-in was not loaded.

This was due to `cmds.ls(type=["aiStandIn", "gpuCache"])` failing to return `aiStandIn` nodes if `gpuCache` node type does not exist. Now we filter out the types that do not exist.

- Introduced `nodetype_exists` function to verify if a node type is registered in the current Maya session.
- Added `arnold_standin.get_supported_node_types` to return only existing node types for look assignment.
- Refactored type hints for better clarity and consistency.

## Additional review information

...

## Testing notes:

1. Make sure your current renderer is set to Arnold.
2. Unload `gpuCache.mll` (gpuCache plug-in)
3. Load an `aiStandIn`
4. Assign look.

It should work.

1. Load the same Alembic as `gpuCache` via loader
2. Assign look (if current renderer is arnold) should also still work.
