### PR TITLE
Workfile: Can be set as mandatory

### DIFF
--- a/client/ayon_maya/plugins/create/create_workfile.py
+++ b/client/ayon_maya/plugins/create/create_workfile.py
@@ -14,6 +14,7 @@ class CreateWorkfile(plugin.MayaCreatorBase, AutoCreator):
 
     default_variant = "Main"
 
+    settings_category = "maya"
     is_mandatory = False
 
     def create(self):

--- a/client/ayon_maya/plugins/create/create_workfile.py
+++ b/client/ayon_maya/plugins/create/create_workfile.py
@@ -14,6 +14,8 @@ class CreateWorkfile(plugin.MayaCreatorBase, AutoCreator):
 
     default_variant = "Main"
 
+    is_mandatory = False
+
     def create(self):
 
         variant = self.default_variant
@@ -74,6 +76,11 @@ class CreateWorkfile(plugin.MayaCreatorBase, AutoCreator):
             current_instance["folderPath"] = folder_path
             current_instance["task"] = task_name
             current_instance["productName"] = product_name
+
+        # The 'mandatory' functionality is available since ayon-core 1.4.1
+        #   or later.
+        if hasattr(current_instance, "set_mandatory"):
+            current_instance.set_mandatory(self.is_mandatory)
 
     def collect_instances(self):
         self.cache_instance_data(self.collection_shared_data)

--- a/server/settings/creators.py
+++ b/server/settings/creators.py
@@ -5,6 +5,17 @@ from ayon_server.settings import (
 )
 
 
+class CreateWorkfileModel(BaseSettingsModel):
+    is_mandatory: bool = SettingsField(
+        False,
+        title="Mandatory workfile",
+        description=(
+            "Workfile cannot be disabled by user in UI."
+            " Requires core addon 1.4.1 or newer."
+        )
+    )
+
+
 class CreateLookModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="Enabled")
     make_tx: bool = SettingsField(title="Make tx files")
@@ -152,6 +163,10 @@ class CreatorsModel(BaseSettingsModel):
         )
     )
 
+    CreateWorkfile: CreateWorkfileModel = SettingsField(
+        default_factory=CreateWorkfileModel,
+        title="Create Workfile"
+    )
     CreateLook: CreateLookModel = SettingsField(
         default_factory=CreateLookModel,
         title="Create Look"


### PR DESCRIPTION
## Changelog Description
Workfile entity can be set as mandatory.

## Additional review information
This PR requires https://github.com/ynput/ayon-core/pull/1360 to be able to work. Is backwards compatible, it just won't do anything before that.

## Testing notes:
1. Change setting of `ayon+settings://maya/create/CreateWorkfile/is_mandatory` to `True`
2. Launch maya and open publisher.
3. Workfile instance won't have enabled checkbox and is always published.
