### PR TITLE
Support of Texture Reference Objects in Look Publish

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4573,7 +4573,7 @@ def apply_connections(connections, target_nodes_by_id, source_nodes_by_id):
     for connection in connections:
         source_node = next(
             iter(source_nodes_by_id.get(
-            connections["sourceID"], [])
+            connection["sourceID"], [])
             ), None
         )
 

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -2054,7 +2054,7 @@ def apply_shaders(relationships, shadernodes, nodes):
 
     # check if there is texture references input and connect the texture
     # reference back to the nodes
-    texture_references_input = relationships.get("texture_connections", [])
+    texture_references_input = relationships.get("connections", [])
     connect_texture_reference_objects(texture_references_input, nodes_by_id)
 
     # endregion
@@ -4562,8 +4562,8 @@ def connect_texture_reference_objects(texture_connections, nodes_by_id):
     """
     # Compare loaded connections to scene.
     for texture_connection in texture_connections:
-        source_node = nodes_by_id.get(input["sourceID"])
-        target_node = nodes_by_id.get(input["destinationID"])
+        source_node = nodes_by_id.get(texture_connection["sourceID"])
+        target_node = nodes_by_id.get(texture_connection["destinationID"])
 
         if not source_node or not target_node:
             self.log.debug(

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4577,7 +4577,7 @@ def apply_connections(connections, target_nodes_by_id, source_nodes_by_id):
             ), None
         )
 
-        target_nodes = target_nodes_by_id.get(connections["destinationID"], [])
+        target_nodes = target_nodes_by_id.get(connection["destinationID"], [])
 
         if not source_node or not target_nodes:
             self.log.debug(

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4601,12 +4601,8 @@ def connect_texture_reference_objects(texture_reference_inputs, nodes_by_id):
                     )
                 )
             )
-            continue
-
-        source_plug = "{}.{}".format(
-            source_node, source_attr
-        )
-        target_plug = "{}.{}".format(
+        source_plug = f"{source_node}.{source_attr}"
+        target_plug = f"{target_node}.{target_attr}"
             target_node, target_attr
         )
         if cmds.isConnected(

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4572,8 +4572,17 @@ def connect_texture_reference_objects(
     """
     # Compare loaded connections to scene.
     for texture_connection in texture_connections:
