### PR TITLE
Publishing model won't error out without texture object included.

### DIFF
--- a/client/ayon_maya/plugins/publish/collect_look.py
+++ b/client/ayon_maya/plugins/publish/collect_look.py
@@ -344,7 +344,7 @@ class CollectLook(plugin.MayaInstancePlugin):
             "attributes": attributes,
             "relationships": sets
         }
-        if instance.data["includeTextureReferenceObjects"]:
+        if instance.data.get("includeTextureReferenceObjects", False):
             collections, texture_object_nodes = (
                 self.collect_texture_reference_object_inputs(instance)
             )


### PR DESCRIPTION
## Changelog Description
This PR is to fix the model product publishing being errored out in the look collector.

## Additional review information
n/a

## Testing notes:
1. Create Model Instance
2. Publish
