### PR TITLE
Add namespace attribute for the arnold standin when load

### DIFF
--- a/client/ayon_maya/plugins/load/load_arnold_standin.py
+++ b/client/ayon_maya/plugins/load/load_arnold_standin.py
@@ -99,7 +99,7 @@ class ArnoldStandinLoader(plugin.Loader):
             cmds.setAttr(standin_shape + ".dso", path, type="string")
             sequence = is_sequence(os.listdir(os.path.dirname(repre_path)))
             cmds.setAttr(standin_shape + ".useFrameExtension", sequence)
-            cmds.setAttr(standin_shape + ".aiNamespace", namespace)
+            cmds.setAttr(standin_shape + ".aiNamespace", namespace, type="string")
 
             fps = (
                 version_attributes.get("fps") or get_fps_for_current_context()

--- a/client/ayon_maya/plugins/load/load_gpucache.py
+++ b/client/ayon_maya/plugins/load/load_gpucache.py
@@ -54,6 +54,10 @@ class GpuCacheLoader(plugin.Loader):
         path = self.filepath_from_context(context)
         cmds.setAttr(cache + '.cacheFileName', path, type="string")
         cmds.setAttr(cache + '.cacheGeomPath', "|", type="string")    # root
+        if cmds.attributeQuery("aiNamespace", node=cache, exists=True):
+            # Set Arnold namespace attribute to ensure shaders are loaded uniquely
+            # when a gpu cache is loaded multiple times
+            cmds.setAttr(cache + '.aiNamespace', namespace, type="string")
 
         # Lock parenting of the transform and cache
         cmds.lockNode([transform, cache], lock=True)


### PR DESCRIPTION
## Changelog Description
This PR is to fix the issue found in https://github.com/ynput/ayon-maya/pull/289 when loading both gpuCache and ArnoldStandIn and using look assigner.

## Additional review information
Detailed information of the changes made to the product or service, providing an in-depth description of the updates and enhancements. This can include technical information, code examples and anything else needed for the review of the PR.

## Testing notes:
1. Load Ass and gpuCache assets
2. Load Look
3. Use look assigner to assign the shaders for both assets
