### PR TITLE
Switch folders in scene inventory can update metadata with the asset across the libraries  

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -33,7 +33,7 @@ from ayon_core.pipeline import (
     AYON_CONTAINER_ID,
     Anatomy,
 )
-from ayon_core.pipeline.load import get_representation_path_from_anatomy
+from ayon_core.pipeline.load import get_representation_path_with_anatomy
 from ayon_core.lib import NumberDef
 from ayon_core.pipeline.context_tools import get_current_task_entity
 from ayon_core.pipeline.create import CreateContext
@@ -1893,7 +1893,7 @@ def get_representation_path_by_project(project_name, repre_entity):
     if project_name is None:
         project_name = get_current_project_name()
     anatomy = Anatomy(project_name)
-    return get_representation_path_from_anatomy(repre_entity, anatomy)
+    return get_representation_path_with_anatomy(repre_entity, anatomy)
 
 
 # region LOOKDEV

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -1879,18 +1879,16 @@ def get_container_members(container):
     return list(all_members)
 
 
-def get_representation_path_by_project(repre_entity, project_name=None):
+def get_representation_path_by_project(project_name, repre_entity):
     """Get the representation path for a given representation entity.
 
     Args:
+        project_name (str): The project name.
         repre_entity (dict): The representation entity.
-        project_name (str, optional): The project name. Defaults to None.
 
     Returns:
         str: The representation path.
     """
-    if project_name is None:
-        project_name = get_current_project_name()
     anatomy = Anatomy(project_name)
     return get_representation_path_from_anatomy(repre_entity, anatomy)
 
@@ -1964,7 +1962,7 @@ def assign_look_by_version(nodes, version_id):
 
     # Load relationships
     shader_relation = get_representation_path_by_project(
-        json_representation, project_name
+        project_name, json_representation
     )
     with open(shader_relation, "r") as f:
         relationships = json.load(f)

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -33,7 +33,7 @@ from ayon_core.pipeline import (
     AYON_CONTAINER_ID,
     Anatomy,
 )
-from ayon_core.pipeline.load import get_representation_path_from_anatomy
+from ayon_core.pipeline.load import get_representation_path_v2
 from ayon_core.lib import NumberDef
 from ayon_core.pipeline.context_tools import get_current_task_entity
 from ayon_core.pipeline.create import CreateContext
@@ -1879,20 +1879,6 @@ def get_container_members(container):
     return list(all_members)
 
 
-def get_representation_path_by_project(project_name, repre_entity):
-    """Get the representation path for a given representation entity.
-
-    Args:
-        project_name (str): The project name.
-        repre_entity (dict): The representation entity.
-
-    Returns:
-        str: The representation path.
-    """
-    anatomy = Anatomy(project_name)
-    return get_representation_path_from_anatomy(repre_entity, anatomy)
-
-
 # region LOOKDEV
 def list_looks(project_name, folder_id):
     """Return all look products for the given folder.
@@ -1961,7 +1947,7 @@ def assign_look_by_version(nodes, version_id):
     shader_nodes = get_container_members(container_node)
 
     # Load relationships
-    shader_relation = get_representation_path_by_project(
+    shader_relation = get_representation_path_v2(
         project_name, json_representation
     )
     with open(shader_relation, "r") as f:

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4262,20 +4262,6 @@ def get_creator_identifier(node: str) -> str | None:
     return get_attribute(f"{node}.creator_identifier")
 
 
-def is_animation_instance(objectset: str) -> bool:
-    """Check if the given object set is an animation instance.
-
-    Arguments:
-        objectset (str): The name of the object set to check.
-
-    Returns:
-        bool: True if the object set is an animation instance, False otherwise.
-    """
-    return (
-        get_creator_identifier(objectset) == "io.openpype.creators.maya.animation"
-    )
-
-
 def create_rig_animation_instance(
     nodes, context, namespace, options=None, log=None
 ):

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -31,7 +31,6 @@ from ayon_core.pipeline import (
     AVALON_INSTANCE_ID,
     AYON_INSTANCE_ID,
     AYON_CONTAINER_ID,
-    Anatomy,
 )
 from ayon_core.pipeline.load import get_representation_path_v2
 from ayon_core.lib import NumberDef

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4246,13 +4246,6 @@ def get_reference_node_parents(ref):
     return parents
 
 
-def get_instance_node_attr(node, attr, default=None):
-    """Helper to get attribute which allows attribute to not exist."""
-    if not cmds.attributeQuery(attr, node=node, exists=True):
-        return default
-    return cmds.getAttr("{}.{}".format(node, attr))
-
-
 def get_creator_identifier(node: str) -> str | None:
     """Get the creator identifier of an instance node.
 
@@ -4262,12 +4255,11 @@ def get_creator_identifier(node: str) -> str | None:
     Returns:
         str | None: The creator identifier of the instance or None if not found.
     """
-    if get_instance_node_attr(node, attr="id") not in {
+    if get_attribute(f"{node}.id") not in {
         AYON_INSTANCE_ID, AVALON_INSTANCE_ID
     }:
         return None
-
-    return get_instance_node_attr(node, "creator_identifier")
+    return get_attribute(f"{node}.creator_identifier")
 
 
 def is_animation_instance(objectset: str) -> bool:

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -25,13 +25,14 @@ from ayon_core.pipeline import (
     get_current_folder_path,
     discover_loader_plugins,
     loaders_from_representation,
-    get_representation_path,
+    get_representation_path_from_anatomy,
     load_container,
     registered_host,
     AVALON_CONTAINER_ID,
     AVALON_INSTANCE_ID,
     AYON_INSTANCE_ID,
     AYON_CONTAINER_ID,
+    Anatomy,
 )
 from ayon_core.lib import NumberDef
 from ayon_core.pipeline.context_tools import get_current_task_entity
@@ -1878,6 +1879,22 @@ def get_container_members(container):
     return list(all_members)
 
 
+def get_representation_path_by_project(repre_entity, project_name=None):
+    """Get the representation path for a given representation entity.
+
+    Args:
+        repre_entity (dict): The representation entity.
+        project_name (str, optional): The project name. Defaults to None.
+
+    Returns:
+        str: The representation path.
+    """
+    if project_name is None:
+        project_name = get_current_project_name()
+    anatomy = Anatomy
+    return get_representation_path_from_anatomy(repre_entity, anatomy)
+
+
 # region LOOKDEV
 def list_looks(project_name, folder_id):
     """Return all look products for the given folder.
@@ -1946,7 +1963,9 @@ def assign_look_by_version(nodes, version_id):
     shader_nodes = get_container_members(container_node)
 
     # Load relationships
