### PR TITLE
Settings: Playblast Overscan setting should be `float` instead of `int`

### DIFF
--- a/server/settings/publish_playblast.py
+++ b/server/settings/publish_playblast.py
@@ -220,7 +220,7 @@ class CameraOptionsSetting(BaseSettingsModel):
     displaySafeTitle: bool = SettingsField(False, title="Display Safe Title")
     displayFilmPivot: bool = SettingsField(False, title="Display Film Pivot")
     displayFilmOrigin: bool = SettingsField(False, title="Display Film Origin")
-    overscan: int = SettingsField(1.0, title="Overscan")
+    overscan: float = SettingsField(1.0, title="Overscan")
 
 
 class CapturePresetSetting(BaseSettingsModel):


### PR DESCRIPTION
## Changelog Description

Settings: Playblast Overscan setting should be `float` instead of `int`

## Additional review information

Field should support decimal point values.

## Testing notes:

1. upload addon
2. tweak and save setting
3. setting should be applied during publish
