### PR TITLE
Connect Geometry: preserve cbId on deformed shapes

### DIFF
--- a/client/ayon_maya/plugins/inventory/connect_geometry.py
+++ b/client/ayon_maya/plugins/inventory/connect_geometry.py
@@ -136,7 +136,7 @@ class ConnectGeometry(InventoryAction):
         if not cmds.referenceQuery(target_shape, isNodeReferenced=True):
             return
 
-        # Taret mesh has no ID to maintain, so we can skip this.
+        # Target mesh has no ID to maintain, so we can skip this.
         if not get_id(target_shape):
             return
 

--- a/client/ayon_maya/plugins/inventory/connect_geometry.py
+++ b/client/ayon_maya/plugins/inventory/connect_geometry.py
@@ -141,7 +141,7 @@ class ConnectGeometry(InventoryAction):
             return
 
         output = cmds.listConnections(
-            blendshape + ".outputGeometry[0]",
+            f"{blendshape}.outputGeometry[0]",
             source=False,
             destination=True,
             shapes=True

--- a/client/ayon_maya/plugins/inventory/connect_geometry.py
+++ b/client/ayon_maya/plugins/inventory/connect_geometry.py
@@ -110,7 +110,10 @@ class ConnectGeometry(InventoryAction):
             target_shapes = [target]
         else:
             target_shapes = cmds.listRelatives(
-                target, type="deformableShape", fullPath=True, noIntermediate=True
+                target,
+                type="deformableShape",
+                fullPath=True,
+                noIntermediate=True,
             ) or []
 
         # Add blendshape


### PR DESCRIPTION
## Changelog Description

Preserve `cbId` when applying Connect Geometries via scene inventory to e.g. referenced `model`.
This way look assignments will continue to work.

## Additional review information

Fix https://github.com/ynput/ayon-maya/issues/286

## Testing notes:

1. Load a model and a pointcache
2. Then in scene inventory do "Connect Geometry"
3. After connecting geometry shader assignment should still work on the "model"