### PR TITLE
Create: Use kwargs to call product name functions

### DIFF
--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -629,12 +629,12 @@ class RenderlayerCreator(Creator, MayaCreatorBase):
             task_type = task_entity["taskType"]
         # creator.product_type != 'render' as expected
         return get_product_name(
-            project_name,
-            task_name,
-            task_type,
-            host_name,
-            self.layer_instance_prefix or self.product_type,
-            variant,
+            project_name=project_name,
+            task_name=task_name,
+            task_type=task_type,
+            host_name=host_name,
+            product_type=self.layer_instance_prefix or self.product_type,
+            variant=variant,
             dynamic_data=dynamic_data,
             project_settings=self.project_settings
         )


### PR DESCRIPTION
## Changelog Description
Use kwargs to call product name functions and use cached data to call them if possible.

## Additional review information
This is preparation for future change in `get_product_name` functionality and update of already added change in `get_product_name` method.

## Testing notes:
1. Product names are calculated correctly.
