### PR TITLE
Load Rig: Fix load if attach to root is disabled due to UnboundLocalError for 'settings'

### DIFF
--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -183,6 +183,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
 
             self[:] = new_nodes
 
+            settings = get_project_settings(project_name)
             if attach_to_root:
                 group_name = "|" + group_name
                 roots = cmds.listRelatives(group_name,
@@ -196,7 +197,6 @@ class ReferenceLoader(plugin.ReferenceLoader):
                     with parent_nodes(roots, parent=None):
                         cmds.xform(group_name, zeroTransformPivots=True)
 
-                settings = get_project_settings(project_name)
                 color = plugin.get_load_color_for_product_type(
                     product_type, settings
                 )


### PR DESCRIPTION
## Changelog Description

Avoids error:
```python
During load error happened on Product: "rigMain" Representation: "ma" Version: 7

Error message: cannot access local variable 'settings' where it is not associated with a value

Traceback (most recent call last):
  File "/mnt/home/fin/.local/share/AYON/addons/core_1.6.1/ayon_core/tools/loader/models/actions.py", line 747, in _load_representations_by_loader
    load_with_repre_context(
  File "/mnt/home/fin/.local/share/AYON/addons/core_1.6.1/ayon_core/pipeline/load/utils.py", line 324, in load_with_repre_context
    return loader.load(repre_context, name, namespace, options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/home/fin/.local/share/AYON/addons/core_1.6.1/ayon_core/pipeline/load/plugins.py", line 420, in wrapped_method
    result = original_method(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/home/fin/.local/share/AYON/addons/maya_0.4.15/ayon_maya/api/plugin.py", line 812, in load
    self.process_reference(
  File "/mnt/home/fin/.local/share/AYON/addons/maya_0.4.15/ayon_maya/plugins/load/load_reference.py", line 221, in process_reference
    settings
UnboundLocalError: cannot access local variable 'settings' where it is not associated with a value
```

## Additional review information

Reported by client.

It got broken with PR https://github.com/ynput/ayon-maya/pull/340

## Testing notes:

1. Load rig with attach to root disabled should work. (Attach to root is the "Group Reference" behavior)
