### PR TITLE
Lock version action: Fix attribute type definition

### DIFF
--- a/client/ayon_maya/plugins/inventory/lock_version.py
+++ b/client/ayon_maya/plugins/inventory/lock_version.py
@@ -25,7 +25,7 @@ class LockVersions(InventoryAction):
             key = "version_locked"
             if cmds.attributeQuery(key, node=node, exists=True):
                 cmds.deleteAttr(f"{node}.{key}")
-            cmds.addAttr(node, longName=key, attributeType=bool)
+            cmds.addAttr(node, longName=key, attributeType="bool")
             cmds.setAttr(
                 f"{node}.{key}", True, keyable=False, channelBox=True
             )


### PR DESCRIPTION
## Changelog Description
Fix lock version action.

## Additional review information
Filled `attributeType` was `bool` type but it should be a string `"bool"` instead.

## Testing notes:
1. Lock version action works.
