### PR TITLE
Support creating first workfile with TemplateBuilder

### DIFF
--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -45,6 +45,10 @@ from ayon_core.pipeline.workfile.lock_workfile import (
     is_workfile_locked,
     is_workfile_lock_enabled
 )
+from ayon_core.pipeline.workfile.workfile_template_builder import (
+    TemplateProfileNotFound
+)
+
 from ayon_maya import MAYA_ROOT_DIR
 from ayon_maya.lib import create_workspace_mel
 
@@ -661,8 +665,14 @@ def on_new():
     with lib.suspended_refresh():
         lib.set_context_settings()
 
-    workfile_template_builder.build_workfile_template(
-        workfile_creation_enabled=True)
+    try:
+        workfile_template_builder.build_workfile_template(
+            workfile_creation_enabled=True)
+    except TemplateProfileNotFound:
+        log.debug(
+            "No workfile template profile enabled for current context. "
+            "Skipping workfile creation."
+        )
     _remove_workfile_lock()
 
 

--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -45,14 +45,11 @@ from ayon_core.pipeline.workfile.lock_workfile import (
     is_workfile_locked,
     is_workfile_lock_enabled
 )
-from ayon_core.pipeline.workfile.workfile_template_builder import (
-    TemplateProfileNotFound
-)
 
 from ayon_maya import MAYA_ROOT_DIR
 from ayon_maya.lib import create_workspace_mel
 
-from . import menu, lib, workfile_template_builder
+from . import menu, lib
 from .workio import (
     open_file,
     save_file,
@@ -666,14 +663,6 @@ def on_new():
     with lib.suspended_refresh():
         lib.set_context_settings()
 
-    try:
-        workfile_template_builder.build_workfile_template(
-            workfile_creation_enabled=True)
-    except TemplateProfileNotFound:
-        log.debug(
-            "No workfile template profile enabled for current context. "
-            "Skipping workfile creation."
-        )
     _remove_workfile_lock()
 
 

--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -48,7 +48,7 @@ from ayon_core.pipeline.workfile.lock_workfile import (
 from ayon_maya import MAYA_ROOT_DIR
 from ayon_maya.lib import create_workspace_mel
 
-from . import menu, lib
+from . import menu, lib, workfile_template_builder
 from .workio import (
     open_file,
     save_file,
@@ -661,6 +661,8 @@ def on_new():
     with lib.suspended_refresh():
         lib.set_context_settings()
 
+    workfile_template_builder.build_workfile_template(
+        workfile_creation_enabled=True)
     _remove_workfile_lock()
 
 

--- a/client/ayon_maya/api/workfile_template_builder.py
+++ b/client/ayon_maya/api/workfile_template_builder.py
@@ -246,9 +246,9 @@ class MayaPlaceholderPlugin(PlaceholderPlugin):
         return data
 
 
-def build_workfile_template(*args):
+def build_workfile_template(*args, **kwargs):
     builder = MayaTemplateBuilder(registered_host())
-    builder.build_template()
+    builder.build_template(*args, **kwargs)
 
 
 def update_workfile_template(*args):

--- a/client/ayon_maya/startup/userSetup.py
+++ b/client/ayon_maya/startup/userSetup.py
@@ -2,7 +2,10 @@ import os
 
 from ayon_core.settings import get_project_settings
 from ayon_core.pipeline import install_host, get_current_project_name
-from ayon_maya.api import MayaHost
+from ayon_maya.api import MayaHost, workfile_template_builder
+from ayon_core.pipeline.workfile.workfile_template_builder import (
+    TemplateProfileNotFound
+)
 
 from maya import cmds
 
@@ -39,8 +42,19 @@ key = "AYON_OPEN_WORKFILE_POST_INITIALIZATION"
 if bool(int(os.environ.get(key, "0"))):
     def _log_and_open():
         path = os.environ["AYON_LAST_WORKFILE"]
-        print("Opening \"{}\"".format(path))
-        cmds.file(path, open=True, force=True)
+        if os.path.exists(path):
+            print("Opening \"{}\"".format(path))
+            cmds.file(path, open=True, force=True)
+        else:
+            try:
+                workfile_template_builder.build_workfile_template(
+                    workfile_creation_enabled=True)
+            except TemplateProfileNotFound:
+                print(
+                    "No workfile template profile enabled for current context. "
+                    "Skipping workfile creation."
+                )
+            
     cmds.evalDeferred(
         _log_and_open,
         lowestPriority=True

--- a/server/settings/templated_workfile_settings.py
+++ b/server/settings/templated_workfile_settings.py
@@ -16,6 +16,13 @@ class WorkfileBuildProfilesModel(BaseSettingsModel):
         default_factory=list, title="Task names"
     )
     path: str = SettingsField("", title="Path to template")
+    keep_placeholder: bool = SettingsField(
+        False,
+        title="Keep placeholders")
+    create_first_version: bool = SettingsField(
+        True,
+        title="Create first version"
+    )
 
 
 class TemplatedProfilesModel(BaseSettingsModel):


### PR DESCRIPTION
## Changelog Description
Supports creating the first initial workfile version from a built template.

## Additional review information
This picks up and continues https://github.com/ynput/ayon-maya/pull/301.
I took the following commit as reference https://github.com/ynput/ayon-houdini/commit/65db6d34639e9ebf22b477bbaca9c3cd87f8c077

When testing u have to build and upload this addon as it contains server-side settings changes ⚠️

## Testing notes:
1. configure a templated workfile for maya with `create_first_version = True`
2. launch maya from a task that atm has 0 workfiles
3. check that your template gets applied accordingly
4. check the workfile is saved as initial v01 in your work-drive

*now falsify*
1. use before created template but set `create_first_version = False`
2. check that the workfile still gets applied but no workfile is saved

*and check already imported templates*
1. open up a workfile that already has your template applied
2. apply the same again
3. check script editor that it intentionally didn't do anything
