### PR TITLE
Add options of lock set on load when loading rig for animation publish

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -109,8 +109,10 @@ def unlocked(node):
     Args:
         node (str): The name of the node to unlock.
     """
-    has_locked = cmds.lockNode(node, query=True, lock=True)
-    cmds.lockNode(node, lock=False)
+    has_locked = False
+    if cmds.lockNode(node, query=True, lock=True):
+        has_locked = True
+        cmds.lockNode(node, lock=False)
 
     try:
         yield

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -109,10 +109,8 @@ def unlocked(node):
     Args:
         node (str): The name of the node to unlock.
     """
-    has_locked = False
-    if cmds.lockNode(node, query=True, lock=True):
-        has_locked = True
-        cmds.lockNode(node, lock=False)
+    has_locked = cmds.lockNode(node, query=True, lock=True)
+    cmds.lockNode(node, lock=False)
 
     try:
         yield
@@ -4340,21 +4338,6 @@ def create_rig_animation_instance(
                 "lock_instance": options.get("lock_instance", False)
             }
         )
-
-
-def is_animation_instance(objectset: str) -> bool:
-    """Check if the given object set is an animation instance.
-
-    Arguments:
-        objectset (str): The name of the object set to check.
-
-    Returns:
-        bool: True if the object set is an animation instance, False otherwise.
-    """
-    creator_identifier = cmds.getAttr(f"{objectset}.creator_identifier")
-    if creator_identifier == "io.openpype.creators.maya.animation":
-        return True
-    return False
 
 
 def get_node_index_under_parent(node: str) -> int:

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4262,20 +4262,6 @@ def get_creator_identifier(node: str) -> str | None:
     return get_attribute(f"{node}.creator_identifier")
 
 
-def is_animation_instance(objectset: str) -> bool:
-    """Check if the given object set is an animation instance.
-
-    Arguments:
-        objectset (str): The name of the object set to check.
-
-    Returns:
-        bool: True if the object set is an animation instance, False otherwise.
-    """
-    return (
-        get_creator_identifier(objectset) == "io.openpype.creators.maya.animation"
-    )
-
-
 def create_rig_animation_instance(
     nodes, context, namespace, options=None, log=None
 ):

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4246,13 +4246,6 @@ def get_reference_node_parents(ref):
     return parents
 
 
-def get_instance_node_attr(node, attr, default=None):
-    """Helper to get attribute which allows attribute to not exist."""
-    if not cmds.attributeQuery(attr, node=node, exists=True):
-        return default
-    return cmds.getAttr("{}.{}".format(node, attr))
-
-
 def get_creator_identifier(node: str) -> str | None:
     """Get the creator identifier of an instance node.
 
@@ -4262,12 +4255,11 @@ def get_creator_identifier(node: str) -> str | None:
     Returns:
         str | None: The creator identifier of the instance or None if not found.
     """
