### PR TITLE
Publish: Use new workfiles API to increment current workfile.

### DIFF
--- a/client/ayon_maya/plugins/publish/increment_current_file_deadline.py
+++ b/client/ayon_maya/plugins/publish/increment_current_file_deadline.py
@@ -26,7 +26,7 @@ class IncrementCurrentFileDeadline(plugin.MayaContextPlugin):
             folder_entity=context.data["folderEntity"],
             task_entity=context.data["taskEntity"],
             description=f"Incremented by publishing.",
-            # Optimize the save by not reducing needed queries for context
+            # Optimize the save by reducing needed queries for context
             prepared_data=SaveWorkfileOptionalData(
                 project_entity=context.data["projectEntity"],
                 project_settings=context.data["project_settings"],


### PR DESCRIPTION
## Changelog Description

When incrementing the workfile during publish, use the new context-based workfile API so that the current author information is stored with the saved file.

## Additional review information

Pending PR: https://github.com/ynput/ayon-core/pull/1275

## Testing notes:

1. Publishing should work
2. Workfile should be incremented
3. Workfile should show the author of the publish 
4. Workfile should have 'artist note' set: "Incremented by publishing."