-        source_node = tx_ref_nodes_by_id.get(texture_connection["sourceID"])[0]
-        target_node = nodes_by_id.get(texture_connection["destinationID"])[0]
+        source_node = next(
+            iter(tx_ref_nodes_by_id.get(
+            texture_connection["sourceID"], [])
+            ), None
+        )
+
+        target_node = next(
+            iter(nodes_by_id.get(texture_connection["destinationID"], [])
+            ), None
+        )
+
 
         if not source_node or not target_node:
             self.log.debug(

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4558,12 +4558,12 @@ def connect_texture_reference_objects(texture_reference_inputs, nodes_by_id):
     Args:
         texture_reference_inputs (list): list of texture reference
         objects connection data
-        node_by_ids ()
+        node_by_id (dict): The dict with node ids.
     """
     # Compare loaded connections to scene.
     for reference_input in texture_reference_inputs:
-        source_node = nodes_by_ids.get(input["sourceID"])
-        target_node = nodes_by_ids.get(input["destinationID"])
+        source_node = node_by_id.get(input["sourceID"])
+        target_node = node_by_id.get(input["destinationID"])
 
         if not source_node or not target_node:
             self.log.debug(

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4558,6 +4558,7 @@ def connect_texture_reference_objects(texture_reference_inputs, nodes_by_id):
     Args:
         texture_reference_inputs (list): list of texture reference
         objects connection data
+        node_by_ids ()
     """
     # Compare loaded connections to scene.
     for reference_input in texture_reference_inputs:

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4559,81 +4559,81 @@ def get_scene_units_settings(project_settings=None)-> tuple[str, str]:
     return linear_unit, angular_unit
 
 
-def apply_connections(texture_connections, nodes_by_id, texture_nodes_by_id):
+def apply_connections(connections, target_nodes_by_id, source_nodes_by_id):
     """Connect texture reference object nodes to the target object
     nodes if there is one.
 
     Args:
-        texture_connections (list): list of texture reference
+        connections (list): list of texture reference
         objects connection data
-        nodes_by_id (dict): The dict with node ids.
-        texture_nodes_by_id (dict): The dict with texture reference node ids.
+        target_nodes_by_id (dict): The dict with target shape node ids
+        source_nodes_by_id (dict): The dict with texture reference node ids.
     """
     # Compare loaded connections to scene.
-    for texture_connection in texture_connections:
-        texture_object_node = next(
-            iter(texture_nodes_by_id.get(
-            texture_connection["sourceID"], [])
+    for connection in connections:
+        source_node = next(
+            iter(source_nodes_by_id.get(
+            connections["sourceID"], [])
             ), None
         )
 
-        shape_nodes = nodes_by_id.get(texture_connection["destinationID"], [])
+        target_nodes = target_nodes_by_id.get(connections["destinationID"], [])
 
-        if not texture_object_node or not shape_nodes:
+        if not source_node or not target_nodes:
             self.log.debug(
                 "Could not find nodes for reference input:\n" +
-                json.dumps(texture_connection, indent=4, sort_keys=True)
+                json.dumps(connection, indent=4, sort_keys=True)
             )
             continue
-        texture_object_attr, shape_nodes_attr = texture_connection["connections"]
+        source_attr, target_attr = connection["connections"]
 
         if not cmds.attributeQuery(
-            texture_object_attr, node=texture_object_node, exists=True
+            source_attr, node=source_node, exists=True
         ):
             self.log.debug(
                 "Could not find attribute {} on node {} for "
                 "reference input:\n{}".format(
-                    texture_object_attr,
-                    texture_object_node,
+                    source_attr,
+                    source_node,
                     json.dumps(
-                        texture_connection, indent=4, sort_keys=True
+                        connection, indent=4, sort_keys=True
                     )
                 )
             )
             continue
 
-        for shape_node in shape_nodes:
+        for target_node in target_nodes:
             if not cmds.attributeQuery(
-                shape_nodes_attr, node=shape_node, exists=True
+                target_attr, node=target_node, exists=True
             ):
                 self.log.debug(
                     "Could not find attribute {} on node {} for "
                     "reference input:\n{}".format(
-                        shape_nodes_attr,
-                        shape_node,
+                        target_attr,
+                        target_node,
                         json.dumps(
-                            texture_connection, indent=4, sort_keys=True
+                            connection, indent=4, sort_keys=True
                         )
                     )
                 )
                 continue
 
-            texture_obj_plug = f"{texture_object_node}.{texture_object_attr}"
-            shape_plug = f"{shape_node}.{shape_nodes_attr}"
+            source_plug = f"{source_node}.{source_attr}"
+            target_plug = f"{target_node}.{target_attr}"
 
             if cmds.isConnected(
-                texture_obj_plug, shape_plug, ignoreUnitConversion=True
+                source_plug, target_plug, ignoreUnitConversion=True
             ):
                 self.log.debug(
                     "Connection already exists: {} -> {}".format(
-                        texture_obj_plug, shape_plug
+                        source_plug, target_plug
                     )
                 )
                 continue
 
-            cmds.connectAttr(texture_obj_plug, shape_plug, force=True)
+            cmds.connectAttr(source_plug, target_plug, force=True)
             self.log.debug(
                 "Connected attributes: {} -> {}".format(
-                    texture_obj_plug, shape_plug
+                    source_plug, target_plug
                 )
             )

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -2011,7 +2011,7 @@ def apply_shaders(relationships, shadernodes, nodes):
     shading_engines = cmds.ls(shadernodes, type="objectSet", long=True)
     assert shading_engines, "Error in retrieving objectSets from reference"
 
-    tx_ref_nodes = cmds.ls(shadernodes, type="mesh", long=True)
+    shader_mesh_nodes = cmds.ls(shadernodes, type="mesh", long=True)
     # region compute lookup
     nodes_by_id = defaultdict(list)
     for node in nodes:
@@ -2021,9 +2021,9 @@ def apply_shaders(relationships, shadernodes, nodes):
     for shad in shading_engines:
         shading_engines_by_id[get_id(shad)].append(shad)
 
-    tx_ref_nodes_by_id = defaultdict(list)
-    for tx_ref_node in tx_ref_nodes:
-        tx_ref_nodes_by_id[get_id(tx_ref_node)].append(tx_ref_node)
+    target_nodes_by_id = defaultdict(list)
+    for mesh_node in shader_mesh_nodes:
+        target_nodes_by_id[get_id(mesh_node)].append(mesh_node)
 
     # endregion
 
@@ -2061,8 +2061,8 @@ def apply_shaders(relationships, shadernodes, nodes):
     # check if there is texture references input and connect the texture
     # reference back to the nodes
     texture_references_input = relationships.get("connections", [])
-    connect_texture_reference_objects(
-        texture_references_input, nodes_by_id, tx_ref_nodes_by_id
+    apply_connections(
+        texture_references_input, nodes_by_id, target_nodes_by_id
     )
 
     # endregion
@@ -4559,8 +4559,7 @@ def get_scene_units_settings(project_settings=None)-> tuple[str, str]:
     return linear_unit, angular_unit
 
 
-def connect_texture_reference_objects(
-        texture_connections, nodes_by_id, tx_ref_nodes_by_id):
+def apply_connections(texture_connections, nodes_by_id, target_nodes_by_id):
     """Connect texture reference object nodes to the target object
     nodes if there is one.
 
@@ -4568,23 +4567,19 @@ def connect_texture_reference_objects(
         texture_connections (list): list of texture reference
         objects connection data
         nodes_by_id (dict): The dict with node ids.
-        tx_ref_nodes_by_id (dict): The dict with texture reference node ids.
+        target_nodes_by_id (dict): The dict with texture reference node ids.
     """
     # Compare loaded connections to scene.
     for texture_connection in texture_connections:
         source_node = next(
-            iter(tx_ref_nodes_by_id.get(
+            iter(target_nodes_by_id.get(
             texture_connection["sourceID"], [])
             ), None
         )
 
-        target_node = next(
-            iter(nodes_by_id.get(texture_connection["destinationID"], [])
-            ), None
-        )
+        target_nodes = nodes_by_id.get(texture_connection["destinationID"], [])
 
-
-        if not source_node or not target_node:
+        if not source_node or not target_nodes:
             self.log.debug(
                 "Could not find nodes for reference input:\n" +
                 json.dumps(texture_connection, indent=4, sort_keys=True)
@@ -4607,35 +4602,38 @@ def connect_texture_reference_objects(
             )
             continue
 
-        if not cmds.attributeQuery(
-            target_attr, node=target_node, exists=True
-        ):
-            self.log.debug(
-                "Could not find attribute {} on node {} for "
-                "reference input:\n{}".format(
-                    target_attr,
-                    target_node,
-                    json.dumps(
-                        texture_connection, indent=4, sort_keys=True
+        for target_node in target_nodes:
+            if not cmds.attributeQuery(
+                target_attr, node=target_node, exists=True
+            ):
+                self.log.debug(
+                    "Could not find attribute {} on node {} for "
+                    "reference input:\n{}".format(
+                        target_attr,
+                        target_node,
+                        json.dumps(
+                            texture_connection, indent=4, sort_keys=True
+                        )
                     )
                 )
-            )
-        source_plug = f"{source_node}.{source_attr}"
-        target_plug = f"{target_node}.{target_attr}"
+                continue
 
-        if cmds.isConnected(
-            source_plug, target_plug, ignoreUnitConversion=True
-        ):
+            source_plug = f"{source_node}.{source_attr}"
+            target_plug = f"{target_node}.{target_attr}"
+
+            if cmds.isConnected(
+                source_plug, target_plug, ignoreUnitConversion=True
+            ):
+                self.log.debug(
+                    "Connection already exists: {} -> {}".format(
+                        source_plug, target_plug
+                    )
+                )
+                continue
+
+            cmds.connectAttr(source_plug, target_plug, force=True)
             self.log.debug(
-                "Connection already exists: {} -> {}".format(
+                "Connected attributes: {} -> {}".format(
                     source_plug, target_plug
                 )
             )
-            continue
-
-        cmds.connectAttr(source_plug, target_plug, force=True)
-        self.log.debug(
-            "Connected attributes: {} -> {}".format(
-                source_plug, target_plug
-            )
-        )

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4566,8 +4566,8 @@ def apply_connections(connections, target_nodes_by_id, source_nodes_by_id):
     Args:
         connections (list): list of texture reference
         objects connection data
-        target_nodes_by_id (dict): The dict with target shape node ids
-        source_nodes_by_id (dict): The dict with texture reference node ids.
+        target_nodes_by_id (dict[str, list[str]]): The dict with target shape node ids
+        source_nodes_by_id (dict[str, list[str]]): The dict with texture reference node ids.
     """
     # Compare loaded connections to scene.
     for connection in connections:

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -2054,7 +2054,7 @@ def apply_shaders(relationships, shadernodes, nodes):
 
     # check if there is texture references input and connect the texture
     # reference back to the nodes
-    texture_references_input = relationships.get("reference_inputs", [])
+    texture_references_input = relationships.get("texture_connections", [])
     connect_texture_reference_objects(texture_references_input, nodes_by_id)
 
     # endregion
@@ -4491,7 +4491,7 @@ def set_scene_units():
 
 def validate_scene_units() -> bool:
     """Validate whether scene units match AYON settings
-    
+
     If not headless and it does not match, a pop-up dialog is
     shown to the user with a choice to fix it automatically.
 
@@ -4551,27 +4551,27 @@ def get_scene_units_settings(project_settings=None)-> tuple[str, str]:
     return linear_unit, angular_unit
 
 
-def connect_texture_reference_objects(texture_reference_inputs, nodes_by_id):
+def connect_texture_reference_objects(texture_connections, nodes_by_id):
     """Connect texture reference object nodes to the target object
     nodes if there is one.
 
     Args:
-        texture_reference_inputs (list): list of texture reference
+        texture_connections (list): list of texture reference
         objects connection data
-        node_by_id (dict): The dict with node ids.
+        nodes_by_id (dict): The dict with node ids.
     """
     # Compare loaded connections to scene.
-    for reference_input in texture_reference_inputs:
-        source_node = node_by_id.get(input["sourceID"])
-        target_node = node_by_id.get(input["destinationID"])
+    for texture_connection in texture_connections:
+        source_node = nodes_by_id.get(input["sourceID"])
+        target_node = nodes_by_id.get(input["destinationID"])
 
         if not source_node or not target_node:
             self.log.debug(
                 "Could not find nodes for reference input:\n" +
-                json.dumps(reference_input, indent=4, sort_keys=True)
+                json.dumps(texture_connection, indent=4, sort_keys=True)
             )
             continue
-        source_attr, target_attr = reference_input["connections"]
+        source_attr, target_attr = texture_connection["connections"]
 
         if not cmds.attributeQuery(
             source_attr, node=source_node, exists=True
@@ -4582,7 +4582,7 @@ def connect_texture_reference_objects(texture_reference_inputs, nodes_by_id):
                     source_attr,
                     source_node,
                     json.dumps(
-                        reference_input, indent=4, sort_keys=True
+                        texture_connection, indent=4, sort_keys=True
                     )
                 )
             )
@@ -4597,14 +4597,13 @@ def connect_texture_reference_objects(texture_reference_inputs, nodes_by_id):
                     target_attr,
                     target_node,
                     json.dumps(
-                        reference_input, indent=4, sort_keys=True
+                        texture_connection, indent=4, sort_keys=True
                     )
                 )
             )
         source_plug = f"{source_node}.{source_attr}"
         target_plug = f"{target_node}.{target_attr}"
-            target_node, target_attr
-        )
+
         if cmds.isConnected(
             source_plug, target_plug, ignoreUnitConversion=True
         ):

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4564,7 +4564,7 @@ def apply_connections(connections, target_nodes_by_id, source_nodes_by_id):
     nodes if there is one.
 
     Args:
-        connections (list): list of texture reference
+        connections (list[dict[str, Any]]): list of texture reference
         objects connection data
         target_nodes_by_id (dict[str, list[str]]): The dict with target shape node ids
         source_nodes_by_id (dict[str, list[str]]): The dict with texture reference node ids.

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4621,11 +4621,6 @@ def apply_connections(connections, target_nodes_by_id, source_nodes_by_id):
             )
             continue
 
-        # Skip if source node is one of our target shapes
-        if source_node in target_nodes:
-            log.debug("Skipping connection to source target: %s", connection)
-            continue
-
         source_attr, target_attr = connection["connections"]
 
         if not cmds.attributeQuery(
@@ -4644,6 +4639,13 @@ def apply_connections(connections, target_nodes_by_id, source_nodes_by_id):
             continue
 
         for target_node in target_nodes:
+            if target_node == source_node:
+                self.log.debug(
+                    "Skipping connection to itself for {source_node} "
+                    "connection {source_attr}->{target_attr}."
+                )
+                continue
+
             if not cmds.attributeQuery(
                 target_attr, node=target_node, exists=True
             ):

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4641,8 +4641,8 @@ def apply_connections(connections, target_nodes_by_id, source_nodes_by_id):
         for target_node in target_nodes:
             if target_node == source_node:
                 self.log.debug(
-                    "Skipping connection to itself for {source_node} "
-                    "connection {source_attr}->{target_attr}."
+                    f"Skipping connection to itself for {source_node} "
+                    f"connection {source_attr}->{target_attr}."
                 )
                 continue
 

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4620,6 +4620,12 @@ def apply_connections(connections, target_nodes_by_id, source_nodes_by_id):
                 json.dumps(connection, indent=4, sort_keys=True)
             )
             continue
+
+        # Skip if source node is one of our target shapes
+        if source_node in target_nodes:
+            log.debug("Skipping connection to source target: %s", connection)
+            continue
+
         source_attr, target_attr = connection["connections"]
 
         if not cmds.attributeQuery(

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -2007,10 +2007,6 @@ def apply_shaders(relationships, shadernodes, nodes):
 
     attributes = relationships.get("attributes", [])
     shader_data = relationships.get("relationships", {})
-    # check if there is texture references input and connect the texture
-    # reference back to the nodes
-    texture_references_input = relationships.get("reference_inputs", [])
-    connect_texture_reference_objects(texture_references_input)
 
     shading_engines = cmds.ls(shadernodes, type="objectSet", long=True)
     assert shading_engines, "Error in retrieving objectSets from reference"
@@ -2055,6 +2051,11 @@ def apply_shaders(relationships, shadernodes, nodes):
             cmds.sets(filtered_nodes, forceElement=id_shading_engines[0])
         except RuntimeError as rte:
             log.error("Error during shader assignment: {}".format(rte))
+
+    # check if there is texture references input and connect the texture
+    # reference back to the nodes
+    texture_references_input = relationships.get("reference_inputs", [])
+    connect_texture_reference_objects(texture_references_input, nodes_by_id)
 
     # endregion
 
@@ -4550,7 +4551,7 @@ def get_scene_units_settings(project_settings=None)-> tuple[str, str]:
     return linear_unit, angular_unit
 
 
-def connect_texture_reference_objects(texture_reference_inputs):
+def connect_texture_reference_objects(texture_reference_inputs, nodes_by_id):
     """Connect texture reference object nodes to the target object
     nodes if there is one.
 
@@ -4560,8 +4561,8 @@ def connect_texture_reference_objects(texture_reference_inputs):
     """
     # Compare loaded connections to scene.
     for reference_input in texture_reference_inputs:
-        source_node = source_ids.get(input["sourceID"])
-        target_node = target_ids.get(input["destinationID"])
+        source_node = nodes_by_ids.get(input["sourceID"])
+        target_node = nodes_by_ids.get(input["destinationID"])
 
         if not source_node or not target_node:
             self.log.debug(

--- a/client/ayon_maya/plugins/create/create_look.py
+++ b/client/ayon_maya/plugins/create/create_look.py
@@ -37,6 +37,11 @@ class CreateLook(plugin.MayaCreator):
                     label="Convert textures to .rstex",
                     tooltip="Whether to generate Redshift .rstex files for "
                             "your textures",
+                    default=self.rs_tex),
+            BoolDef("textureRefObj",
+                    label="Texture Reference Objects",
+                    tooltip="Whether to use texture reference objects for "
+                            "your textures",
                     default=self.rs_tex)
         ]
 

--- a/client/ayon_maya/plugins/create/create_look.py
+++ b/client/ayon_maya/plugins/create/create_look.py
@@ -18,6 +18,7 @@ class CreateLook(plugin.MayaCreator):
 
     make_tx = True
     rs_tex = False
+    include_texture_reference_objects = False
 
     def get_instance_attr_defs(self):
 
@@ -45,7 +46,7 @@ class CreateLook(plugin.MayaCreator):
                         "with the published look to reconnect to geometry "
                         "when assigning the look."
                     ),
-                    default=self.rs_tex)
+                    default=self.include_texture_reference_objects)
         ]
 
     def get_pre_create_attr_defs(self):

--- a/client/ayon_maya/plugins/create/create_look.py
+++ b/client/ayon_maya/plugins/create/create_look.py
@@ -33,31 +33,7 @@ class CreateLook(plugin.MayaCreator):
         ]:
             if key in pre_create_data:
                 creator_attributes[key] = pre_create_data[key]
