### PR TITLE
Reduce task entity and project settings queries on context resets or maya startup

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -3280,7 +3280,7 @@ def update_content_on_context_change():
 
     instance_values = {
         "folderPath": create_context.get_current_folder_path(),
-        "task": create_context.get_current_task_name(),
+        "task": task_entity["name"],
     }
     creator_attribute_values = {
         "frameStart": float(task_entity["attrib"]["frameStart"]),


### PR DESCRIPTION
## Changelog Description

Re-use task entity and project settings whenever we can on resetting context attributes.

## Additional review information

All the FPS, frame range, resolution, etc. resets on context change (save to another context) or when starting Maya should still continue to work and be faster too.

## Testing notes:

1. All the FPS, frame range, resolution, etc. resets on context change (save to another context) or when starting Maya should still continue to work and be faster too.