-    shader_relation = get_representation_path(json_representation)
+    shader_relation = get_representation_path_by_project(
+        json_representation, project_name
+    )
     with open(shader_relation, "r") as f:
         relationships = json.load(f)
 

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -31,8 +31,9 @@ from ayon_core.pipeline import (
     AVALON_INSTANCE_ID,
     AYON_INSTANCE_ID,
     AYON_CONTAINER_ID,
+    Anatomy,
 )
-from ayon_core.pipeline.load import get_representation_path_v2
+from ayon_core.pipeline.load import get_representation_path_from_anatomy
 from ayon_core.lib import NumberDef
 from ayon_core.pipeline.context_tools import get_current_task_entity
 from ayon_core.pipeline.create import CreateContext
@@ -1878,6 +1879,23 @@ def get_container_members(container):
     return list(all_members)
 
 
+def get_representation_path_by_project(project_name, repre_entity):
+    """Get the representation path for a given representation entity.
+    This function would be used temporarily until the version from
+    the core addon is available.
+    Args:
+        project_name (str): The project name.
+        repre_entity (dict): The representation entity.
+        project_name (str, optional): The project name. Defaults to None.
+    Returns:
+        str: The representation path.
+    """
+    if project_name is None:
+        project_name = get_current_project_name()
+    anatomy = Anatomy(project_name)
+    return get_representation_path_from_anatomy(repre_entity, anatomy)
+
+
 # region LOOKDEV
 def list_looks(project_name, folder_id):
     """Return all look products for the given folder.
@@ -1946,7 +1964,7 @@ def assign_look_by_version(nodes, version_id):
     shader_nodes = get_container_members(container_node)
 
     # Load relationships
-    shader_relation = get_representation_path_v2(
+    shader_relation = get_representation_path_by_project(
         project_name, json_representation
     )
     with open(shader_relation, "r") as f:

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -25,7 +25,6 @@ from ayon_core.pipeline import (
     get_current_folder_path,
     discover_loader_plugins,
     loaders_from_representation,
-    get_representation_path_from_anatomy,
     load_container,
     registered_host,
     AVALON_CONTAINER_ID,
@@ -34,6 +33,7 @@ from ayon_core.pipeline import (
     AYON_CONTAINER_ID,
     Anatomy,
 )
+from ayon_core.pipeline.load import get_representation_path_from_anatomy
 from ayon_core.lib import NumberDef
 from ayon_core.pipeline.context_tools import get_current_task_entity
 from ayon_core.pipeline.create import CreateContext

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -27,11 +27,18 @@ from maya.app.renderSetup.model import renderSetup
 from pyblish.api import ContextPlugin, InstancePlugin
 
 from . import lib
-from .lib import imprint, read, unlocked, get_instance_node_attr
+from .lib import imprint, read, unlocked
 from .pipeline import containerise
 
 log = Logger.get_logger()
 SETTINGS_CATEGORY = "maya"
+
+
+def _get_attr(node, attr, default=None):
+    """Helper to get attribute which allows attribute to not exist."""
+    if not cmds.attributeQuery(attr, node=node, exists=True):
+        return default
+    return cmds.getAttr("{}.{}".format(node, attr))
 
 
 # Backwards compatibility: these functions has been moved to lib.
@@ -122,18 +129,18 @@ class MayaCreatorBase:
 
             for node in cmds.ls(type="objectSet"):
 
-                if get_instance_node_attr(node, attr="id") not in {
+                if _get_attr(node, attr="id") not in {
                     AYON_INSTANCE_ID, AVALON_INSTANCE_ID
                 }:
                     continue
 
-                creator_id = get_instance_node_attr(node, attr="creator_identifier")
+                creator_id = _get_attr(node, attr="creator_identifier")
                 if creator_id is not None:
                     # creator instance
                     cache.setdefault(creator_id, []).append(node)
                 else:
                     # legacy instance
-                    family = get_instance_node_attr(node, attr="family")
+                    family = _get_attr(node, attr="family")
                     if family is None:
                         # must be a broken instance
                         continue

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -16,7 +16,6 @@ from ayon_core.pipeline import (
     HiddenCreator,
     LoaderPlugin,
     get_current_project_name,
-    get_representation_path,
     publish,
 )
 from ayon_core.pipeline.create import get_product_name
@@ -848,8 +847,7 @@ class ReferenceLoader(Loader):
         project_name = context["project"]["name"]
         repre_entity = context["representation"]
 
-        path = get_representation_path(repre_entity)
-
+        path = self.filepath_from_context(context)
         # Get reference node from container members
         members = get_container_members(node)
         reference_node = lib.get_reference_node(members, self.log)

--- a/client/ayon_maya/api/setdress.py
+++ b/client/ayon_maya/api/setdress.py
@@ -344,7 +344,7 @@ def update_package(set_container, context):
     )
 
     current_file = get_representation_path_by_project(
-        current_representation, project_name
+        project_name, current_representation
     )
     assert current_file.endswith(".json")
     with open(current_file, "r") as fp:
@@ -352,7 +352,7 @@ def update_package(set_container, context):
 
     # Load the new package data
     new_file = get_representation_path_by_project(
-        repre_entity, project_name
+        project_name, repre_entity
     )
     assert new_file.endswith(".json")
     with open(new_file, "r") as fp:

--- a/client/ayon_maya/api/setdress.py
+++ b/client/ayon_maya/api/setdress.py
@@ -17,12 +17,12 @@ from ayon_core.pipeline import (
     remove_container,
     get_current_project_name,
 )
-from ayon_core.pipeline.load import get_representation_path_v2
 from ayon_maya.api.lib import (
     matrix_equals,
     unique_namespace,
     get_container_transforms,
-    DEFAULT_MATRIX
+    DEFAULT_MATRIX,
+    get_representation_path_by_project,
 )
 
 log = logging.getLogger("PackageLoader")
@@ -343,7 +343,7 @@ def update_package(set_container, context):
         project_name, set_container["representation"]
     )
 
-    current_file = get_representation_path_v2(
+    current_file = get_representation_path_by_project(
         project_name, current_representation
     )
     assert current_file.endswith(".json")
@@ -351,7 +351,7 @@ def update_package(set_container, context):
         current_data = json.load(fp)
 
     # Load the new package data
-    new_file = get_representation_path_v2(
+    new_file = get_representation_path_by_project(
         project_name, repre_entity
     )
     assert new_file.endswith(".json")

--- a/client/ayon_maya/api/setdress.py
+++ b/client/ayon_maya/api/setdress.py
@@ -17,11 +17,11 @@ from ayon_core.pipeline import (
     remove_container,
     get_current_project_name,
 )
+from ayon_core.pipeline.load import get_representation_path_v2
 from ayon_maya.api.lib import (
     matrix_equals,
     unique_namespace,
     get_container_transforms,
-    get_representation_path_by_project,
     DEFAULT_MATRIX
 )
 
@@ -343,7 +343,7 @@ def update_package(set_container, context):
         project_name, set_container["representation"]
     )
 
-    current_file = get_representation_path_by_project(
+    current_file = get_representation_path_v2(
         project_name, current_representation
     )
     assert current_file.endswith(".json")
@@ -351,7 +351,7 @@ def update_package(set_container, context):
         current_data = json.load(fp)
 
     # Load the new package data
-    new_file = get_representation_path_by_project(
+    new_file = get_representation_path_v2(
         project_name, repre_entity
     )
     assert new_file.endswith(".json")

--- a/client/ayon_maya/api/setdress.py
+++ b/client/ayon_maya/api/setdress.py
@@ -15,13 +15,13 @@ from ayon_core.pipeline import (
     load_container,
     update_container,
     remove_container,
-    get_representation_path,
     get_current_project_name,
 )
 from ayon_maya.api.lib import (
     matrix_equals,
     unique_namespace,
     get_container_transforms,
+    get_representation_path_by_project,
     DEFAULT_MATRIX
 )
 
@@ -343,13 +343,17 @@ def update_package(set_container, context):
         project_name, set_container["representation"]
     )
 
-    current_file = get_representation_path(current_representation)
+    current_file = get_representation_path_by_project(
+        current_representation, project_name
+    )
     assert current_file.endswith(".json")
     with open(current_file, "r") as fp:
         current_data = json.load(fp)
 
     # Load the new package data
-    new_file = get_representation_path(repre_entity)
+    new_file = get_representation_path_by_project(
+        repre_entity, project_name
+    )
     assert new_file.endswith(".json")
     with open(new_file, "r") as fp:
         new_data = json.load(fp)

--- a/client/ayon_maya/plugins/inventory/connect_ornatrix_rig.py
+++ b/client/ayon_maya/plugins/inventory/connect_ornatrix_rig.py
@@ -9,10 +9,10 @@ from ayon_core.pipeline import (
     get_repres_contexts,
     get_current_project_name
 )
-from ayon_core.pipeline.load import get_representation_path_v2
 from ayon_maya.api.lib import (
     get_container_members,
-    get_node_name
+    get_node_name,
+    get_representation_path_by_project,
 )
 from ayon_api import (
     get_representation_by_id,
@@ -96,7 +96,7 @@ class ConnectOrnatrixRig(InventoryAction):
         )
 
         # Validate source representation is an alembic.
-        source_path = get_representation_path_v2(
+        source_path = get_representation_path_by_project(
             source_project,
             repre_contexts_by_id[source_repre_id]["representation"]
         ).replace("\\", "/")
@@ -131,7 +131,7 @@ class ConnectOrnatrixRig(InventoryAction):
                 representation_name="rigsettings")
             if not settings_repre:
                 continue
-            settings_file = get_representation_path_v2(
+            settings_file = get_representation_path_by_project(
                 project_name, settings_repre
             )
             if not os.path.exists(settings_file):

--- a/client/ayon_maya/plugins/inventory/connect_ornatrix_rig.py
+++ b/client/ayon_maya/plugins/inventory/connect_ornatrix_rig.py
@@ -9,9 +9,9 @@ from ayon_core.pipeline import (
     get_repres_contexts,
     get_current_project_name
 )
+from ayon_core.pipeline.load import get_representation_path_v2
 from ayon_maya.api.lib import (
     get_container_members,
-    get_representation_path_by_project,
     get_node_name
 )
 from ayon_api import (
@@ -96,7 +96,7 @@ class ConnectOrnatrixRig(InventoryAction):
         )
 
         # Validate source representation is an alembic.
-        source_path = get_representation_path_by_project(
+        source_path = get_representation_path_v2(
             source_project,
             repre_contexts_by_id[source_repre_id]["representation"]
         ).replace("\\", "/")
@@ -131,7 +131,7 @@ class ConnectOrnatrixRig(InventoryAction):
                 representation_name="rigsettings")
             if not settings_repre:
                 continue
-            settings_file = get_representation_path_by_project(
+            settings_file = get_representation_path_v2(
                 project_name, settings_repre
             )
             if not os.path.exists(settings_file):

--- a/client/ayon_maya/plugins/inventory/connect_ornatrix_rig.py
+++ b/client/ayon_maya/plugins/inventory/connect_ornatrix_rig.py
@@ -7,10 +7,13 @@ from typing import List, Dict, Any, Optional
 from ayon_core.pipeline import (
     InventoryAction,
     get_repres_contexts,
-    get_representation_path,
     get_current_project_name
 )
-from ayon_maya.api.lib import get_container_members, get_node_name
+from ayon_maya.api.lib import (
+    get_container_members,
+    get_representation_path_by_project,
+    get_node_name
+)
 from ayon_api import (
     get_representation_by_id,
     get_representation_by_name
@@ -88,10 +91,14 @@ class ConnectOrnatrixRig(InventoryAction):
         source_container = source_containers[0]
         source_repre_id = source_container["representation"]
         source_namespace = source_container["namespace"]
+        source_project = source_container.get(
+            "project_name", get_current_project_name()
+        )
 
         # Validate source representation is an alembic.
-        source_path = get_representation_path(
-            repre_contexts_by_id[source_repre_id]["representation"]
+        source_path = get_representation_path_by_project(
+            repre_contexts_by_id[source_repre_id]["representation"],
+            source_project
         ).replace("\\", "/")
         message = "Animation container \"{}\" is not an alembic:\n{}".format(
             source_container["namespace"], source_path
@@ -124,7 +131,9 @@ class ConnectOrnatrixRig(InventoryAction):
                 representation_name="rigsettings")
             if not settings_repre:
                 continue
-            settings_file = get_representation_path(settings_repre)
+            settings_file = get_representation_path_by_project(
+                settings_repre, project_name
+            )
             if not os.path.exists(settings_file):
                 continue
 

--- a/client/ayon_maya/plugins/inventory/connect_ornatrix_rig.py
+++ b/client/ayon_maya/plugins/inventory/connect_ornatrix_rig.py
@@ -97,8 +97,8 @@ class ConnectOrnatrixRig(InventoryAction):
 
         # Validate source representation is an alembic.
         source_path = get_representation_path_by_project(
-            repre_contexts_by_id[source_repre_id]["representation"],
-            source_project
+            source_project,
+            repre_contexts_by_id[source_repre_id]["representation"]
         ).replace("\\", "/")
         message = "Animation container \"{}\" is not an alembic:\n{}".format(
             source_container["namespace"], source_path
@@ -132,7 +132,7 @@ class ConnectOrnatrixRig(InventoryAction):
             if not settings_repre:
                 continue
             settings_file = get_representation_path_by_project(
-                settings_repre, project_name
+                project_name, settings_repre
             )
             if not os.path.exists(settings_file):
                 continue

--- a/client/ayon_maya/plugins/inventory/connect_xgen.py
+++ b/client/ayon_maya/plugins/inventory/connect_xgen.py
@@ -67,8 +67,8 @@ class ConnectXgen(InventoryAction):
 
         # Validate source representation is an alembic.
         source_path = get_representation_path_by_project(
-            repre_contexts_by_id[source_repre_id]["representation"],
-            source_project
+            source_project,
+            repre_contexts_by_id[source_repre_id]["representation"]
         ).replace("\\", "/")
         message = "Animation container \"{}\" is not an alembic:\n{}".format(
             source_container["namespace"], source_path

--- a/client/ayon_maya/plugins/inventory/connect_xgen.py
+++ b/client/ayon_maya/plugins/inventory/connect_xgen.py
@@ -6,7 +6,7 @@ from ayon_core.pipeline import (
     get_repres_contexts,
     get_current_project_name,
 )
-from ayon_maya.api.lib import get_representation_path_by_project
+from ayon_core.pipeline.load import get_representation_path_v2
 
 
 class ConnectXgen(InventoryAction):
@@ -66,7 +66,7 @@ class ConnectXgen(InventoryAction):
         )
 
         # Validate source representation is an alembic.
-        source_path = get_representation_path_by_project(
+        source_path = get_representation_path_v2(
             source_project,
             repre_contexts_by_id[source_repre_id]["representation"]
         ).replace("\\", "/")

--- a/client/ayon_maya/plugins/inventory/connect_xgen.py
+++ b/client/ayon_maya/plugins/inventory/connect_xgen.py
@@ -4,8 +4,9 @@ import xgenm
 from ayon_core.pipeline import (
     InventoryAction,
     get_repres_contexts,
-    get_representation_path,
+    get_current_project_name,
 )
+from ayon_maya.api.lib import get_representation_path_by_project
 
 
 class ConnectXgen(InventoryAction):
@@ -60,10 +61,14 @@ class ConnectXgen(InventoryAction):
         source_container = source_containers[0]
         source_repre_id = source_container["representation"]
         source_object = source_container["objectName"]
+        source_project = source_container.get(
+            "project_name", get_current_project_name()
+        )
 
         # Validate source representation is an alembic.
-        source_path = get_representation_path(
-            repre_contexts_by_id[source_repre_id]["representation"]
+        source_path = get_representation_path_by_project(
+            repre_contexts_by_id[source_repre_id]["representation"],
+            source_project
         ).replace("\\", "/")
         message = "Animation container \"{}\" is not an alembic:\n{}".format(
             source_container["namespace"], source_path

--- a/client/ayon_maya/plugins/inventory/connect_xgen.py
+++ b/client/ayon_maya/plugins/inventory/connect_xgen.py
@@ -6,7 +6,7 @@ from ayon_core.pipeline import (
     get_repres_contexts,
     get_current_project_name,
 )
-from ayon_core.pipeline.load import get_representation_path_v2
+from ayon_maya.api.lib import get_representation_path_by_project
 
 
 class ConnectXgen(InventoryAction):
@@ -66,7 +66,7 @@ class ConnectXgen(InventoryAction):
         )
 
         # Validate source representation is an alembic.
-        source_path = get_representation_path_v2(
+        source_path = get_representation_path_by_project(
             source_project,
             repre_contexts_by_id[source_repre_id]["representation"]
         ).replace("\\", "/")

--- a/client/ayon_maya/plugins/inventory/connect_yeti_rig.py
+++ b/client/ayon_maya/plugins/inventory/connect_yeti_rig.py
@@ -9,10 +9,10 @@ from ayon_core.pipeline import (
     get_repres_contexts,
     get_current_project_name,
 )
+from ayon_core.pipeline.load import get_representation_path_v2
 from ayon_maya.api.lib import (
     get_container_members,
     get_id,
-    get_representation_path_by_project,
 )
 
 
@@ -85,7 +85,7 @@ class ConnectYetiRig(InventoryAction):
             target_ids.update(self.nodes_by_id(container))
             repre_id = container["representation"]
 
-            maya_file = get_representation_path_by_project(
+            maya_file = get_representation_path_v2(
                 source_project,
                 repre_contexts_by_id[repre_id]["representation"]
             )

--- a/client/ayon_maya/plugins/inventory/connect_yeti_rig.py
+++ b/client/ayon_maya/plugins/inventory/connect_yeti_rig.py
@@ -7,9 +7,13 @@ from maya import cmds
 from ayon_core.pipeline import (
     InventoryAction,
     get_repres_contexts,
-    get_representation_path,
+    get_current_project_name,
 )
-from ayon_maya.api.lib import get_container_members, get_id
+from ayon_maya.api.lib import (
+    get_container_members,
+    get_id,
+    get_representation_path_by_project,
+)
 
 
 class ConnectYetiRig(InventoryAction):
@@ -62,6 +66,9 @@ class ConnectYetiRig(InventoryAction):
 
         source_container = source_containers[0]
         source_ids = self.nodes_by_id(source_container)
+        source_project = source_container.get(
+            "project_name", get_current_project_name()
+        )
 
         # Target containers.
         target_ids = {}
@@ -78,8 +85,9 @@ class ConnectYetiRig(InventoryAction):
             target_ids.update(self.nodes_by_id(container))
             repre_id = container["representation"]
 
-            maya_file = get_representation_path(
-                repre_contexts_by_id[repre_id]["representation"]
+            maya_file = get_representation_path_by_project(
+                repre_contexts_by_id[repre_id]["representation"],
+                source_project
             )
             _, ext = os.path.splitext(maya_file)
             settings_file = maya_file.replace(ext, ".rigsettings")

--- a/client/ayon_maya/plugins/inventory/connect_yeti_rig.py
+++ b/client/ayon_maya/plugins/inventory/connect_yeti_rig.py
@@ -86,8 +86,8 @@ class ConnectYetiRig(InventoryAction):
             repre_id = container["representation"]
 
             maya_file = get_representation_path_by_project(
-                repre_contexts_by_id[repre_id]["representation"],
-                source_project
+                source_project,
+                repre_contexts_by_id[repre_id]["representation"]
             )
             _, ext = os.path.splitext(maya_file)
             settings_file = maya_file.replace(ext, ".rigsettings")

--- a/client/ayon_maya/plugins/inventory/connect_yeti_rig.py
+++ b/client/ayon_maya/plugins/inventory/connect_yeti_rig.py
@@ -9,10 +9,10 @@ from ayon_core.pipeline import (
     get_repres_contexts,
     get_current_project_name,
 )
-from ayon_core.pipeline.load import get_representation_path_v2
 from ayon_maya.api.lib import (
     get_container_members,
     get_id,
+    get_representation_path_by_project,
 )
 
 
@@ -85,7 +85,7 @@ class ConnectYetiRig(InventoryAction):
             target_ids.update(self.nodes_by_id(container))
             repre_id = container["representation"]
 
-            maya_file = get_representation_path_v2(
+            maya_file = get_representation_path_by_project(
                 source_project,
                 repre_contexts_by_id[repre_id]["representation"]
             )

--- a/client/ayon_maya/plugins/inventory/import_modelrender.py
+++ b/client/ayon_maya/plugins/inventory/import_modelrender.py
@@ -145,7 +145,7 @@ class ImportModelRender(InventoryAction):
             print("No model render sets for this model version..")
             return
 
-        # TODO use 'get_representation_path_with_anatomy' instead
+        # TODO use 'get_representation_path_by_project_with_anatomy' instead
         #   of 'filepath_from_context'
         context = contexts_by_repre_id.get(look_repre["id"])
         maya_file = self.filepath_from_context(context)

--- a/client/ayon_maya/plugins/inventory/import_modelrender.py
+++ b/client/ayon_maya/plugins/inventory/import_modelrender.py
@@ -145,7 +145,7 @@ class ImportModelRender(InventoryAction):
             print("No model render sets for this model version..")
             return
 
-        # TODO use 'get_representation_path_by_project_with_anatomy' instead
+        # TODO use 'get_representation_path_with_anatomy' instead
         #   of 'filepath_from_context'
         context = contexts_by_repre_id.get(look_repre["id"])
         maya_file = self.filepath_from_context(context)

--- a/client/ayon_maya/plugins/load/load_arnold_standin.py
+++ b/client/ayon_maya/plugins/load/load_arnold_standin.py
@@ -2,7 +2,6 @@ import os
 
 import clique
 import maya.cmds as cmds
-from ayon_core.pipeline import get_representation_path
 from ayon_core.settings import get_project_settings
 from ayon_maya.api.lib import (
     get_attribute_input,
@@ -202,7 +201,7 @@ class ArnoldStandinLoader(plugin.Loader):
                 standin = shapes[0]
 
         repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = self.filepath_from_context(context)
         proxy_basename, proxy_path = self._get_proxy_path(path)
 
         # Whether there is proxy or not, we still update the string operator.

--- a/client/ayon_maya/plugins/load/load_audio.py
+++ b/client/ayon_maya/plugins/load/load_audio.py
@@ -1,4 +1,3 @@
-from ayon_core.pipeline import get_representation_path
 from ayon_maya.api.lib import get_container_members, unique_namespace
 from ayon_maya.api.pipeline import containerise
 from ayon_maya.api import plugin
@@ -58,7 +57,7 @@ class AudioLoader(plugin.Loader):
         )
         activate_sound = current_sound == audio_node
 
-        path = get_representation_path(repre_entity)
+        path = self.filepath_from_context(context)
 
         cmds.sound(
             audio_node,

--- a/client/ayon_maya/plugins/load/load_gpucache.py
+++ b/client/ayon_maya/plugins/load/load_gpucache.py
@@ -1,5 +1,4 @@
 import maya.cmds as cmds
-from ayon_core.pipeline import get_representation_path
 from ayon_core.settings import get_project_settings
 from ayon_maya.api.lib import unique_namespace
 from ayon_maya.api.pipeline import containerise
@@ -74,7 +73,7 @@ class GpuCacheLoader(plugin.Loader):
 
     def update(self, container, context):
         repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = self.filepath_from_context(context)
 
         # Update the cache
         members = cmds.sets(container['objectName'], query=True)

--- a/client/ayon_maya/plugins/load/load_image.py
+++ b/client/ayon_maya/plugins/load/load_image.py
@@ -7,7 +7,6 @@ from ayon_core.pipeline.colorspace import (
     get_imageio_file_rules,
     get_imageio_file_rules_colorspace_from_filepath,
 )
-from ayon_core.pipeline.load.utils import get_representation_path_from_context
 from ayon_core.settings import get_project_settings
 from ayon_maya.api.lib import namespaced, unique_namespace
 from ayon_maya.api.pipeline import containerise
@@ -276,7 +275,7 @@ class FileNodeLoader(plugin.Loader):
             project_settings=project_settings
         )
 
-        path = get_representation_path_from_context(context)
+        path = self.filepath_from_context(context)
         colorspace = get_imageio_file_rules_colorspace_from_filepath(
             path,
             host_name,
@@ -296,7 +295,7 @@ class FileNodeLoader(plugin.Loader):
         template = representation.get("attrib", {}).get("template")
         if not template:
             # No template to find token locations for
-            return get_representation_path_from_context(context)
+            return self.filepath_from_context(context)
 
         def _placeholder(key):
             # Substitute with a long placeholder value so that potential
@@ -324,7 +323,7 @@ class FileNodeLoader(plugin.Loader):
 
         # Replace with our custom template that has the tokens set
         representation["attrib"]["template"] = template
-        path = get_representation_path_from_context(context)
+        path = self.filepath_from_context(context)
 
         if has_tokens:
             for key, token in tokens.items():

--- a/client/ayon_maya/plugins/load/load_image_plane.py
+++ b/client/ayon_maya/plugins/load/load_image_plane.py
@@ -1,4 +1,3 @@
-from ayon_core.pipeline import get_representation_path
 from ayon_maya.api.lib import (
     get_container_members,
     namespaced,
@@ -217,7 +216,7 @@ class ImagePlaneLoader(plugin.Loader):
         assert image_planes, "Image plane not found."
         image_plane_shape = image_planes[0]
 
-        path = get_representation_path(repre_entity)
+        path = self.filepath_from_context(context)
         cmds.setAttr("{}.imageName".format(image_plane_shape),
                      path,
                      type="string")

--- a/client/ayon_maya/plugins/load/load_look.py
+++ b/client/ayon_maya/plugins/load/load_look.py
@@ -9,7 +9,7 @@ from ayon_core.tools.utils import ScrollMessageBox
 from ayon_maya.api import lib
 from ayon_maya.api.lib import (
     get_reference_node,
-    get_representation_path_by_project
+    get_representation_path_v2
 )
 from qtpy import QtWidgets
 
@@ -82,7 +82,7 @@ class LookLoader(ayon_maya.api.plugin.ReferenceLoader):
         )
 
         # Load relationships
-        shader_relation = get_representation_path_by_project(
+        shader_relation = get_representation_path_v2(
             project_name, json_representation
         )
         with open(shader_relation, "r") as f:

--- a/client/ayon_maya/plugins/load/load_look.py
+++ b/client/ayon_maya/plugins/load/load_look.py
@@ -5,10 +5,12 @@ from collections import defaultdict
 
 import ayon_maya.api.plugin
 from ayon_api import get_representation_by_name
-from ayon_core.pipeline import get_representation_path
 from ayon_core.tools.utils import ScrollMessageBox
 from ayon_maya.api import lib
-from ayon_maya.api.lib import get_reference_node
+from ayon_maya.api.lib import (
+    get_reference_node,
+    get_representation_path_by_project
+)
 from qtpy import QtWidgets
 
 
@@ -80,7 +82,9 @@ class LookLoader(ayon_maya.api.plugin.ReferenceLoader):
         )
 
         # Load relationships
-        shader_relation = get_representation_path(json_representation)
+        shader_relation = get_representation_path_by_project(
+            json_representation, project_name
+        )
         with open(shader_relation, "r") as f:
             json_data = json.load(f)
 

--- a/client/ayon_maya/plugins/load/load_look.py
+++ b/client/ayon_maya/plugins/load/load_look.py
@@ -6,9 +6,11 @@ from collections import defaultdict
 import ayon_maya.api.plugin
 from ayon_api import get_representation_by_name
 from ayon_core.tools.utils import ScrollMessageBox
-from ayon_core.pipeline.load import get_representation_path_v2
 from ayon_maya.api import lib
-from ayon_maya.api.lib import get_reference_node
+from ayon_maya.api.lib import (
+    get_reference_node,
+    get_representation_path_by_project
+)
 
 from qtpy import QtWidgets
 
@@ -81,7 +83,7 @@ class LookLoader(ayon_maya.api.plugin.ReferenceLoader):
         )
 
         # Load relationships
-        shader_relation = get_representation_path_v2(
+        shader_relation = get_representation_path_by_project(
             project_name, json_representation
         )
         with open(shader_relation, "r") as f:

--- a/client/ayon_maya/plugins/load/load_look.py
+++ b/client/ayon_maya/plugins/load/load_look.py
@@ -83,7 +83,7 @@ class LookLoader(ayon_maya.api.plugin.ReferenceLoader):
 
         # Load relationships
         shader_relation = get_representation_path_by_project(
-            json_representation, project_name
+            project_name, json_representation
         )
         with open(shader_relation, "r") as f:
             json_data = json.load(f)

--- a/client/ayon_maya/plugins/load/load_look.py
+++ b/client/ayon_maya/plugins/load/load_look.py
@@ -6,11 +6,10 @@ from collections import defaultdict
 import ayon_maya.api.plugin
 from ayon_api import get_representation_by_name
 from ayon_core.tools.utils import ScrollMessageBox
+from ayon_core.pipeline.load import get_representation_path_v2
 from ayon_maya.api import lib
-from ayon_maya.api.lib import (
-    get_reference_node,
-    get_representation_path_v2
-)
+from ayon_maya.api.lib import get_reference_node
+
 from qtpy import QtWidgets
 
 

--- a/client/ayon_maya/plugins/load/load_multiverse_usd.py
+++ b/client/ayon_maya/plugins/load/load_multiverse_usd.py
@@ -3,7 +3,6 @@ import os
 
 import maya.cmds as cmds
 from ayon_api import get_representation_by_id
-from ayon_core.pipeline import get_representation_path
 from ayon_maya.api import plugin
 from ayon_maya.api.lib import maintained_selection, namespaced, unique_namespace
 from ayon_maya.api.pipeline import containerise
@@ -72,7 +71,7 @@ class MultiverseUsdLoader(plugin.Loader):
 
         project_name = context["project"]["name"]
         repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = self.filepath_from_context(context)
         prev_representation_id = cmds.getAttr("{}.representation".format(node))
         prev_representation = get_representation_by_id(project_name,
                                                        prev_representation_id)

--- a/client/ayon_maya/plugins/load/load_multiverse_usd_over.py
+++ b/client/ayon_maya/plugins/load/load_multiverse_usd_over.py
@@ -4,7 +4,6 @@ import os
 import maya.cmds as cmds
 import qargparse
 from ayon_api import get_representation_by_id
-from ayon_core.pipeline import get_representation_path
 from ayon_maya.api import plugin
 from ayon_maya.api.lib import maintained_selection
 from ayon_maya.api.pipeline import containerise
@@ -90,7 +89,7 @@ class MultiverseUsdOverLoader(plugin.Loader):
                                                        prev_representation_id)
         prev_path = os.path.normpath(prev_representation["attrib"]["path"])
 
-        path = get_representation_path(repre_entity)
+        path = self.filepath_from_context(context)
 
         for shape in shapes:
             asset_paths = multiverse.GetUsdCompoundAssetPaths(shape)

--- a/client/ayon_maya/plugins/load/load_redshift_proxy.py
+++ b/client/ayon_maya/plugins/load/load_redshift_proxy.py
@@ -4,7 +4,6 @@ import os
 
 import clique
 import maya.cmds as cmds
-from ayon_core.pipeline import get_representation_path
 from ayon_core.settings import get_project_settings
 from ayon_maya.api import plugin
 from ayon_maya.api.lib import maintained_selection, namespaced, unique_namespace
@@ -78,7 +77,7 @@ class RedshiftProxyLoader(plugin.Loader):
         rs_meshes = cmds.ls(members, type="RedshiftProxyMesh")
         assert rs_meshes, "Cannot find RedshiftProxyMesh in container"
         repre_entity = context["representation"]
-        filename = get_representation_path(repre_entity)
+        filename = self.filepath_from_context(context)
 
         for rs_mesh in rs_meshes:
             cmds.setAttr("{}.fileName".format(rs_mesh),

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -278,9 +278,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
         object_sets = set()
         for member in members:
             object_sets.update(
-                cmds.listSets(object=member,
-                            extendToShape=False,
-                            type=2) or []
+                cmds.listSets(object=member, extendToShape=False) or []
             )
 
         super().remove(container)

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -10,7 +10,7 @@ from ayon_maya.api.lib import (
     RigSetsNotExistError,
     create_rig_animation_instance,
     get_container_members,
-    is_animation_instance,
+    get_creator_identifier,
     maintained_selection,
     parent_nodes,
 )
@@ -304,7 +304,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
 
             # Then only here confirm whether this is an animation instance, if so
             # then we will want to auto-remove the instance
-            if is_animation_instance(object_set):
+            if get_creator_identifier(object_set) == "io.openpype.creators.maya.animation":
                 cmds.lockNode(object_set, lock=False)
                 cmds.delete(object_set)
 

--- a/client/ayon_maya/plugins/load/load_rendersetup.py
+++ b/client/ayon_maya/plugins/load/load_rendersetup.py
@@ -13,7 +13,6 @@ import maya.app.renderSetup.model.renderSetup as renderSetup
 from maya import cmds
 
 from ayon_core.lib import BoolDef, EnumDef
-from ayon_core.pipeline import get_representation_path
 from ayon_maya.api import lib
 from ayon_maya.api import plugin
 from ayon_maya.api.pipeline import containerise
@@ -146,7 +145,7 @@ class RenderSetupLoader(plugin.Loader):
             "setting specified by user not included in loaded version "
             "will be lost.")
         repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = self.filepath_from_context(context)
         with open(path, "r") as file:
             try:
                 renderSetup.instance().decode(

--- a/client/ayon_maya/plugins/load/load_vdb_to_arnold.py
+++ b/client/ayon_maya/plugins/load/load_vdb_to_arnold.py
@@ -6,7 +6,6 @@ TODO:
 """
 import os
 
