### PR TITLE
Fix Extract Playblast not triggering when review is attached to another instance

### DIFF
--- a/client/ayon_maya/plugins/publish/collect_review.py
+++ b/client/ayon_maya/plugins/publish/collect_review.py
@@ -70,12 +70,13 @@ class CollectReview(plugin.MayaInstancePlugin):
             data = reviewable_inst.data
 
             self.log.debug(
-                'Adding review family to {}'.format(reviewable_product)
+                'Adding review families to {}'.format(reviewable_product)
             )
+            review_families = ["review", "review.playblast"]
             if data.get('families'):
-                data['families'].append('review')
+                data['families'].extend(review_families)
             else:
-                data['families'] = ['review']
+                data['families'] = review_families
 
             data["cameras"] = cameras
             data['review_camera'] = camera


### PR DESCRIPTION
## Changelog Description

Fix Extract Playblast not triggering when review is attached to another product (e.g. `pointcache` instance object set is inside the `review` instance object set)

## Additional review information

Mentioned [here](https://discord.com/channels/517362899170230292/563751989075378201/1473218121350381642)

## Testing notes:

1. Playblast should trigger correctly in all scenarios.
