### PR TITLE
Skip non-dag nodes in `get_all_children`

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -3971,7 +3971,7 @@ def get_all_children(nodes, ignore_intermediate_objects=False):
     focus on a fast query.
 
     Args:
-        nodes (iterable): List of nodes to get children for.
+        nodes (iterable[str]): List of nodes to get children for.
         ignore_intermediate_objects (bool): Ignore any children that
             are intermediate objects.
 
@@ -3979,7 +3979,6 @@ def get_all_children(nodes, ignore_intermediate_objects=False):
         set: Children of input nodes.
 
     """
-
     sel = OpenMaya.MSelectionList()
     traversed = set()
     iterator = OpenMaya.MItDag(OpenMaya.MItDag.kDepthFirst)
@@ -3993,6 +3992,11 @@ def get_all_children(nodes, ignore_intermediate_objects=False):
 
         sel.clear()
         sel.add(node)
+        obj = sel.getDependNode(0)
+        if not obj.hasFn(OpenMaya.MFn.kDagNode):
+            # Not a dag node, skip
+            continue
+
         dag = sel.getDagPath(0)
 
         iterator.reset(dag)


### PR DESCRIPTION
## Changelog Description

Skip non-dag nodes in `get_all_children`

## Additional review information

Avoids error `TypeError: item is not a DAG path`

Fix #297

## Testing notes:

1. Publish a rig with an objectSet inside the `out_SET` of the rig
2. Then with that rig loaded, try to publish animation.

It should pass and allow publishing.