-from ayon_core.pipeline import get_representation_path
 from ayon_core.settings import get_project_settings
 from ayon_maya.api import plugin
 from ayon_maya.api.plugin import get_load_color_for_product_type
@@ -86,7 +85,7 @@ class LoadVDBtoArnold(plugin.Loader):
 
         repre_entity = context["representation"]
 
-        path = get_representation_path(repre_entity)
+        path = self.filepath_from_context(context)
 
         # Find VRayVolumeGrid
         members = cmds.sets(container['objectName'], query=True)

--- a/client/ayon_maya/plugins/load/load_vdb_to_redshift.py
+++ b/client/ayon_maya/plugins/load/load_vdb_to_redshift.py
@@ -1,7 +1,6 @@
 import os
 from typing import List
 
-from ayon_core.pipeline import get_representation_path
 from ayon_core.settings import get_project_settings
 from ayon_core.lib import BoolDef
 
@@ -106,7 +105,7 @@ class LoadVDBtoRedShift(plugin.Loader):
     def update(self, container, context):
 
         repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = self.filepath_from_context(context)
 
         # Find VRayVolumeGrid
         members = cmds.sets(container['objectName'], query=True)

--- a/client/ayon_maya/plugins/load/load_vdb_to_vray.py
+++ b/client/ayon_maya/plugins/load/load_vdb_to_vray.py
@@ -1,6 +1,5 @@
 import os
 