-    if get_instance_node_attr(node, attr="id") not in {
+    if get_attribute(f"{node}.id") not in {
         AYON_INSTANCE_ID, AVALON_INSTANCE_ID
     }:
         return None
-
-    return get_instance_node_attr(node, "creator_identifier")
+    return get_attribute(f"{node}.creator_identifier")
 
 
 def is_animation_instance(objectset: str) -> bool:

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -103,17 +103,12 @@ def get_main_window():
 
 
 @contextlib.contextmanager
-def unlocked_node(node, product_type):
+def unlocked(node):
     """Unlock a node for the duration of the context.
 
     Args:
         node (str): The name of the node to unlock.
-        product_type (str): The type of product being processed.
     """
-    if product_type != "animation":
-        yield
-        return
-
     has_locked = False
     if cmds.lockNode(node, query=True, lock=True):
         has_locked = True
@@ -4253,8 +4248,7 @@ def get_reference_node_parents(ref):
 
 
 def create_rig_animation_instance(
-    nodes, context, namespace, options=None, log=None,
-    settings=None
+    nodes, context, namespace, options=None, log=None
 ):
     """Create an animation publish instance for loaded rigs.
 
@@ -4267,7 +4261,6 @@ def create_rig_animation_instance(
         namespace (str): Namespace of the rig container
         options (dict, optional): Additional loader data
         log (logging.Logger, optional): Logger to log to if provided
-        settings (dict, optional): Loader settings from Ayon
 
     Returns:
         None
@@ -4346,11 +4339,13 @@ def create_rig_animation_instance(
             pre_create_data={"use_selection": True}
         )
 
-        if settings is not None:
-            lock_set_on_load = settings['maya']['load'].get(
-                'reference_loader', {}
-            ).get('lock_set_on_load', False)
-            cmds.lockNode(node.product_name, lock=lock_set_on_load)
+        cmds.lockNode(
+            node.product_name,
+            lock=options.get(
+                "lock_animation_instance_on_load",
+                False
+            )
+        )
 
 
 def get_node_index_under_parent(node: str) -> int:

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4247,6 +4247,45 @@ def get_reference_node_parents(ref):
     return parents
 
 
+def get_attr(node, attr, default=None):
+    """Helper to get attribute which allows attribute to not exist."""
+    if not cmds.attributeQuery(attr, node=node, exists=True):
+        return default
+    return cmds.getAttr("{}.{}".format(node, attr))
+
+
+def get_creator_identifier(node: str) -> str | None:
+    """Get the creator identifier of an instance node.
+
+    Arguments:
+        node (str): The name of the instance node.
+
+    Returns:
+        str | None: The creator identifier of the instance or None if not found.
+    """
+    if get_attr(node, attr="id") not in {
+        AYON_INSTANCE_ID, AVALON_INSTANCE_ID
+    }:
+        return None
+
+    return get_attr(node, "creator_identifier")
+
+
+def is_animation_instance(objectset: str) -> bool:
+    """Check if the given object set is an animation instance.
+
+    Arguments:
+        objectset (str): The name of the object set to check.
+
+    Returns:
+        bool: True if the object set is an animation instance, False otherwise.
+    """
+    creator_id = get_creator_identifier(objectset)
+    if creator_id is None:
+        return False
+    return creator_id == "io.openpype.creators.maya.animation"
+
+
 def create_rig_animation_instance(
     nodes, context, namespace, options=None, log=None
 ):

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -109,13 +109,12 @@ def unlocked(node):
     Args:
         node (str): The name of the node to unlock.
     """
-    has_locked = False
-    if cmds.lockNode(node, query=True, lock=True):
-        has_locked = True
-        cmds.lockNode(node, lock=False)
+    has_locked = cmds.lockNode(node, query=True, lock=True)[0]
+    cmds.lockNode(node, lock=False)
 
     try:
         yield
+
     finally:
         cmds.lockNode(node, lock=has_locked)
 
@@ -4247,7 +4246,7 @@ def get_reference_node_parents(ref):
     return parents
 
 
-def get_attr(node, attr, default=None):
+def get_instance_node_attr(node, attr, default=None):
     """Helper to get attribute which allows attribute to not exist."""
     if not cmds.attributeQuery(attr, node=node, exists=True):
         return default
@@ -4263,12 +4262,12 @@ def get_creator_identifier(node: str) -> str | None:
     Returns:
         str | None: The creator identifier of the instance or None if not found.
     """
-    if get_attr(node, attr="id") not in {
+    if get_instance_node_attr(node, attr="id") not in {
         AYON_INSTANCE_ID, AVALON_INSTANCE_ID
     }:
         return None
 
-    return get_attr(node, "creator_identifier")
+    return get_instance_node_attr(node, "creator_identifier")
 
 
 def is_animation_instance(objectset: str) -> bool:
@@ -4280,10 +4279,9 @@ def is_animation_instance(objectset: str) -> bool:
     Returns:
         bool: True if the object set is an animation instance, False otherwise.
     """
-    creator_id = get_creator_identifier(objectset)
-    if creator_id is None:
-        return False
-    return creator_id == "io.openpype.creators.maya.animation"
+    return (
+        get_creator_identifier(objectset) == "io.openpype.creators.maya.animation"
+    )
 
 
 def create_rig_animation_instance(

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4330,22 +4330,32 @@ def create_rig_animation_instance(
     rig_sets = [output, controls, anim_skeleton, skeleton_mesh]
     # Remove sets that this particular rig does not have
     rig_sets = [s for s in rig_sets if s is not None]
-
+    print("options:", options)
     with maintained_selection():
         cmds.select(rig_sets + roots, noExpand=True)
-        node = create_context.create(
+        create_context.create(
             creator_identifier=creator_identifier,
             variant=namespace,
-            pre_create_data={"use_selection": True}
+            pre_create_data={
+                "use_selection": True,
+                "lock_instance": options.get("lock_instance", False)
+            }
         )
 
-        cmds.lockNode(
-            node.product_name,
-            lock=options.get(
-                "lock_animation_instance_on_load",
-                False
-            )
-        )
+
+def is_animation_instance(objectset: str) -> bool:
+    """Check if the given object set is an animation instance.
+
+    Arguments:
+        objectset (str): The name of the object set to check.
+
+    Returns:
+        bool: True if the object set is an animation instance, False otherwise.
+    """
+    creator_identifier = cmds.getAttr(f"{objectset}.creator_identifier")
+    if creator_identifier == "io.openpype.creators.maya.animation":
+        return True
+    return False
 
 
 def get_node_index_under_parent(node: str) -> int:

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4230,7 +4230,8 @@ def get_reference_node_parents(ref):
 
 
 def create_rig_animation_instance(
-    nodes, context, namespace, options=None, log=None
+    nodes, context, namespace, options=None, log=None,
+    lock_set_on_load=False
 ):
     """Create an animation publish instance for loaded rigs.
 
@@ -4243,6 +4244,7 @@ def create_rig_animation_instance(
         namespace (str): Namespace of the rig container
         options (dict, optional): Additional loader data
         log (logging.Logger, optional): Logger to log to if provided
+        lock_set_on_load (bool, optional): Whether to lock the set on load
 
     Returns:
         None
@@ -4319,6 +4321,8 @@ def create_rig_animation_instance(
             variant=namespace,
             pre_create_data={"use_selection": True}
         )
+
+    cmds.lockNode(f"*{namespace}", lock=lock_set_on_load)
 
 
 def get_node_index_under_parent(node: str) -> int:

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4330,7 +4330,6 @@ def create_rig_animation_instance(
     rig_sets = [output, controls, anim_skeleton, skeleton_mesh]
     # Remove sets that this particular rig does not have
     rig_sets = [s for s in rig_sets if s is not None]
-    print("options:", options)
     with maintained_selection():
         cmds.select(rig_sets + roots, noExpand=True)
         create_context.create(

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -1,5 +1,6 @@
 import json
 import os
+from platform import node
 
 import ayon_api
 import qargparse
@@ -1012,7 +1013,6 @@ class ReferenceLoader(Loader):
         fname = cmds.referenceQuery(reference_node, filename=True)
         cmds.file(fname, removeReference=True)
 
-
         try:
             cmds.delete(node)
 
@@ -1048,6 +1048,27 @@ class ReferenceLoader(Loader):
             file_url = anatomy.replace_root_with_env_key(file_url, '${{{}}}')
 
         return file_url
+
+
+    def is_animation_instance(self, objectset: str) -> bool:
+        """Check if the given object set is an animation instance.
+
+        Arguments:
+            objectset (str): The name of the object set to check.
+
+        Returns:
+            bool: True if the object set is an animation instance, False otherwise.
+        """
+        if _get_attr(node, attr="id") not in {
+            AYON_INSTANCE_ID, AVALON_INSTANCE_ID
+        }:
+            return False
+
+        creator_id = _get_attr(objectset, "creator_identifier")
+        if creator_id is None:
+            return False
+
+        return creator_id == "io.openpype.creators.maya.animation"
 
     @classmethod
     def get_representation_name_aliases(cls, representation_name):

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -1,6 +1,5 @@
 import json
 import os
-from platform import node
 
 import ayon_api
 import qargparse
@@ -257,8 +256,8 @@ class MayaCreatorBase:
         cached_instances = (
             self.collection_shared_data["maya_cached_instance_data"]
         )
-        for instance_node in cached_instances.get(self.identifier, []):
-            node_data = self.read_instance_node(instance_node)
+        for node in cached_instances.get(self.identifier, []):
+            node_data = self.read_instance_node(node)
 
             created_instance = CreatedInstance.from_existing(node_data, self)
             self._add_instance_to_context(created_instance)
@@ -510,18 +509,16 @@ class RenderlayerCreator(Creator, MayaCreatorBase):
             type="objectSet"
         ) or []
 
-        for layer_instance_node in connected_sets:
+        for node in connected_sets:
             if not cmds.attributeQuery("creator_identifier",
-                                       node=layer_instance_node,
+                                       node=node,
                                        exists=True):
                 continue
 
-            creator_identifier = cmds.getAttr(
-                layer_instance_node + ".creator_identifier"
-            )
+            creator_identifier = cmds.getAttr(node + ".creator_identifier")
             if creator_identifier == self.identifier:
-                self.log.info("Found node: {}".format(layer_instance_node))
-                return layer_instance_node
+                self.log.info("Found node: {}".format(node))
+                return node
 
     def _create_layer_instance_node(self, layer):
 

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -264,8 +264,8 @@ class MayaCreatorBase:
         cached_instances = (
             self.collection_shared_data["maya_cached_instance_data"]
         )
-        for node in cached_instances.get(self.identifier, []):
-            node_data = self.read_instance_node(node)
+        for instance_node in cached_instances.get(self.identifier, []):
+            node_data = self.read_instance_node(instance_node)
 
             created_instance = CreatedInstance.from_existing(node_data, self)
             self._add_instance_to_context(created_instance)
@@ -517,16 +517,18 @@ class RenderlayerCreator(Creator, MayaCreatorBase):
             type="objectSet"
         ) or []
 
-        for node in connected_sets:
+        for layer_instance_node in connected_sets:
             if not cmds.attributeQuery("creator_identifier",
-                                       node=node,
+                                       node=layer_instance_node,
                                        exists=True):
                 continue
 
-            creator_identifier = cmds.getAttr(node + ".creator_identifier")
+            creator_identifier = cmds.getAttr(
+                layer_instance_node + ".creator_identifier"
+            )
             if creator_identifier == self.identifier:
-                self.log.info("Found node: {}".format(node))
-                return node
+                self.log.info("Found node: {}".format(layer_instance_node))
+                return layer_instance_node
 
     def _create_layer_instance_node(self, layer):
 

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -999,8 +999,6 @@ class ReferenceLoader(Loader):
         from maya import cmds
 
         node = container["objectName"]
-        if "rig" in node.lower():
-            self._remove_linked_animation_instance(container)
 
         # Assume asset has been referenced
         members = cmds.sets(node, query=True)
@@ -1029,16 +1027,6 @@ class ReferenceLoader(Loader):
 
         except RuntimeError:
             pass
-
-    def _remove_linked_animation_instance(self, container):
-        namespace = container["namespace"]
-        node = next((
-            node for node
-            in cmds.ls(f"*{namespace}", type="objectSet")),
-            None
-        )
-        if node:
-            cmds.lockNode(node, lock=False)
 
     def prepare_root_value(self, file_url, project_name):
         """Replace root value with env var placeholder.

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -324,6 +324,10 @@ class MayaCreator(Creator, MayaCreatorBase):
 
             self.imprint_instance_node(instance_node,
                                        data=instance.data_to_store())
+
+            if pre_create_data.get("lock_instance", False):
+                cmds.lockNode(instance_node, lock=True)
+
             return instance
 
     def collect_instances(self):

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -27,11 +27,18 @@ from maya.app.renderSetup.model import renderSetup
 from pyblish.api import ContextPlugin, InstancePlugin
 
 from . import lib
-from .lib import imprint, read, unlocked, get_instance_node_attr
+from .lib import imprint, read, unlocked
 from .pipeline import containerise
 
 log = Logger.get_logger()
 SETTINGS_CATEGORY = "maya"
+
+
+def _get_attr(node, attr, default=None):
+    """Helper to get attribute which allows attribute to not exist."""
+    if not cmds.attributeQuery(attr, node=node, exists=True):
+        return default
+    return cmds.getAttr("{}.{}".format(node, attr))
 
 
 # Backwards compatibility: these functions has been moved to lib.
@@ -122,18 +129,18 @@ class MayaCreatorBase:
 
             for node in cmds.ls(type="objectSet"):
 
-                if get_instance_node_attr(node, attr="id") not in {
+                if _get_attr(node, attr="id") not in {
                     AYON_INSTANCE_ID, AVALON_INSTANCE_ID
                 }:
                     continue
 
-                creator_id = get_instance_node_attr(node, attr="creator_identifier")
+                creator_id = _get_attr(node, attr="creator_identifier")
                 if creator_id is not None:
                     # creator instance
                     cache.setdefault(creator_id, []).append(node)
                 else:
                     # legacy instance
-                    family = get_instance_node_attr(node, attr="family")
+                    family = _get_attr(node, attr="family")
                     if family is None:
                         # must be a broken instance
                         continue

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -27,7 +27,7 @@ from maya.app.renderSetup.model import renderSetup
 from pyblish.api import ContextPlugin, InstancePlugin
 
 from . import lib
-from .lib import imprint, read
+from .lib import imprint, read, unlocked_node
 from .pipeline import containerise
 
 log = Logger.get_logger()
@@ -270,11 +270,12 @@ class MayaCreatorBase:
             self._add_instance_to_context(created_instance)
 
     def _default_update_instances(self, update_list):
+
         for created_inst, _changes in update_list:
             data = created_inst.data_to_store()
             node = data.get("instance_node")
-
-            self.imprint_instance_node(node, data)
+            with unlocked_node(node, data.get("productType")):
+                self.imprint_instance_node(node, data)
 
     @lib.undo_chunk()
     def _default_remove_instances(self, instances):
@@ -287,6 +288,8 @@ class MayaCreatorBase:
         for instance in instances:
             node = instance.data.get("instance_node")
             if node:
+                if cmds.lockNode(node, query=True, lock=True):
+                    cmds.lockNode(node, lock=False)
                 cmds.delete(node)
 
             self._remove_instance_from_context(instance)
@@ -992,17 +995,18 @@ class ReferenceLoader(Loader):
         """
         from maya import cmds
 
-        locknode_namespace = container["namespace"]
-        # check if the node has been locked and unlocked it
-        if cmds.lockNode(f"*{locknode_namespace}", query=True, lock=True):
-            cmds.lockNode(f"*{locknode_namespace}", lock=False)
-
         node = container["objectName"]
-
+        namespace = container["namespace"]
+        associated_namespace_node = next((
+            associated_node for associated_node
+            in cmds.ls(f"*{namespace}", type="objectSet")),
+            None
+        )
+        if associated_namespace_node:
+            cmds.lockNode(associated_namespace_node, lock=False)
         # Assume asset has been referenced
         members = cmds.sets(node, query=True)
         reference_node = lib.get_reference_node(members, self.log)
-
         assert reference_node, ("Imported container not supported; "
                                 "container must be referenced.")
 
@@ -1015,6 +1019,7 @@ class ReferenceLoader(Loader):
 
         try:
             cmds.delete(node)
+            print(node)
         except ValueError:
             # Already implicitly deleted by Maya upon removing reference
             pass
@@ -1023,6 +1028,7 @@ class ReferenceLoader(Loader):
             # If container is not automatically cleaned up by May (issue #118)
             cmds.namespace(removeNamespace=namespace,
                            deleteNamespaceContent=True)
+            print(namespace)
         except RuntimeError:
             pass
 

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -992,6 +992,11 @@ class ReferenceLoader(Loader):
         """
         from maya import cmds
 
+        locknode_namespace = container["namespace"]
+        # check if the node has been locked and unlocked it
+        if cmds.lockNode(f"*{locknode_namespace}", query=True, lock=True):
+            cmds.lockNode(f"*{locknode_namespace}", lock=False)
+
         node = container["objectName"]
 
         # Assume asset has been referenced
@@ -1006,6 +1011,7 @@ class ReferenceLoader(Loader):
         namespace = cmds.referenceQuery(reference_node, namespace=True)
         fname = cmds.referenceQuery(reference_node, filename=True)
         cmds.file(fname, removeReference=True)
+
 
         try:
             cmds.delete(node)

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -1049,7 +1049,6 @@ class ReferenceLoader(Loader):
 
         return file_url
 
-
     def is_animation_instance(self, objectset: str) -> bool:
         """Check if the given object set is an animation instance.
 

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -27,7 +27,7 @@ from maya.app.renderSetup.model import renderSetup
 from pyblish.api import ContextPlugin, InstancePlugin
 
 from . import lib
-from .lib import imprint, read, unlocked, get_attr
+from .lib import imprint, read, unlocked, get_instance_node_attr
 from .pipeline import containerise
 
 log = Logger.get_logger()
@@ -122,18 +122,18 @@ class MayaCreatorBase:
 
             for node in cmds.ls(type="objectSet"):
 
-                if get_attr(node, attr="id") not in {
+                if get_instance_node_attr(node, attr="id") not in {
                     AYON_INSTANCE_ID, AVALON_INSTANCE_ID
                 }:
                     continue
 
-                creator_id = get_attr(node, attr="creator_identifier")
+                creator_id = get_instance_node_attr(node, attr="creator_identifier")
                 if creator_id is not None:
                     # creator instance
                     cache.setdefault(creator_id, []).append(node)
                 else:
                     # legacy instance
-                    family = get_attr(node, attr="family")
+                    family = get_instance_node_attr(node, attr="family")
                     if family is None:
                         # must be a broken instance
                         continue

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -218,9 +218,11 @@ class ReferenceLoader(plugin.ReferenceLoader):
 
             if product_type == "rig":
                 options["lock_instance"] = (
-                        settings['maya']['load'].get(
-                        'reference_loader', {}
-                    ).get('lock_animation_instance_on_load', False)
+                    settings
+                    ["maya"]
+                    ["load"]
+                    ["reference_loader"]
+                    ["lock_animation_instance_on_load"]
                 )
                 self._post_process_rig(namespace, context, options)
             else:
@@ -258,10 +260,14 @@ class ReferenceLoader(plugin.ReferenceLoader):
             )
             product_type: str = context["product"]["productType"]
 
-        if product_type != "rig":
+        if product_type == "rig":
             # No special handling needed for non-rig containers
-            super().remove(container)
+            self._remove_rig(container)
+            return
 
+        super().remove(container)
+
+    def _remove_rig(self, container):
         members = get_container_members(container)
         object_sets = set()
         for member in members:

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -278,9 +278,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
         object_sets = set()
         for member in members:
             object_sets.update(
-                cmds.listSets(object=member,
-                            extendToShape=False,
-                            type=2) or []
+                cmds.listSets(object=member, extendToShape=False) or []
             )
 
         super().remove(container)

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -261,13 +261,18 @@ class ReferenceLoader(plugin.ReferenceLoader):
             product_type: str = context["product"]["productType"]
 
         if product_type == "rig":
-            # No special handling needed for non-rig containers
+            # Special handling needed for rig containers
             self._remove_rig(container)
             return
 
         super().remove(container)
 
     def _remove_rig(self, container):
+        """Remove rig container.
+
+        Args:
+            container (dict): The container to remove.
+        """
         members = get_container_members(container)
         object_sets = set()
         for member in members:
@@ -300,9 +305,23 @@ class ReferenceLoader(plugin.ReferenceLoader):
 
             # Then only here confirm whether this is an animation instance, if so
             # then we will want to auto-remove the instance
-            if is_animation_instance(object_set):
+            if self.is_animation_instance(object_set):
                 cmds.lockNode(object_set, lock=False)
                 cmds.delete(object_set)
+
+    def is_animation_instance(self, objectset: str) -> bool:
+        """Check if the given object set is an animation instance.
+
+        Arguments:
+            objectset (str): The name of the object set to check.
+
+        Returns:
+            bool: True if the object set is an animation instance, False otherwise.
+        """
+        creator_identifier = cmds.getAttr(f"{objectset}.creator_identifier")
+        if creator_identifier == "io.openpype.creators.maya.animation":
+            return True
+        return False
 
     def _post_process_rig(self, namespace, context, options):
 

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -215,7 +215,15 @@ class ReferenceLoader(plugin.ReferenceLoader):
                     self._set_display_handle(group_name)
 
             if product_type == "rig":
-                self._post_process_rig(namespace, context, options)
+                lock_set_on_load = settings['maya']['load'].get(
+                    'reference_loader', {}
+                ).get('lock_set_on_load', False)
+                self._post_process_rig(
+                    namespace,
+                    context,
+                    options,
+                    lock_set_on_load=lock_set_on_load
+                )
             else:
                 if "translate" in options:
                     if not attach_to_root and new_nodes:
@@ -239,12 +247,14 @@ class ReferenceLoader(plugin.ReferenceLoader):
         members = get_container_members(container)
         self._lock_camera_transforms(members)
 
-    def _post_process_rig(self, namespace, context, options):
+    def _post_process_rig(self, namespace, context, options, lock_set_on_load=False):
 
         nodes = self[:]
         try:
             create_rig_animation_instance(
-                nodes, context, namespace, options=options, log=self.log
+                nodes, context, namespace,
+                options=options, log=self.log,
+                lock_set_on_load=lock_set_on_load
             )
         except RigSetsNotExistError as exc:
             self.log.warning(

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -215,15 +215,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
                     self._set_display_handle(group_name)
 
             if product_type == "rig":
-                lock_set_on_load = settings['maya']['load'].get(
-                    'reference_loader', {}
-                ).get('lock_set_on_load', False)
-                self._post_process_rig(
-                    namespace,
-                    context,
-                    options,
-                    lock_set_on_load=lock_set_on_load
-                )
+                self._post_process_rig(namespace, context, options, settings)
             else:
                 if "translate" in options:
                     if not attach_to_root and new_nodes:
@@ -247,14 +239,14 @@ class ReferenceLoader(plugin.ReferenceLoader):
         members = get_container_members(container)
         self._lock_camera_transforms(members)
 
-    def _post_process_rig(self, namespace, context, options, lock_set_on_load=False):
+    def _post_process_rig(self, namespace, context, options, settings):
 
         nodes = self[:]
         try:
             create_rig_animation_instance(
                 nodes, context, namespace,
                 options=options, log=self.log,
-                lock_set_on_load=lock_set_on_load
+                settings=settings
             )
         except RigSetsNotExistError as exc:
             self.log.warning(

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -11,7 +11,6 @@ from ayon_maya.api.lib import (
     create_rig_animation_instance,
     get_container_members,
     maintained_selection,
-    is_animation_instance,
     parent_nodes,
 )
 from maya import cmds

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -261,13 +261,14 @@ class ReferenceLoader(plugin.ReferenceLoader):
 
         if product_type == "rig":
             # Special handling needed for rig containers
-            self._remove_rig(container)
+            self._removed_linked_animation_instance(container)
             return
 
         super().remove(container)
 
-    def _remove_rig(self, container):
-        """Remove rig container.
+    def _removed_linked_animation_instance(self, container):
+        """Remove linked animation instance no matter if it
+        is locked or not.
 
         Args:
             container (dict): The container to remove.
@@ -307,20 +308,6 @@ class ReferenceLoader(plugin.ReferenceLoader):
             if self.is_animation_instance(object_set):
                 cmds.lockNode(object_set, lock=False)
                 cmds.delete(object_set)
-
-    def is_animation_instance(self, objectset: str) -> bool:
-        """Check if the given object set is an animation instance.
-
-        Arguments:
-            objectset (str): The name of the object set to check.
-
-        Returns:
-            bool: True if the object set is an animation instance, False otherwise.
-        """
-        creator_identifier = cmds.getAttr(f"{objectset}.creator_identifier")
-        if creator_identifier == "io.openpype.creators.maya.animation":
-            return True
-        return False
 
     def _post_process_rig(self, namespace, context, options):
 

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -10,7 +10,7 @@ from ayon_maya.api.lib import (
     RigSetsNotExistError,
     create_rig_animation_instance,
     get_container_members,
-    is_animation_instance,
+    get_creator_identifier,
     maintained_selection,
     parent_nodes,
 )
@@ -304,7 +304,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
 
             # Then only here confirm whether this is an animation instance, if so
             # then we will want to auto-remove the instance
-            if is_animation_instance(object_set):
+            if get_creator_identifier(object_set) == "io.openpype.creators.maya.animation":
                 cmds.lockNode(object_set, lock=False)
                 cmds.delete(object_set)
 

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -266,7 +266,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
 
         super().remove(container)
 
-    def _removed_linked_animation_instance(self, container):
+    def _remove_rig(self, container):
         """Remove linked animation instance no matter if it
         is locked or not.
 

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -10,6 +10,7 @@ from ayon_maya.api.lib import (
     RigSetsNotExistError,
     create_rig_animation_instance,
     get_container_members,
+    is_animation_instance,
     maintained_selection,
     parent_nodes,
 )
@@ -261,7 +262,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
 
         if product_type == "rig":
             # Special handling needed for rig containers
-            self._removed_linked_animation_instance(container)
+            self._remove_rig(container)
             return
 
         super().remove(container)
@@ -305,7 +306,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
 
             # Then only here confirm whether this is an animation instance, if so
             # then we will want to auto-remove the instance
-            if self.is_animation_instance(object_set):
+            if is_animation_instance(object_set):
                 cmds.lockNode(object_set, lock=False)
                 cmds.delete(object_set)
 

--- a/server/settings/loaders.py
+++ b/server/settings/loaders.py
@@ -111,7 +111,7 @@ class ReferenceLoaderModel(BaseSettingsModel):
         title="Display Handle On Load References"
     )
     lock_animation_instance_on_load: bool = SettingsField(
-        title="Lock animation instance on rig load."
+        title="Lock Animation Instance on Rig Load"
     )
 
 

--- a/server/settings/loaders.py
+++ b/server/settings/loaders.py
@@ -110,6 +110,9 @@ class ReferenceLoaderModel(BaseSettingsModel):
     display_handle: bool = SettingsField(
         title="Display Handle On Load References"
     )
+    lock_set_on_load: bool = SettingsField(
+        title="Lock Set on Load"
+    )
 
 
 class ImportLoaderModel(BaseSettingsModel):
@@ -286,7 +289,8 @@ DEFAULT_LOADERS_SETTING = {
     "reference_loader": {
         "namespace": "{folder[name]}_{product[name]}_##_",
         "group_name": "_GRP",
-        "display_handle": True
+        "display_handle": True,
+        "lock_set_on_load": False
     },
     "import_loader": {
         "enabled": True,

--- a/server/settings/loaders.py
+++ b/server/settings/loaders.py
@@ -110,8 +110,8 @@ class ReferenceLoaderModel(BaseSettingsModel):
     display_handle: bool = SettingsField(
         title="Display Handle On Load References"
     )
-    lock_set_on_load: bool = SettingsField(
-        title="Lock Set when Create Animation Instance on load"
+    lock_animation_instance_on_load: bool = SettingsField(
+        title="Lock animation instance on rig load."
     )
 
 
@@ -290,7 +290,7 @@ DEFAULT_LOADERS_SETTING = {
         "namespace": "{folder[name]}_{product[name]}_##_",
         "group_name": "_GRP",
         "display_handle": True,
-        "lock_set_on_load": False
+        "lock_animation_instance_on_load": False
     },
     "import_loader": {
         "enabled": True,

--- a/server/settings/loaders.py
+++ b/server/settings/loaders.py
@@ -111,7 +111,7 @@ class ReferenceLoaderModel(BaseSettingsModel):
         title="Display Handle On Load References"
     )
     lock_set_on_load: bool = SettingsField(
-        title="Lock Set on Load"
+        title="Lock Set when Create Animation Instance on load"
     )
 
 


### PR DESCRIPTION
## Changelog Description
This PR is to add lock set on load in ayon setting so that users load the rig for animation publish. This would prevent users accidentally delete the instance during animating process.
Resolve https://github.com/ynput/ayon-maya/issues/131

## Additional review information
n/a

## Testing notes:
1. Enable `ayon+settings://maya/load/reference_loader/lock_set_on_load` and disable it 
<img width="1075" height="301" alt="image" src="https://github.com/user-attachments/assets/847b1f51-94f2-4f03-abdb-d14cda5ed261" />

2. Load Rig
3. Animating it
4. Publish
5. Should be all working
6. Removing instance is also working as expected