-        members = list()
-        if pre_create_data.get("use_selection"):
-            members = cmds.ls(selection=True)
-
-        # Allow a Creator to define multiple families
-        publish_families = self.get_publish_families()
-        if publish_families:
-            families = instance_data.setdefault("families", [])
-            for family in self.get_publish_families():
-                if family not in families:
-                    families.append(family)
-
-        with lib.undo_chunk():
-            instance_node = cmds.sets(members, name=product_name)
-            instance_data["instance_node"] = instance_node
-            instance = CreatedInstance(
-                self.product_type,
-                product_name,
-                instance_data,
-                self)
-            self._add_instance_to_context(instance)
-
-            self.imprint_instance_node(instance_node,
-                                       data=instance.data_to_store())
-            return instance
+        return super().create(product_name, instance_data, pre_create_data)
 
     def get_instance_attr_defs(self):
 

--- a/client/ayon_maya/plugins/create/create_look.py
+++ b/client/ayon_maya/plugins/create/create_look.py
@@ -40,8 +40,11 @@ class CreateLook(plugin.MayaCreator):
                     default=self.rs_tex),
             BoolDef("includeTextureReferenceObjects",
                     label="Texture Reference Objects",
-                    tooltip="Whether to use texture reference objects for "
-                            "your textures",
+                    tooltip=(
+                        "Whether to include texture reference objects "
+                        "with the published look to reconnect to geometry "
+                        "when assigning the look."
+                    ),
                     default=self.rs_tex)
         ]
 

