### PR TITLE
Arnold: Image Prefix token setting aligns with default multilayer value

### DIFF
--- a/server/settings/render_settings.py
+++ b/server/settings/render_settings.py
@@ -485,7 +485,7 @@ DEFAULT_RENDER_SETTINGS = {
     "reset_current_frame": False,
     "remove_aovs": False,
     "arnold_renderer": {
-        "image_prefix": "<Scene>/<RenderLayer>/<RenderLayer>_<RenderPass>",
+        "image_prefix": "<Scene>/<RenderLayer>/<RenderLayer>",
         "image_format": "exr",
         "multilayer_exr": True,
         "tiled": True,


### PR DESCRIPTION
## Changelog Description
This PR is the continuity of the comment https://github.com/ynput/ayon-maya/pull/334#discussion_r2285551039, toremove `<RenderPass>` token to ease the confusion when the multilayer setting are True by default.

<img width="450" height="127" alt="Screenshot 2025-08-20 091618" src="https://github.com/user-attachments/assets/e49e5e22-908f-4bf3-bf01-8b5162af02f7" />


## Additional review information
No Validator should fail with ```Multilayer``` enabled and adjusted ```Image Prefix Template``` without the ```<RenderPass>``` token

## Testing notes:
1. Create Render Instance
2. Publish
