### PR TITLE
Image Loader: load any image 🖼️

### DIFF
--- a/client/ayon_maya/plugins/load/load_image.py
+++ b/client/ayon_maya/plugins/load/load_image.py
@@ -83,9 +83,10 @@ def create_stencil():
 class FileNodeLoader(plugin.Loader):
     """File node loader."""
 
-    product_types = {"image", "plate", "render"}
+    product_types = {"*"}
     label = "Load file node"
-    representations = {"exr", "tif", "png", "jpg"}
+    representations = {"*"}
+    extensions = {"exr", "tif", "png", "jpg", "jpeg"}
     icon = "image"
     color = "orange"
     order = 2


### PR DESCRIPTION
## Changelog Description
Image Loader will load any supported image format and is no longer constrained by product type or representation name.



## Testing notes:
1) publish texture in Tray Publisher
2) load it in Maya