-from ayon_core.pipeline import get_representation_path
 from ayon_core.settings import get_project_settings
 from ayon_maya.api import plugin
 from ayon_maya.api.plugin import get_load_color_for_product_type
@@ -251,7 +250,7 @@ class LoadVDBtoVRay(plugin.Loader):
     def update(self, container, context):
         repre_entity = context["representation"]
 
-        path = get_representation_path(repre_entity)
+        path = self.filepath_from_context(context)
 
         # Find VRayVolumeGrid
         members = cmds.sets(container['objectName'], query=True)

--- a/client/ayon_maya/plugins/load/load_vrayproxy.py
+++ b/client/ayon_maya/plugins/load/load_vrayproxy.py
@@ -9,9 +9,13 @@ import os
 
 import ayon_api
 import maya.cmds as cmds
-from ayon_core.pipeline import get_representation_path
 from ayon_core.settings import get_project_settings
-from ayon_maya.api.lib import maintained_selection, namespaced, unique_namespace
+from ayon_maya.api.lib import (
+    maintained_selection,
+    namespaced,
+    unique_namespace,
+    get_representation_path_by_project,
+)
 from ayon_maya.api.pipeline import containerise
 from ayon_maya.api import plugin
 from ayon_maya.api.plugin import get_load_color_for_product_type
