### PR TITLE
Ensure the scene without trailing collection after camera publish

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_camera_mayaScene.py
+++ b/client/ayon_maya/plugins/publish/extract_camera_mayaScene.py
@@ -160,7 +160,7 @@ class ExtractCameraMayaScene(plugin.MayaExtractorPlugin,
             stack.enter_context(lib.maintained_selection())
             stack.enter_context(lib.evaluation("off"))
             stack.enter_context(lib.suspended_refresh())
-            stack.enter_context(rendersetup_use_untitled_collection())
+            stack.enter_context(rendersetup_disable_untitled_collection())
             if bake_to_worldspace:
                 baked = lib.bake_to_world_space(
                     transforms,
@@ -306,7 +306,7 @@ def transfer_image_planes(source_cameras, target_cameras,
 
 
 @contextlib.contextmanager
-def rendersetup_use_untitled_collection():
+def rendersetup_disable_untitled_collection():
     """Disable MAYA_RENDER_SETUP_USE_UNTITLED_COLLECTIONS environment
     variable during context to ensure no trailing collection after the publish.
     """

--- a/client/ayon_maya/plugins/publish/extract_camera_mayaScene.py
+++ b/client/ayon_maya/plugins/publish/extract_camera_mayaScene.py
@@ -160,6 +160,7 @@ class ExtractCameraMayaScene(plugin.MayaExtractorPlugin,
             stack.enter_context(lib.maintained_selection())
             stack.enter_context(lib.evaluation("off"))
             stack.enter_context(lib.suspended_refresh())
+            stack.enter_context(rendersetup_use_untitled_collection())
             if bake_to_worldspace:
                 baked = lib.bake_to_world_space(
                     transforms,
@@ -302,6 +303,23 @@ def transfer_image_planes(source_cameras, target_cameras,
         for camera, image_planes in originals.items():
             for image_plane in image_planes:
                 _attach_image_plane(camera, image_plane)
+
+
+@contextlib.contextmanager
+def rendersetup_use_untitled_collection():
+    """Disable MAYA_RENDER_SETUP_USE_UNTITLED_COLLECTIONS environment
+    variable during context to ensure no trailing collection after the publish.
+    """
+    key = "MAYA_RENDER_SETUP_USE_UNTITLED_COLLECTIONS"
+    original_value = os.getenv(key)
+    try:
+        os.environ[key] = str(int(False))
+        yield
+    finally:
+        if original_value is not None:
+            os.environ[key] = original_value
+        else:
+            del os.environ[key]
 
 
 def _attach_image_plane(camera, image_plane):


### PR DESCRIPTION
## Changelog Description
This PR is to ensure the scene does not have any trailing collection with the existing rendersetup after the camera publish with baked options enabled.
Resolve https://github.com/ynput/ayon-maya/issues/44
## Additional review information
n/a

## Testing notes:
1. Create camera
2. Create camera instance
3. Create and activate a render setup layer
4. Have Enable untitled collections when new objects are created setting enabled
5. Publish camera