--- a/client/ayon_maya/plugins/create/create_look.py
+++ b/client/ayon_maya/plugins/create/create_look.py
@@ -6,9 +6,6 @@ from ayon_core.lib import (
     BoolDef,
     TextDef
 )
-from ayon_core.pipeline import CreatedInstance
-import maya.cmds as cmds
-
 
 
 class CreateLook(plugin.MayaCreator):
@@ -61,8 +58,7 @@ class CreateLook(plugin.MayaCreator):
                         "with the published look to reconnect to geometry "
                         "when assigning the look."
                     ),
-                    default=self.include_texture_reference_objects
-                    )
+                    default=self.include_texture_reference_objects)
         ]
 
     def get_pre_create_attr_defs(self):

--- a/client/ayon_maya/plugins/create/create_look.py
+++ b/client/ayon_maya/plugins/create/create_look.py
@@ -38,7 +38,7 @@ class CreateLook(plugin.MayaCreator):
                     tooltip="Whether to generate Redshift .rstex files for "
                             "your textures",
                     default=self.rs_tex),
-            BoolDef("textureRefObj",
+            BoolDef("includeTextureReferenceObjects",
                     label="Texture Reference Objects",
                     tooltip="Whether to use texture reference objects for "
                             "your textures",

--- a/client/ayon_maya/plugins/publish/collect_look.py
+++ b/client/ayon_maya/plugins/publish/collect_look.py
@@ -676,7 +676,7 @@ class CollectLook(plugin.MayaInstancePlugin):
         if not input_content:
             return []
 
-        attrs = [f"{mesh}.referenceObject" for mesh in input_content]
+        attrs = [f"{mesh}.referenceObject" for mesh in set(input_content)]
         # Store all connections
         connections = cmds.listConnections(attrs,
                                            source=True,

--- a/client/ayon_maya/plugins/publish/collect_look.py
+++ b/client/ayon_maya/plugins/publish/collect_look.py
@@ -672,7 +672,12 @@ class CollectLook(plugin.MayaInstancePlugin):
                                             fullPath=True) or []
 
         # Ignore intermediate objects
-        input_content = cmds.ls(input_content, long=True, noIntermediate=True)
+        input_content = cmds.ls(
+            input_content, 
+            long=True, 
+            noIntermediate=True,
+            type="mesh"
+        )
         if not input_content:
             return []
 

--- a/client/ayon_maya/plugins/publish/collect_look.py
+++ b/client/ayon_maya/plugins/publish/collect_look.py
@@ -348,8 +348,8 @@ class CollectLook(plugin.MayaInstancePlugin):
             input_collections, tx_object_nodes = (
                 self.collect_texture_reference_object_inputs(instance)
             )
-            instance.data["lookData"].update(
-                {"texture_connections": input_collections}
+            instance.data["lookData"]["connections"] = (
+                input_collections
             )
             instance.data["textureReferenceObjects"] = tx_object_nodes
         # Collect file nodes used by shading engines (if we have any)

--- a/client/ayon_maya/plugins/publish/collect_look.py
+++ b/client/ayon_maya/plugins/publish/collect_look.py
@@ -704,9 +704,11 @@ class CollectLook(plugin.MayaInstancePlugin):
                     "object nodes inside the instance: %s -> %s" % (src, dest))
                 continue
 
-            inputs.append({"connections": [source_attr, dest_attr],
-                           "sourceID": lib.get_id(source_node),
-                           "destinationID": lib.get_id(dest_node)})
+            inputs.append({
+                "connections": [source_attr, dest_attr],
+                "sourceID": lib.get_id(source_node),
+                "destinationID": lib.get_id(dest_node)
+            })
             tx_ref_nodes.append(source_node)
 
         return inputs, tx_ref_nodes

--- a/client/ayon_maya/plugins/publish/collect_look.py
+++ b/client/ayon_maya/plugins/publish/collect_look.py
@@ -344,14 +344,14 @@ class CollectLook(plugin.MayaInstancePlugin):
             "attributes": attributes,
             "relationships": sets
         }
-        if instance.data["textureRefObj"]:
+        if instance.data["includeTextureReferenceObjects"]:
             input_collections, tx_object_nodes = (
                 self.collect_texture_reference_object_inputs(instance)
             )
             instance.data["lookData"].update(
-                {"reference_inputs": input_collections}
+                {"texture_connections": input_collections}
             )
-            instance.data["textureObjects"] = tx_object_nodes
+            instance.data["textureReferenceObjects"] = tx_object_nodes
         # Collect file nodes used by shading engines (if we have any)
         files = []
         look_sets = list(sets.keys())

--- a/client/ayon_maya/plugins/publish/collect_look.py
+++ b/client/ayon_maya/plugins/publish/collect_look.py
@@ -685,7 +685,7 @@ class CollectLook(plugin.MayaInstancePlugin):
                                            connections=True,
                                            # Only allow inputs from dagNodes
                                            # (avoid display layers, etc.)
-                                           type="dagNode",
+                                           type="mesh",
                                            plugs=True) or []
         connections = cmds.ls(connections, long=True)      # Ensure long names
 