@@ -185,7 +189,7 @@ class VRayProxyLoader(plugin.Loader):
         )
         if abc_rep:
             self.log.debug("Found, we'll link alembic to vray proxy.")
-            file_name = get_representation_path(abc_rep)
+            file_name = get_representation_path_by_project(abc_rep, project_name)
             self.log.debug("File: {}".format(file_name))
             return file_name
 

--- a/client/ayon_maya/plugins/load/load_vrayproxy.py
+++ b/client/ayon_maya/plugins/load/load_vrayproxy.py
@@ -189,7 +189,7 @@ class VRayProxyLoader(plugin.Loader):
         )
         if abc_rep:
             self.log.debug("Found, we'll link alembic to vray proxy.")
-            file_name = get_representation_path_by_project(abc_rep, project_name)
+            file_name = get_representation_path_by_project(project_name, abc_rep)
             self.log.debug("File: {}".format(file_name))
             return file_name
 

--- a/client/ayon_maya/plugins/load/load_vrayproxy.py
+++ b/client/ayon_maya/plugins/load/load_vrayproxy.py
@@ -10,11 +10,11 @@ import os
 import ayon_api
 import maya.cmds as cmds
 from ayon_core.settings import get_project_settings
-from ayon_core.pipeline.load import get_representation_path_v2
 from ayon_maya.api.lib import (
     maintained_selection,
     namespaced,
-    unique_namespace
+    unique_namespace,
+    get_representation_path_by_project
 )
 from ayon_maya.api.pipeline import containerise
 from ayon_maya.api import plugin
