### PR TITLE
Feature/eng 3362/fix color management prefs disable

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -3496,6 +3496,12 @@ def set_colorspace(project_settings=None):
         cmds.colorManagementPrefs(edit=True, cmEnabled=False)
         return
 
+    if not imageio["workfile"]["enabled"]:
+        log.info(
+            "AYON Maya Color Management settings for workfile are disabled."
+        )
+        return
+        
     # set color spaces for rendering space and view transforms
     def _colormanage(**kwargs):
         """Wrapper around `cmds.colorManagementPrefs`.


### PR DESCRIPTION
## Changelog Description

Add support for `activate_host_color_management` setting in Maya's `set_colorspace()` function. When this setting is `false`, Maya's color management is now explicitly disabled. 

## Additional review information
Previously, only the `workfile.enabled` setting was checked, which would simply skip color management configuration but not disable it, leaving Maya with its default (enabled) state. This allows studios to explicitly disable color management via AYON settings rather than relying on Maya's default preferences.

## Testing notes:

1. Set Maya imageio settings: `activate_host_color_management: false`, `workfile.enabled: false`
2. Launch Maya through AYON - verify color management is disabled in Preferences > Color Management
3. Set Maya imageio settings: `activate_host_color_management: true`, `workfile.enabled: false`
4. Launch Maya through AYON - verify color management state is unchanged (Maya defaults)
5. Set Maya imageio settings: `activate_host_color_management: true`, `workfile.enabled: true`
6. Launch Maya through AYON - verify color management is enabled with the configured render space, display, and view settings