### PR TITLE
Expose `exportVisibility` for USD exports

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -508,6 +508,12 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                             "as UsdGeomSubset data.",
                     visible=visible,
                     default=False),
+            BoolDef("exportVisibility",
+                    label="Export Visibility",
+                    tooltip="Export any state and animation on Maya visibility"
+                            " attributes.",
+                    visible=visible,
+                    default=True),
             BoolDef("mergeTransformAndShape",
                     label="Merge Transform and Shape",
                     tooltip=(
@@ -535,6 +541,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                         "To specify per mesh subdivision schemes add a "
                         "USD_ATTR_subdivisionScheme attribute."
                     ),
+                    visible=visible,
                     default="catmullClark"
             )
         ]


### PR DESCRIPTION
## Changelog Description

Expose `exportVisibility` for USD exports.

## Additional review information

Add a toggle for USD exports to allow disabling the export of the visibility attributes. Which may be useful e.g. from animation instances if you don't want to override say the visibility state from lookdev.

## Testing notes:

1. Export visibility toggle should influence the resulting data in the generated USD file.
2. Attribute should be available only on USD instances.