### PR TITLE
Only process `dagNode` type in `get_highest_in_hierarchy`

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -2179,17 +2179,18 @@ def get_highest_in_hierarchy(nodes):
     """Return highest nodes in the hierarchy that are in the `nodes` list.
 
     The "highest in hierarchy" are the nodes closest to world: top-most level.
+    The result only contains DAG nodes.
 
     Args:
-        nodes (list): The nodes in which find the highest in hierarchies.
+        nodes (list[str]): The nodes in which find the highest in hierarchies.
 
     Returns:
-        list: The highest nodes from the input nodes.
+        list[str]: The highest DAG nodes from the input nodes.
 
     """
 
     # Ensure we use long names
-    nodes = cmds.ls(nodes, long=True)
+    nodes = cmds.ls(nodes, long=True, type="dagNode")
     lookup = set(nodes)
 
     highest = []


### PR DESCRIPTION
## Changelog Description

Only process `dagNode` type in `get_highest_in_hierarchy` because dependency nodes would otherwise always appear as a 'highest' object even though they are not hierarchical.

Note that we filter by `type="dagNode"` instead of `dag=True` in `cmds.ls` because `dag=True` extends the returned list to include all its children, which would return way more data then we care about and which the function would then just end up processing to directly filter out again.

## Additional review information

Mentioned originally here: https://discord.com/channels/517362899170230292/517382145552154634/1359111623066779811

## Testing notes:

1. Publishing and loading should continue to work
2. Specifically test exporting alembics with `includeParentHierarchy` disabled.