### PR TITLE
:bug: fix types issues in Maya 2022 (python 3.7)

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -1,5 +1,5 @@
 """Standalone helper functions"""
-
+from __future__ import annotations
 import os
 import copy
 import sys


### PR DESCRIPTION
## Changelog Description
Fix issue with newer python syntax in older Maya 2022

## Additional review information
FIxing issue on Maya startup:
```
File "C:\Users\annat\Documents\Projects\Ayon\ayon-maya\client\ayon_maya\api\lib.py", line 4597, in <module>
    def get_scene_units_settings(project_settings=None)-> tuple[str, str]:
```

## Testing notes:
1. Run Maya 2022 in AYON
2. All should work
