### PR TITLE
Fix AYON menu failing to install when launching into workspace with invalid workspace.mel

### DIFF
--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -289,7 +289,15 @@ def _set_project():
         else:
             raise
 
-    cmds.workspace(workdir, openWorkspace=True)
+    try:
+        cmds.workspace(workdir, openWorkspace=True)
+    except RuntimeError:
+        # Allow to pass through with an error log in case `workspace.mel`
+        # may have been invalid or setting workspace fails for some other
+        # reason.
+        log.error(
+            "Failed to set Maya workspace to '%s': %s", workdir, exc_info=True
+        )
 
 
 def _on_maya_initialized(*args):


### PR DESCRIPTION
## Changelog Description

Allow to passthrough on failing to open a workspace with a logged error - just so that if it happens during startup on install the remainder of the code still runs and the AYON menu will still end up appearing.

## Additional review information

In a context put some gibberish code in the `workspace.mel` - now with this PR when launching into the context the AYON menu will still install. You can also try breaking the `workspace.mel` in `ayon+settings://maya/mel_workspace` because launching Maya via AYON should generate that workspace (it might actually always do that, see e.g. [here](https://github.com/ynput/ayon-maya/blob/ca40abe992efce70d9ef26f049a5500513ba0ea7/client/ayon_maya/hooks/pre_copy_mel.py#L5-L23))

Related to: https://discord.com/channels/517362899170230292/1438459788928483378/1438461418281373778 (private)

**Note: This PR is very low priority - it's purely for stability in the case someones happens to have some corrupt workspace configured.**

## Testing notes:

1. With broken `workspace.mel` the AYON menu should still install.