### PR TITLE
Improve debug message for validate frame range

### DIFF
--- a/client/ayon_maya/plugins/publish/validate_frame_range.py
+++ b/client/ayon_maya/plugins/publish/validate_frame_range.py
@@ -82,10 +82,10 @@ class ValidateFrameRange(plugin.MayaInstancePlugin,
             return
 
         checks = {
+            "frame start from context": (frame_start_handle, inst_start),
+            "frame end from context": (frame_end_handle, inst_end),
             "frame start": (frame_start, inst_frame_start),
             "frame end": (frame_end, inst_frame_end),
-            "frame start handle": (frame_start_handle, inst_start),
-            "frame end handle": (frame_end_handle, inst_end),
             "handle start": (handle_start, inst_handle_start),
             "handle end": (handle_end, inst_handle_end)
         }

--- a/client/ayon_maya/plugins/publish/validate_frame_range.py
+++ b/client/ayon_maya/plugins/publish/validate_frame_range.py
@@ -82,19 +82,17 @@ class ValidateFrameRange(plugin.MayaInstancePlugin,
             return
 
         checks = {
-            "frame start from context": (frame_start_handle, inst_start),
-            "frame end from context": (frame_end_handle, inst_end),
+            "frame start including handles": (frame_start_handle, inst_start),
+            "frame end including handles": (frame_end_handle, inst_end),
             "frame start": (frame_start, inst_frame_start),
             "frame end": (frame_end, inst_frame_end),
             "handle start": (handle_start, inst_handle_start),
             "handle end": (handle_end, inst_handle_end)
         }
-        for label, values in checks.items():
-            if values[0] != values[1]:
+        for label, (required, current) in checks.items():
+            if current != required:
                 errors.append(
-                    "{} on instance is {} but should be {}. ".format(
-                        label.title(), values[0], values[1]
-                    )
+                    f"{label.title()} on instance is {current} but should be {required}. "
                 )
 
         if errors:
@@ -102,7 +100,7 @@ class ValidateFrameRange(plugin.MayaInstancePlugin,
             folder_path = context.data.get("folderPath")
             if task_name:
                 report = (
-                    "Frame range settings do not match \n\n"
+                    "Frame range settings do not match"
                     f"task '{task_name}' in folder '{folder_path}'.\n\n"
                 )
             else:

--- a/client/ayon_maya/plugins/publish/validate_frame_range.py
+++ b/client/ayon_maya/plugins/publish/validate_frame_range.py
@@ -92,12 +92,24 @@ class ValidateFrameRange(plugin.MayaInstancePlugin,
         for label, values in checks.items():
             if values[0] != values[1]:
                 errors.append(
-                    "{} on instance ({}) does not match with the folder "
-                    "({}).".format(label.title(), values[1], values[0])
+                    "{} on instance is {} but should be {}. ".format(
+                        label.title(), values[0], values[1]
+                    )
                 )
 
         if errors:
-            report = "Frame range settings are incorrect.\n\n"
+            task_name = context.data.get("task")
+            folder_path = context.data.get("folderPath")
+            if task_name:
+                report = (
+                    "Frame range settings do not match \n\n"
+                    f"task '{task_name}' in folder '{folder_path}'.\n\n"
+                )
+            else:
+                report = (
+                    "Frame range settings do not match \n\n"
+                    f"folder '{folder_path}'.\n\n"
+                )
             for error in errors:
                 report += "- {}\n\n".format(error)
 

--- a/client/ayon_maya/plugins/publish/validate_frame_range.py
+++ b/client/ayon_maya/plugins/publish/validate_frame_range.py
@@ -101,12 +101,12 @@ class ValidateFrameRange(plugin.MayaInstancePlugin,
             if task_name:
                 report = (
                     "Frame range settings do not match"
-                    f"task '{task_name}' in folder '{folder_path}'.\n\n"
+                    f" task '{task_name}' in folder '{folder_path}'.\n\n"
                 )
             else:
                 report = (
-                    "Frame range settings do not match \n\n"
-                    f"folder '{folder_path}'.\n\n"
+                    "Frame range settings do not match"
+                    f" folder '{folder_path}'.\n\n"
                 )
             for error in errors:
                 report += "- {}\n\n".format(error)

--- a/client/ayon_maya/plugins/publish/validate_frame_range.py
+++ b/client/ayon_maya/plugins/publish/validate_frame_range.py
@@ -82,10 +82,10 @@ class ValidateFrameRange(plugin.MayaInstancePlugin,
             return
 
         checks = {
-            "frame start handle": (frame_start_handle, inst_start),
-            "frame end handle": (frame_end_handle, inst_end),
             "frame start": (frame_start, inst_frame_start),
             "frame end": (frame_end, inst_frame_end),
+            "frame start handle": (frame_start_handle, inst_start),
+            "frame end handle": (frame_end_handle, inst_end),
             "handle start": (handle_start, inst_handle_start),
             "handle end": (handle_end, inst_handle_end)
         }

--- a/client/ayon_maya/plugins/publish/validate_frame_range.py
+++ b/client/ayon_maya/plugins/publish/validate_frame_range.py
@@ -81,25 +81,9 @@ class ValidateFrameRange(plugin.MayaInstancePlugin,
         ]:
             return
 
-        if (inst_start != frame_start_handle):
-            errors.append("Instance start frame [ {} ] doesn't "
-                          "match the one set on folder [ {} ]: "
-                          "{}/{}/{}/{} (handle/start/end/handle)".format(
-                              inst_start,
-                              frame_start_handle,
-                              handle_start, frame_start, frame_end, handle_end
-                          ))
-
-        if (inst_end != frame_end_handle):
-            errors.append("Instance end frame [ {} ] doesn't "
-                          "match the one set on folder [ {} ]: "
-                          "{}/{}/{}/{} (handle/start/end/handle)".format(
-                              inst_end,
-                              frame_end_handle,
-                              handle_start, frame_start, frame_end, handle_end
-                          ))
-
         checks = {
+            "frame start handle": (frame_start_handle, inst_start),
+            "frame end handle": (frame_end_handle, inst_end),
             "frame start": (frame_start, inst_frame_start),
             "frame end": (frame_end, inst_frame_end),
             "handle start": (handle_start, inst_handle_start),


### PR DESCRIPTION
## Changelog Description
This PR is to improve debug message for validate frame range so that the users won't be confused where they should correct their frame range settings (Should they correct through task or folder). If there is no task specific, the frame range should be correct through the folder entity.

Resolve: https://github.com/ynput/ayon-maya/issues/423

## Additional review information
n/a

## Testing notes:
1. Launch Maya
2. Make sure you have frame range which does not align with the folder/task entity set in your project
3. Publish
4. Validation block
5. The message would show incorrect frame range at which task and folder path.