--- a/client/ayon_maya/plugins/publish/extract_look.py
+++ b/client/ayon_maya/plugins/publish/extract_look.py
@@ -535,9 +535,7 @@ class ExtractLook(plugin.MayaExtractorPlugin):
             "relationships": relationships
         }
         if instance.data.get("includeTextureReferenceObjects"):
-            data.update({
-                "connections": lookdata["connections"]
-            })
+            data["connections"] = lookdata["connections"]
 
         self.log.debug("Extracting json file: {}".format(json_path))
         with open(json_path, "w") as f:

--- a/client/ayon_maya/plugins/publish/extract_look.py
+++ b/client/ayon_maya/plugins/publish/extract_look.py
@@ -473,7 +473,7 @@ class ExtractLook(plugin.MayaExtractorPlugin):
             self.log.debug("No sets found for the look")
             return
 
-        texture_objs = instance.data.get("textureObjects", [])
+        texture_objs = instance.data.get("textureReferenceObjects", [])
         # Specify texture processing executables to activate
         # TODO: Load these more dynamically once we support more processors
         processors = []
@@ -514,6 +514,8 @@ class ExtractLook(plugin.MayaExtractorPlugin):
                 with no_workspace_dir():
                     with lib.attribute_values(remap):
                         with lib.maintained_selection():
