### PR TITLE
Adding debug message for render product in Collect Render

### DIFF
--- a/client/ayon_maya/plugins/publish/collect_render.py
+++ b/client/ayon_maya/plugins/publish/collect_render.py
@@ -116,6 +116,7 @@ class CollectMayaRender(plugin.MayaInstancePlugin):
         expected_files = []
         multipart = False
         for product in render_products:
+            self.log.debug(f"Getting render product: {product}")
             if product.multipart:
                 multipart = True
             product_name = product.productName


### PR DESCRIPTION
## Changelog Description
This PR is to add debug message for render product in Collect Render to make sure the extension format lasted in the dictionary.
Fixes https://github.com/ynput/ayon-maya/issues/294

## Additional review information
This PR is already tested. 

## Testing notes:
1. Create Render Instance
2.Publish
3. Check rendermetada.JSON for ext present