### PR TITLE
Validate FPS against task FPS instead of folder FPS 

### DIFF
--- a/client/ayon_maya/plugins/publish/validate_maya_units.py
+++ b/client/ayon_maya/plugins/publish/validate_maya_units.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import pyblish.api
+
 import ayon_maya.api.lib as mayalib
 import maya.cmds as cmds
 from ayon_core.pipeline.publish import (
@@ -37,58 +41,56 @@ class ValidateMayaUnits(plugin.MayaContextPlugin,
     def process(self, context):
         if not self.is_active(context.data):
             return
+
         # Collected units
-        linearunits = context.data.get('linearUnits')
-        angularunits = context.data.get('angularUnits')
+        scene_linear_units = context.data.get('linearUnits')
+        scene_angular_units = context.data.get('angularUnits')
+        scene_fps = context.data.get('fps')
+        self.log.info('Units (linear): {0}'.format(scene_linear_units))
+        self.log.info('Units (angular): {0}'.format(scene_angular_units))
+        self.log.info('Units (time): {0} FPS'.format(scene_fps))
 
-        fps = context.data.get('fps')
-
-        folder_attributes = context.data["folderEntity"]["attrib"]
-        folder_fps = mayalib.convert_to_maya_fps(folder_attributes["fps"])
-
-        self.log.info('Units (linear): {0}'.format(linearunits))
-        self.log.info('Units (angular): {0}'.format(angularunits))
-        self.log.info('Units (time): {0} FPS'.format(fps))
-
-        invalid = []
+        context_fps = mayalib.convert_to_maya_fps(
+            self._get_context_fps(context)
+        )
 
         project_settings: dict = context.data["project_settings"]
         linear_units, angular_units = get_scene_units_settings(
             project_settings
         )
 
+        invalid = []
         # Check if units are correct
         if (
             self.validate_linear_units
-            and linearunits
-            and linearunits != linear_units
+            and scene_linear_units
+            and scene_linear_units != linear_units
         ):
             invalid.append({
                 "setting": "Linear units",
                 "required_value": linear_units,
-                "current_value": linearunits
+                "current_value": scene_linear_units
             })
 
         if (
             self.validate_angular_units
-            and angularunits
-            and angularunits != angular_units
+            and scene_angular_units
+            and scene_angular_units != angular_units
         ):
             invalid.append({
                 "setting": "Angular units",
                 "required_value": angular_units,
-                "current_value": angularunits
+                "current_value": scene_angular_units
             })
 
-        if self.validate_fps and fps and fps != folder_fps:
+        if self.validate_fps and scene_fps and scene_fps != context_fps:
             invalid.append({
                 "setting": "FPS",
-                "required_value": folder_fps,
-                "current_value": fps
+                "required_value": context_fps,
+                "current_value": scene_fps
             })
 
         if invalid:
-
             issues = []
             for data in invalid:
                 self.log.error(self.log_message_format.format(**data))
@@ -114,6 +116,10 @@ class ValidateMayaUnits(plugin.MayaContextPlugin,
             cls.log.info("Setting linear unit to '{}'".format(linear_units))
             cmds.currentUnit(linear=linear_units)
 
-        cls.log.info("Setting time unit to match project")
-        folder_entity = context.data["folderEntity"]
-        mayalib.set_scene_fps(folder_entity["attrib"]["fps"])
+        context_fps = cls._get_context_fps(context)
+        cls.log.info(f"Setting time unit to match context: {context_fps}")
+        mayalib.set_scene_fps(context_fps)
+
+    @staticmethod
+    def _get_context_fps(context: pyblish.api.Context) -> float:
+        return context.data["taskEntity"]["attrib"]["fps"]

--- a/client/ayon_maya/plugins/publish/validate_maya_units.py
+++ b/client/ayon_maya/plugins/publish/validate_maya_units.py
@@ -43,12 +43,12 @@ class ValidateMayaUnits(plugin.MayaContextPlugin,
             return
 
         # Collected units
-        scene_linear_units = context.data.get('linearUnits')
-        scene_angular_units = context.data.get('angularUnits')
-        scene_fps = context.data.get('fps')
-        self.log.info('Units (linear): {0}'.format(scene_linear_units))
-        self.log.info('Units (angular): {0}'.format(scene_angular_units))
-        self.log.info('Units (time): {0} FPS'.format(scene_fps))
+        scene_linear_units = context.data.get("linearUnits")
+        scene_angular_units = context.data.get("angularUnits")
+        scene_fps = context.data.get("fps")
+        self.log.info(f"Units (linear): {scene_linear_units}")
+        self.log.info(f"Units (angular): {scene_angular_units}")
+        self.log.info(f"Units (time): {scene_fps} FPS")
 
         context_fps = mayalib.convert_to_maya_fps(
             self._get_context_fps(context)
@@ -109,11 +109,11 @@ class ValidateMayaUnits(plugin.MayaContextPlugin,
 
         linear_units, angular_units = get_scene_units_settings()
         if cls.validate_angular_units:
-            cls.log.info("Setting angular unit to '{}'".format(angular_units))
+            cls.log.info(f"Setting angular unit to '{angular_units}'")
             cmds.currentUnit(angle=angular_units)
 
         if cls.validate_linear_units:
-            cls.log.info("Setting linear unit to '{}'".format(linear_units))
+            cls.log.info(f"Setting linear unit to '{linear_units}'")
             cmds.currentUnit(linear=linear_units)
 
         context_fps = cls._get_context_fps(context)


### PR DESCRIPTION
## Changelog Description

Validate FPS against task FPS instead of folder FPS 

## Additional review information

Fix https://github.com/ynput/ayon-maya/issues/421

## Testing notes:

1. FPS should be validated against the task of the context, not using the folder's FPS.
