### PR TITLE
Added missing dynamic data for Unreal Static and Skeletal Mesh creators

### DIFF
--- a/client/ayon_maya/plugins/create/create_unreal_skeletalmesh.py
+++ b/client/ayon_maya/plugins/create/create_unreal_skeletalmesh.py
@@ -41,7 +41,17 @@ class CreateUnrealSkeletalMesh(plugin.MayaCreator):
             host_name,
             instance
         )
-        dynamic_data["asset"] = folder_entity["name"]
+        
+        dynamic_data.update(
+            {
+                "asset": folder_entity["name"],
+                "folder": {
+                            "label": folder_entity["label"],
+                            "name": folder_entity["name"]
+                }
+            }
+        )
+        
         return dynamic_data
 
     def create(self, product_name, instance_data, pre_create_data):

--- a/client/ayon_maya/plugins/create/create_unreal_staticmesh.py
+++ b/client/ayon_maya/plugins/create/create_unreal_staticmesh.py
@@ -36,7 +36,17 @@ class CreateUnrealStaticMesh(plugin.MayaCreator):
             host_name,
             instance
         )
-        dynamic_data["asset"] = folder_entity["name"]
+        
+        dynamic_data.update(
+            {
+                "asset": folder_entity["name"],
+                "folder": {
+                            "label": folder_entity["label"],
+                            "name": folder_entity["name"]
+                }
+            }
+        )
+        
         return dynamic_data
 
     def create(self, product_name, instance_data, pre_create_data):


### PR DESCRIPTION
## Changelog Description
Added missing {folder[name]}, {folder[label]} dynamic data for Unreal Static and Skeletal Mesh creators similar to ayon-houdini - Hda creator

## Additional review information
I was getting the following error due to dynamic data missing
ayon_core.lib.path_templates.TemplateUnsolved: Template "S_{folder[name]}{variant}" is unsolved. Missing keys: "folder".

