### PR TITLE
Load: Added actions to lock and unlock container versions

### DIFF
--- a/client/ayon_maya/plugins/inventory/lock_version.py
+++ b/client/ayon_maya/plugins/inventory/lock_version.py
@@ -1,0 +1,44 @@
+from ayon_core.pipeline import InventoryAction
+from ayon_maya.api.lib import imprint, get_container_members
+
+
+class LockVersions(InventoryAction):
+    label = "Lock versions"
+    icon = "lock"
+    color = "#ffffff"
+    order = -1
+
+    @staticmethod
+    def is_compatible(container):
+        return container.get("version_locked") is not True
+
+    def process(self, containers):
+        for container in containers:
+            if container.get("version_locked") is True:
+                continue
+            container["version_locked"] = True
+            members = get_container_members(container)
+            for member in members:
+                imprint(member, {"version_locked": True})
+        return True
+
+
+class UnlockVersions(InventoryAction):
+    label = "Unlock versions"
+    icon = "lock-open"
+    color = "#ffffff"
+    order = -1
+
+    @staticmethod
+    def is_compatible(container):
+        return container.get("version_locked") is True
+
+    def process(self, containers):
+        for container in containers:
+            if container.get("version_locked") is not True:
+                continue
+            container["version_locked"] = False
+            members = get_container_members(container)
+            for member in members:
+                imprint(member, {"version_locked": False})
+        return True

--- a/client/ayon_maya/plugins/inventory/lock_version.py
+++ b/client/ayon_maya/plugins/inventory/lock_version.py
@@ -1,5 +1,6 @@
+from maya import cmds
+
 from ayon_core.pipeline import InventoryAction
-from ayon_maya.api.lib import imprint
 
 
 class LockVersions(InventoryAction):
@@ -17,7 +18,12 @@ class LockVersions(InventoryAction):
             if container.get("version_locked") is True:
                 continue
             node = container["objectName"]
-            imprint(node, {"version_locked": True})
+            key = "version_locked"
+            if not cmds.attributeQuery(key, node=node, exists=True):
+                cmds.addAttr(node, longName=key, attributeType=bool)
+            cmds.setAttr(
+                f"{node}.{key}", True, keyable=False, channelBox=True
+            )
         return True
 
 
@@ -36,5 +42,9 @@ class UnlockVersions(InventoryAction):
             if container.get("version_locked") is not True:
                 continue
             node = container["objectName"]
-            imprint(node, {"version_locked": False})
+            key = "version_locked"
+            if cmds.attributeQuery(key, node=node, exists=True):
+                cmds.setAttr(
+                    f"{node}.{key}", False, keyable=False, channelBox=True
+                )
         return True

--- a/client/ayon_maya/plugins/inventory/lock_version.py
+++ b/client/ayon_maya/plugins/inventory/lock_version.py
@@ -23,8 +23,9 @@ class LockVersions(InventoryAction):
                 continue
             node = container["objectName"]
             key = "version_locked"
-            if not cmds.attributeQuery(key, node=node, exists=True):
-                cmds.addAttr(node, longName=key, attributeType=bool)
+            if cmds.attributeQuery(key, node=node, exists=True):
+                cmds.deleteAttr(f"{node}.{key}")
+            cmds.addAttr(node, longName=key, attributeType=bool)
             cmds.setAttr(
                 f"{node}.{key}", True, keyable=False, channelBox=True
             )
@@ -48,7 +49,5 @@ class UnlockVersions(InventoryAction):
             node = container["objectName"]
             key = "version_locked"
             if cmds.attributeQuery(key, node=node, exists=True):
-                cmds.setAttr(
-                    f"{node}.{key}", False, keyable=False, channelBox=True
-                )
+                cmds.deleteAttr(f"{node}.{key}")
         return True

--- a/client/ayon_maya/plugins/inventory/lock_version.py
+++ b/client/ayon_maya/plugins/inventory/lock_version.py
@@ -16,7 +16,6 @@ class LockVersions(InventoryAction):
         for container in containers:
             if container.get("version_locked") is True:
                 continue
-            container["version_locked"] = True
             node = container["objectName"]
             imprint(node, {"version_locked": True})
         return True
@@ -36,7 +35,6 @@ class UnlockVersions(InventoryAction):
         for container in containers:
             if container.get("version_locked") is not True:
                 continue
-            container["version_locked"] = False
             node = container["objectName"]
             imprint(node, {"version_locked": False})
         return True

--- a/client/ayon_maya/plugins/inventory/lock_version.py
+++ b/client/ayon_maya/plugins/inventory/lock_version.py
@@ -1,5 +1,5 @@
 from ayon_core.pipeline import InventoryAction
-from ayon_maya.api.lib import imprint, get_container_members
+from ayon_maya.api.lib import imprint
 
 
 class LockVersions(InventoryAction):

--- a/client/ayon_maya/plugins/inventory/lock_version.py
+++ b/client/ayon_maya/plugins/inventory/lock_version.py
@@ -17,9 +17,8 @@ class LockVersions(InventoryAction):
             if container.get("version_locked") is True:
                 continue
             container["version_locked"] = True
-            members = get_container_members(container)
-            for member in members:
-                imprint(member, {"version_locked": True})
+            node = container["objectName"]
+            imprint(node, {"version_locked": True})
         return True
 
 
@@ -38,7 +37,6 @@ class UnlockVersions(InventoryAction):
             if container.get("version_locked") is not True:
                 continue
             container["version_locked"] = False
-            members = get_container_members(container)
-            for member in members:
-                imprint(member, {"version_locked": False})
+            node = container["objectName"]
+            imprint(node, {"version_locked": False})
         return True

--- a/client/ayon_maya/plugins/inventory/lock_version.py
+++ b/client/ayon_maya/plugins/inventory/lock_version.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 from maya import cmds
 
 from ayon_core.pipeline import InventoryAction
@@ -10,10 +14,10 @@ class LockVersions(InventoryAction):
     order = -1
 
     @staticmethod
-    def is_compatible(container):
+    def is_compatible(container: dict[str, Any]) -> bool:
         return container.get("version_locked") is not True
 
-    def process(self, containers):
+    def process(self, containers: list[dict[str, Any]]) -> bool:
         for container in containers:
             if container.get("version_locked") is True:
                 continue
@@ -34,10 +38,10 @@ class UnlockVersions(InventoryAction):
     order = -1
 
     @staticmethod
-    def is_compatible(container):
+    def is_compatible(container: dict[str, Any]) -> bool:
         return container.get("version_locked") is True
 
-    def process(self, containers):
+    def process(self, containers: list[dict[str, Any]]) -> bool:
         for container in containers:
             if container.get("version_locked") is not True:
                 continue


### PR DESCRIPTION
## Changelog Description
Implement inventory actions to be able to lock/unlock version of a container.

## Additional review information
The PR is related to https://github.com/ynput/ayon-core/pull/1447 which adds the option to lock and unload version of a container.

Added 2 actions to lock and unlock the version by settings `"version_locked"` on the object.

## Testing notes:
1. Make sure to use both PRs (if not merged yet).
2. Launch Maya.
3. Load something to scene that is not from latest version.
4. Open scene manager.
5. Select the container and run `Actions > Lock version` on the container.
6. Validation of outdated containers (e.g. during publishing) should not raise an error.