### PR TITLE
use `getStage` without passing `|world`

### DIFF
--- a/client/ayon_maya/plugins/create/create_maya_usd_layer.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd_layer.py
@@ -23,7 +23,7 @@ class CreateMayaUsdLayer(plugin.MayaCreator):
         # scene and the Sdf.Layer stack of the Usd.Stage per proxy.
         items = []
         for proxy in cmds.ls(type="mayaUsdProxyShape", long=True):
-            stage = mayaUsd.ufe.getStage("|world{}".format(proxy))
+            stage = mayaUsd.ufe.getStage(proxy)
             if not stage:
                 continue
 

--- a/client/ayon_maya/plugins/publish/extract_maya_usd_layer.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd_layer.py
@@ -30,7 +30,7 @@ class ExtractMayaUsdLayer(publish.Extractor):
         # TODO: The stage and layer should actually be retrieved during
         #  Collecting so that they can be validated upon and potentially that
         #  any 'child layers' can potentially be recursively exported along
-        stage = mayaUsd.ufe.getStage('|world' + proxy)
+        stage = mayaUsd.ufe.getStage(proxy)
         layers = stage.GetLayerStack(includeSessionLayers=False)
         layer = next(
             layer for layer in layers if layer.identifier == layer_identifier


### PR DESCRIPTION
## Changelog Description
resolve #299

![Animation_1034](https://github.com/user-attachments/assets/29c44fe2-0cbe-4852-9e0c-edab7e5562c6)

## Additional Info
I'm on Maya 2026. I've no idea if this fix is for this maya version in particular.

## Testing notes:
1. create a stage
2. use `Maya USD Export Layer` creator.
3. pick any layer you want in publish tab.
4. publishing should be as expected.
