### PR TITLE
Add input connection and up-axis settings for Collect Fbx camera

### DIFF
--- a/client/ayon_maya/plugins/publish/collect_fbx_camera.py
+++ b/client/ayon_maya/plugins/publish/collect_fbx_camera.py
@@ -2,7 +2,14 @@
 import pyblish.api
 from ayon_maya.api import plugin
 from ayon_core.pipeline.publish import OptionalPyblishPluginMixin
+from ayon_core.lib import (
+    UISeparatorDef,
+    UILabelDef,
+    EnumDef,
+    BoolDef
+)
 from maya import cmds  # noqa
+
 
 
 class CollectFbxCamera(plugin.MayaInstancePlugin,
@@ -13,6 +20,8 @@ class CollectFbxCamera(plugin.MayaInstancePlugin,
     label = "Collect Camera for FBX export"
     families = ["camera"]
     optional = False
+    input_connections = True
+    up_axis = "y"
 
     def process(self, instance):
         if not self.is_active(instance.data):
@@ -25,3 +34,38 @@ class CollectFbxCamera(plugin.MayaInstancePlugin,
             instance.data["families"].append("fbx")
 
         instance.data["cameras"] = True
+
+        attribute_values = self.get_attr_values_from_data(
+            instance.data
+        )
+
+        instance.data["upAxis"] = attribute_values.get(
+            "upAxis", self.up_axis)
+        instance.data["inputConnections"] = attribute_values.get(
+            "inputConnections", self.input_connections)
+
+    @classmethod
+    def get_attribute_defs(cls):
+        defs = [
+            UISeparatorDef("sep_fbx_options"),
+            UILabelDef("Fbx Options"),
+        ]
+        defs.extend(
+            super().get_attribute_defs() + [
+            EnumDef("upAxis",
+                    items=["y", "z"],
+                    label="Up Axis",
+                    default=cls.up_axis,
+                    tooltip="Convert the scene's orientation in your FBX file"),
+            BoolDef("inputConnections",
+                    label="Input Connections",
+                    default=cls.input_connections,
+                    tooltip=(
+                        "Whether input connections to "
+                        "selected objects are to be exported."
+                        ),
+                    ),
+            UISeparatorDef("sep_fbx_options_end")
+        ])
+
+        return defs

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -162,8 +162,15 @@ class CollectFbxAnimationModel(BaseSettingsModel):
         enum_resolver=up_axis_enum, title="Up Axis"
     )
 
+
 class CollectFbxCameraModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="CollectFbxCamera")
+    optional: bool = SettingsField(title="Optional")
+    active: bool = SettingsField(title="Active")
+    input_connections: bool = SettingsField(True, title="Input Connections")
+    up_axis: str = SettingsField(
+        enum_resolver=up_axis_enum, title="Up Axis"
+    )
 
 
 class CollectGLTFModel(BaseSettingsModel):
@@ -639,8 +646,8 @@ class PublishersModel(BaseSettingsModel):
         default_factory=CollectFbxAnimationModel,
         title="Collect FBX Animation",
     )
-    CollectFbxCamera: BasicValidateModel = SettingsField(
-        default_factory=BasicValidateModel,
+    CollectFbxCamera: CollectFbxCameraModel = SettingsField(
+        default_factory=CollectFbxCameraModel,
         title="Collect Camera for FBX export",
     )
     CollectFbxModel: BasicValidateModel = SettingsField(
@@ -1116,7 +1123,9 @@ DEFAULT_PUBLISH_SETTINGS = {
     "CollectFbxCamera": {
         "enabled": False,
         "optional": True,
-        "active": True
+        "active": True,
+        "input_connections": True,
+        "up_axis": "y"
     },
     "CollectFbxModel": {
         "enabled": False,

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -1122,7 +1122,7 @@ DEFAULT_PUBLISH_SETTINGS = {
     },
     "CollectFbxCamera": {
         "enabled": False,
-        "optional": True,
+        "optional": False,
         "active": True,
         "input_connections": True,
         "up_axis": "y"


### PR DESCRIPTION
## Changelog Description
This PR is to add input connection and up-axis settings to Collect Fbx camera so that users can set up their own preferred settings for the camera export in fbx format. It is beneficial when the users want to export the camera at z-up axis and loading it correctly in Unreal.
Resolve https://github.com/ynput/ayon-maya/issues/261

## Additional review information
n/a

## Testing notes:
1. Create Camera
2. Enable `ayon+settings://maya/publish/CollectFbxCamera`
3. Publish with up-axis as `z` and input collection as `True`
4. Launch Unreal
5. Load camera