@@ -189,7 +189,7 @@ class VRayProxyLoader(plugin.Loader):
         )
         if abc_rep:
             self.log.debug("Found, we'll link alembic to vray proxy.")
-            file_name = get_representation_path_v2(project_name, abc_rep)
+            file_name = get_representation_path_by_project(project_name, abc_rep)
             self.log.debug("File: {}".format(file_name))
             return file_name
 

--- a/client/ayon_maya/plugins/load/load_vrayproxy.py
+++ b/client/ayon_maya/plugins/load/load_vrayproxy.py
@@ -103,7 +103,7 @@ class VRayProxyLoader(plugin.Loader):
             context["project"]["name"], context["version"]["id"]
         )
         if not filename:
-            filename = get_representation_path(repre_entity)
+            filename = self.filepath_from_context(context)
 
         for vray_mesh in vraymeshes:
             cmds.setAttr("{}.fileName".format(vray_mesh),

--- a/client/ayon_maya/plugins/load/load_vrayproxy.py
+++ b/client/ayon_maya/plugins/load/load_vrayproxy.py
@@ -10,11 +10,11 @@ import os
 import ayon_api
 import maya.cmds as cmds
 from ayon_core.settings import get_project_settings
+from ayon_core.pipeline.load import get_representation_path_v2
 from ayon_maya.api.lib import (
     maintained_selection,
     namespaced,
-    unique_namespace,
-    get_representation_path_by_project,
+    unique_namespace
 )
 from ayon_maya.api.pipeline import containerise
 from ayon_maya.api import plugin
@@ -189,7 +189,7 @@ class VRayProxyLoader(plugin.Loader):
         )
         if abc_rep:
             self.log.debug("Found, we'll link alembic to vray proxy.")
