### PR TITLE
Camera: Check if image plane is referenced during detaching in the context

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_camera_mayaScene.py
+++ b/client/ayon_maya/plugins/publish/extract_camera_mayaScene.py
@@ -286,8 +286,8 @@ def transfer_image_planes(source_cameras, target_cameras,
                 # TODO: Find a way to manage referenced image planes
                 if cmds.referenceQuery(image_plane, isNodeReferenced=True):
                     log.warning(
-                        f"Image plane {image_plane} is referenced,"
-                        " skipping reattachment"
+                        f"Image plane '{image_plane}' is referenced,"
+                        " skipping reattachment for camera extraction."
                     )
                     continue
                 if keep_input_connections:


### PR DESCRIPTION
## Changelog Description
This PR is to check if image plane is referenced during detaching in the context. If it is the reference node, it would skip the detaching process. 
Resolve https://github.com/ynput/ayon-maya/issues/401

## Additional review information
I am not sure if it is right approach to do so make it draft before final decision is made.

## Testing notes:
1. Create Camera with image plane
2. Publish Camera
3. Loaded back the published camera
4. Then publish 'camera' product type with that loaded camera.
