### PR TITLE
Use long names in `maintained_selection()`

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -138,7 +138,7 @@ def maintained_selection():
 
     """
 
-    previous_selection = cmds.ls(selection=True)
+    previous_selection = cmds.ls(selection=True, long=True)
     try:
         yield
     finally:


### PR DESCRIPTION
## Changelog Description

Use long names in `maintained_selection()` to avoid clashes with new nodes coming in during the context with similar object names

## Additional review information

Mentioned originally here: https://discord.com/channels/517362899170230292/517382145552154634/1359111623066779811

## Testing notes:

1. Publishing and loading should still work as usual