-            file_name = get_representation_path_by_project(project_name, abc_rep)
+            file_name = get_representation_path_v2(project_name, abc_rep)
             self.log.debug("File: {}".format(file_name))
             return file_name
 

--- a/client/ayon_maya/plugins/load/load_vrayscene.py
+++ b/client/ayon_maya/plugins/load/load_vrayscene.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import maya.cmds as cmds  # noqa
-from ayon_core.pipeline import get_representation_path
 from ayon_core.settings import get_project_settings
 from ayon_maya.api.lib import maintained_selection, namespaced, unique_namespace
 from ayon_maya.api.pipeline import containerise
@@ -72,7 +71,7 @@ class VRaySceneLoader(plugin.Loader):
         assert vraymeshes, "Cannot find VRayScene in container"
 
         repre_entity = context["representation"]
-        filename = get_representation_path(repre_entity)
+        filename = self.filepath_from_context(context)
 
         for vray_mesh in vraymeshes:
             cmds.setAttr("{}.FilePath".format(vray_mesh),

--- a/client/ayon_maya/plugins/load/load_xgen.py
+++ b/client/ayon_maya/plugins/load/load_xgen.py
@@ -4,7 +4,6 @@ import shutil
 from ayon_maya.api import plugin
 import maya.cmds as cmds
 import xgenm
-from ayon_core.pipeline import get_representation_path
 from ayon_maya.api import current_file
 from ayon_maya.api.lib import (
     attribute_values,
@@ -145,8 +144,7 @@ class XgenLoader(plugin.ReferenceLoader):
 
         self.set_palette_attributes(xgen_palette, xgen_file, xgd_file)
 
-        repre_entity = context["representation"]
-        maya_file = get_representation_path(repre_entity)
+        maya_file = self.filepath_from_context(context)
         _, extension = os.path.splitext(maya_file)
         new_xgen_file = maya_file.replace(extension, ".xgen")
         data_path = ""

--- a/client/ayon_maya/plugins/load/load_yeti_cache.py
+++ b/client/ayon_maya/plugins/load/load_yeti_cache.py
@@ -4,7 +4,6 @@ import re
 from collections import defaultdict
 
 import clique
-from ayon_core.pipeline import get_representation_path
 from ayon_core.settings import get_project_settings
 from ayon_maya.api import lib
 from ayon_maya.api.pipeline import containerise
@@ -132,7 +131,7 @@ class YetiCacheLoader(plugin.Loader):
         namespace = container["namespace"]
         container_node = container["objectName"]
 
-        path = get_representation_path(repre_entity)
+        path = self.filepath_from_context(context)
         settings = self.read_settings(path)
 
         # Collect scene information of asset

--- a/client/ayon_maya/tools/mayalookassigner/lib.py
+++ b/client/ayon_maya/tools/mayalookassigner/lib.py
@@ -34,7 +34,7 @@ def get_look_relationships(version_id: str) -> dict:
 
     # Load relationships
     shader_relation = lib.get_representation_path_by_project(
-        json_representation, project_name
+        project_name, json_representation
     )
     with open(shader_relation, "r") as f:
         relationships = json.load(f)

--- a/client/ayon_maya/tools/mayalookassigner/lib.py
+++ b/client/ayon_maya/tools/mayalookassigner/lib.py
@@ -6,7 +6,6 @@ from ayon_api import get_representation_by_name
 
 from ayon_core.pipeline import (
     get_current_project_name,
-    get_representation_path,
     registered_host,
     discover_loader_plugins,
     loaders_from_representation,
@@ -34,7 +33,9 @@ def get_look_relationships(version_id: str) -> dict:
     )
 
     # Load relationships
-    shader_relation = get_representation_path(json_representation)
+    shader_relation = lib.get_representation_path_by_project(
+        json_representation, project_name
+    )
     with open(shader_relation, "r") as f:
         relationships = json.load(f)
 

--- a/client/ayon_maya/tools/mayalookassigner/lib.py
+++ b/client/ayon_maya/tools/mayalookassigner/lib.py
@@ -11,6 +11,7 @@ from ayon_core.pipeline import (
     loaders_from_representation,
     load_container
 )
+from ayon_core.pipeline.load import get_representation_path_v2
 from ayon_maya.api import lib
 
 
@@ -33,7 +34,7 @@ def get_look_relationships(version_id: str) -> dict:
     )
 
     # Load relationships
-    shader_relation = lib.get_representation_path_by_project(
+    shader_relation = get_representation_path_v2(
         project_name, json_representation
     )
     with open(shader_relation, "r") as f:

--- a/client/ayon_maya/tools/mayalookassigner/lib.py
+++ b/client/ayon_maya/tools/mayalookassigner/lib.py
@@ -11,7 +11,6 @@ from ayon_core.pipeline import (
     loaders_from_representation,
     load_container
 )
-from ayon_core.pipeline.load import get_representation_path_v2
 from ayon_maya.api import lib
 
 
@@ -34,7 +33,7 @@ def get_look_relationships(version_id: str) -> dict:
     )
 
     # Load relationships
-    shader_relation = get_representation_path_v2(
+    shader_relation = lib.get_representation_path_by_project(
         project_name, json_representation
     )
     with open(shader_relation, "r") as f:


### PR DESCRIPTION
## Changelog Description
This PR is to make sure updating/switching folder in scene inventory can update metadata with the asset which are loaded from different libraries. 
Resolve https://github.com/ynput/ayon-maya/issues/328

## Additional review information
Tested with all loaders, look assigners, connect actions etc.
Please uses the PR for testing: https://github.com/ynput/ayon-core/pull/1451

## Testing notes:
1. Load Everything
2. Tested with Connect action, look assigners
3. Should be working 