+                            # texture reference objects would publish along with
+                            # construction history and constraints
                             cmds.select(sets + texture_objs, noExpand=True)
                             cmds.file(
                                 maya_path,
@@ -532,8 +534,10 @@ class ExtractLook(plugin.MayaExtractorPlugin):
             "attributes": lookdata["attributes"],
             "relationships": relationships
         }
-        if instance.data.get("textureRefObj"):
-            data.update({"reference_inputs": lookdata["reference_inputs"]})
+        if instance.data.get("includeTextureReferenceObjects"):
+            data.update({
+                "texture_connections": lookdata["texture_connections"]
+            })
 
         self.log.debug("Extracting json file: {}".format(json_path))
         with open(json_path, "w") as f:

--- a/client/ayon_maya/plugins/publish/extract_look.py
+++ b/client/ayon_maya/plugins/publish/extract_look.py
@@ -536,7 +536,7 @@ class ExtractLook(plugin.MayaExtractorPlugin):
         }
         if instance.data.get("includeTextureReferenceObjects"):
             data.update({
-                "texture_connections": lookdata["texture_connections"]
+                "connections": lookdata["connections"]
             })
 
         self.log.debug("Extracting json file: {}".format(json_path))

--- a/client/ayon_maya/plugins/publish/extract_look.py
+++ b/client/ayon_maya/plugins/publish/extract_look.py
@@ -473,6 +473,7 @@ class ExtractLook(plugin.MayaExtractorPlugin):
             self.log.debug("No sets found for the look")
             return
 
