### PR TITLE
Add create first version and keep placeholders settings to Templated Workfile Build 

### DIFF
--- a/server/settings/templated_workfile_settings.py
+++ b/server/settings/templated_workfile_settings.py
@@ -16,6 +16,13 @@ class WorkfileBuildProfilesModel(BaseSettingsModel):
         default_factory=list, title="Task names"
     )
     path: str = SettingsField("", title="Path to template")
+    keep_placeholder: bool = SettingsField(
+        False,
+        title="Keep placeholders")
+    create_first_version: bool = SettingsField(
+        True,
+        title="Create first version"
+    )
 
 
 class TemplatedProfilesModel(BaseSettingsModel):


### PR DESCRIPTION
## Changelog Description

Add create first version and keep placeholders settings to Templated Workfile Build settings in Maya, to match e.g. `ayon-nuke` and other integrations

## Additional review information

Came up here: https://discord.com/channels/517362899170230292/563751989075378201/1387011018206609498

## Testing notes:
1. The added "create first version" and "keep placeholders" templated workfile build settings should work.