### PR TITLE
Import Loader: Relabel `Clean Import` to `Strip existing AYON asset metadata`

### DIFF
--- a/client/ayon_maya/plugins/load/actions.py
+++ b/client/ayon_maya/plugins/load/actions.py
@@ -1,8 +1,8 @@
 """A module containing generic loader actions that will display in the Loader.
 
 """
-import qargparse
 from ayon_core.pipeline import load
+from ayon_core.lib import BoolDef
 from ayon_maya.api.lib import (
     maintained_selection,
     get_custom_namespace
@@ -117,11 +117,14 @@ class ImportMayaLoader(ayon_maya.api.plugin.Loader):
     color = "#775555"
 
     options = [
-        qargparse.Boolean(
+        BoolDef(
             "clean_import",
-            label="Clean import",
+            label="Strip existing AYON asset metadata",
             default=False,
-            help="Should all occurrences of cbId be purged?"
+            tooltip=(
+                "When enabled, existing AYON 'cbId' attributes on nodes will "
+                "be removed upon import."
+            )
         )
     ]
 


### PR DESCRIPTION
## Changelog Description

Import Loader: Relabel `Clean Import` to `Strip existing AYON asset metadata`

## Additional review information

Also improve the tooltip and use `BoolDef` instead of the legacy `qargparse` dependency.

## Testing notes:

1. Import option box should be clearer.
2. The option box checkbox should still work.