+        texture_objs = instance.data.get("textureObjects", [])
         # Specify texture processing executables to activate
         # TODO: Load these more dynamically once we support more processors
         processors = []
@@ -513,7 +514,7 @@ class ExtractLook(plugin.MayaExtractorPlugin):
                 with no_workspace_dir():
                     with lib.attribute_values(remap):
                         with lib.maintained_selection():
-                            cmds.select(sets, noExpand=True)
+                            cmds.select(sets + texture_objs, noExpand=True)
                             cmds.file(
                                 maya_path,
                                 force=True,
@@ -531,6 +532,8 @@ class ExtractLook(plugin.MayaExtractorPlugin):
             "attributes": lookdata["attributes"],
             "relationships": relationships
         }
+        if instance.data.get("textureRefObj"):
+            data.update({"reference_inputs": lookdata["reference_inputs"]})
 
         self.log.debug("Extracting json file: {}".format(json_path))
         with open(json_path, "w") as f:

--- a/server/settings/creators.py
+++ b/server/settings/creators.py
@@ -20,6 +20,7 @@ class CreateLookModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="Enabled")
     make_tx: bool = SettingsField(title="Make tx files")
     rs_tex: bool = SettingsField(title="Make Redshift texture files")
+    include_texture_reference_objects: bool = SettingsField(title="Texture Reference Objects")
     default_variants: list[str] = SettingsField(
         default_factory=list, title="Default Products"
     )
@@ -281,6 +282,7 @@ DEFAULT_CREATORS_SETTINGS = {
         "enabled": True,
         "make_tx": True,
         "rs_tex": False,
+        "include_texture_reference_objects": False,
         "default_variants": [
             "Main"
         ]


### PR DESCRIPTION
## Changelog Description
This PR is to introduce the support of Texture Reference Objects in Look Publish, users can publish their texture reference objects in the look and connect it back to the geometry with Look Assigner.

## Additional review information

Fix https://github.com/ynput/ayon-maya/issues/269

## Testing notes:
1. Create Look with `Texture Reference Objects` options on
2. Publish
3. Load look with the related geometry
4. Use Look Assigner to assign look 
