### PR TITLE
Load USD: Ayon entity uri in Hero version should be loaded correctly 

### DIFF
--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -122,16 +122,15 @@ def _convert_uri(uri: str) -> str:
     version = results["version"]
     # strip the "v" from version and convert to int
     version_number = int(version[1:])
-    if version_number < 0:
-        version = "hero"
+    if version_number > 0:
+        return uri
 
     return (
-        "ayon+entity://{project}{folder_path}?product={product}&version={version}"
+        "ayon+entity://{project}{folder_path}?product={product}&version=hero"
         "&representation={representation}".format(
             project=results["project"],
             folder_path=results["folderPath"],
             product=results["product"],
-            version=version,
             representation=results["representation"]
         )
     )

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -20,6 +20,7 @@ from ayon_core.pipeline import (
     get_current_project_name,
     publish,
 )
+from ayon_core.pipeline.entity_uri import parse_ayon_entity_uri
 from ayon_core.pipeline.load import LoadError
 from ayon_core.settings import get_project_settings
 
@@ -104,7 +105,36 @@ def get_ayon_entity_uri_from_representation_context(context: dict) -> str:
             f"representation id '{representation_id}' to single URI. "
             f"Received data: {response.data}"
         )
-    return uris[0]["uri"]
+    return _convert_uri(uris[0]["uri"])
+
+
+def _convert_uri(uri: str) -> str:
+    """Convert an AYON entity URI to its hero version.
+
+    Args:
+        uri (str): The AYON entity URI to convert.
+
+    Returns:
+        str: The converted hero AYON entity URI.
+
+    """
+    results = parse_ayon_entity_uri(uri)
+    version = results["version"]
+    # strip the "v" from version and convert to int
+    version_number = int(version[1:])
+    if version_number < 0:
+        version = "hero"
+
+    return (
+        "ayon+entity://{project}{folder_path}?product={product}&version={version}"
+        "&representation={representation}".format(
+            project=results["project"],
+            folder_path=results["folderPath"],
+            product=results["product"],
+            version=version,
+            representation=results["representation"]
+        )
+    )
 
 
 class MayaCreatorBase:

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 import json
 import os
+from urllib.parse import urlparse
 
 import ayon_api
 import qargparse
@@ -125,9 +126,11 @@ def _convert_uri(uri: str) -> str:
     if version_number > 0:
         return uri
 
+    scheme = urlparse(uri).scheme
     return (
-        "ayon+entity://{project}{folder_path}?product={product}&version=hero"
+        "{scheme}://{project}{folder_path}?product={product}&version=hero"
         "&representation={representation}".format(
+            scheme=scheme,
             project=results["project"],
             folder_path=results["folderPath"],
             product=results["product"],


### PR DESCRIPTION
## Changelog Description
This PR is to fix the broken ayon entity uri when users trying to load the asset in hero version.
Resolve https://github.com/ynput/ayon-maya/issues/417

## Additional review information
n/a

## Testing notes:
1. Load USD with `ayon+settings://maya/load/MayaUsdLoader/use_ayon_entity_uri` enabled
2. Go to scene inventory to set version for both hero and versioned
3. The entity should be showcased without negative version
<img width="841" height="206" alt="image" src="https://github.com/user-attachments/assets/ca9be2d1-0651-4ee5-b12f-f925f8705315" />

