### PR TITLE
Implementation of validator for scene unknown nodes

### DIFF
--- a/client/ayon_maya/plugins/publish/validate_unknown_nodes.py
+++ b/client/ayon_maya/plugins/publish/validate_unknown_nodes.py
@@ -1,9 +1,9 @@
 from maya import cmds
 
 import os
+import inspect
 import pyblish.api
 from ayon_maya.api.action import SelectInvalidAction
-from ayon_core.pipeline import registered_host
 from ayon_core.pipeline.publish import (
     ValidateContentsOrder,
     RepairContextAction,
@@ -59,8 +59,7 @@ class ValidateSceneUnknownNodes(pyblish.api.ContextPlugin,
             item["name"]: item["value"]
             for item in maya_settings["ext_mapping"]
         }
-        host = registered_host()
-        current_file = host.get_current_workfile()
+        current_file = context.data["currentFile"]
         extension = os.path.splitext(current_file)[-1].strip(".")
         correct_extension = ext_mapping.get(context.data["productBaseType"])
         return extension == correct_extension
@@ -83,7 +82,10 @@ class ValidateSceneUnknownNodes(pyblish.api.ContextPlugin,
 
         invalid = self.get_invalid(context)
         if invalid:
-            raise PublishValidationError("Unknown nodes found: {0}".format(invalid))
+            raise PublishValidationError(
+                "Unknown nodes found: {0}".format(invalid),
+                description=self.get_description()
+            )
 
     @classmethod
     def repair(cls, context):
@@ -92,3 +94,17 @@ class ValidateSceneUnknownNodes(pyblish.api.ContextPlugin,
                 force_delete(node)
             except RuntimeError as exc:
                 cls.log.error(exc)
+
+    def get_description(self) -> str:
+        return inspect.cleandoc("""
+            ## Unknown Nodes Found
+            Unknown nodes were found in the scene. This often happens if nodes from
+            plug-ins are used but are not available on this machine.
+            Note: Some studios use unknown nodes to store data on (as attributes)
+            because it's a lightweight node.
+            ### How to Fix
+            You can either:
+            - Install the missing plug-in that the unknown nodes belong to.
+            - Delete the unknown nodes from the scene. You can use the "Repair"
+            action to automatically delete the unknown nodes.
+        """)

--- a/client/ayon_maya/plugins/publish/validate_unknown_nodes.py
+++ b/client/ayon_maya/plugins/publish/validate_unknown_nodes.py
@@ -42,7 +42,7 @@ class ValidateSceneUnknownNodes(pyblish.api.ContextPlugin,
     hosts = ['maya']
     families = ["model", "rig", "mayaScene", "look", "renderlayer", "yetiRig"]
     optional = True
-    label = "Unknown Nodes"
+    label = "Unknown Nodes in Scene"
     actions = [SelectInvalidAction, RepairContextAction]
 
     def _is_workfile_extension_align_with_extension_mapping(self, context) -> bool:

--- a/client/ayon_maya/plugins/publish/validate_unknown_nodes.py
+++ b/client/ayon_maya/plugins/publish/validate_unknown_nodes.py
@@ -73,10 +73,11 @@ class ValidateSceneUnknownNodes(pyblish.api.ContextPlugin,
         if not self.is_active(context.data):
             return
 
-        if not self._is_workfile_extension_align_with_extension_mapping(context):
+        if self._is_workfile_extension_align_with_extension_mapping(context):
             self.log.warning(
-                "Workfile extension is not aligned with the extension mapping. "
-                "Skipping unknown nodes validation to prevent false positives."
+                "Workfile extension is not aligned with the extension mapping."
+                " Skipping unknown nodes validation to prevent false"
+                " positives."
             )
             return
 

--- a/client/ayon_maya/plugins/publish/validate_unknown_nodes.py
+++ b/client/ayon_maya/plugins/publish/validate_unknown_nodes.py
@@ -96,14 +96,18 @@ class ValidateSceneUnknownNodes(pyblish.api.ContextPlugin,
             except RuntimeError as exc:
                 cls.log.error(exc)
 
-    def get_description(self) -> str:
+    @staticmethod
+    def get_description() -> str:
         return inspect.cleandoc("""
             ## Unknown Nodes Found
-            Unknown nodes were found in the scene. This often happens if nodes from
-            plug-ins are used but are not available on this machine.
-            Note: Some studios use unknown nodes to store data on (as attributes)
-            because it's a lightweight node.
+            
+            Unknown nodes were found in the scene. This often happens if nodes
+            from plug-ins are used but are not available on this machine.
+            Note: Some studios use unknown nodes to store data on (as 
+            attributes) because it's a lightweight node.
+            
             ### How to Fix
+            
             You can either:
             - Install the missing plug-in that the unknown nodes belong to.
             - Delete the unknown nodes from the scene. You can use the "Repair"

--- a/client/ayon_maya/plugins/publish/validate_unknown_nodes.py
+++ b/client/ayon_maya/plugins/publish/validate_unknown_nodes.py
@@ -3,6 +3,7 @@ from maya import cmds
 import os
 import inspect
 import pyblish.api
+import pyblish.logic
 from ayon_maya.api.action import SelectInvalidAction
 from ayon_core.pipeline.publish import (
     ValidateContentsOrder,
@@ -60,9 +61,26 @@ class ValidateSceneUnknownNodes(pyblish.api.ContextPlugin,
             for item in maya_settings["ext_mapping"]
         }
         current_file = context.data["currentFile"]
-        extension = os.path.splitext(current_file)[-1].strip(".")
-        correct_extension = ext_mapping.get(context.data["productBaseType"])
-        return extension == correct_extension
+        if not current_file:
+            # Unsaved file
+            return True
+        workfile_extension = os.path.splitext(current_file)[-1].strip(".")
+        for instance in context:
+            # Skip inactivate instances
+            if not instance.data.get("publish", True):
+                continue
+            # Consider only relevant instances
+            if not pyblish.logic.plugins_by_families(
+                [self.__class__],
+                self.families
+            ):
+                continue
+            instance_extension = ext_mapping.get(
+                instance.data["productBaseType"]
+            )
+            if workfile_extension != instance_extension:
+                return False
+        return True
 
     @staticmethod
     def get_invalid(context) -> list:
@@ -100,14 +118,14 @@ class ValidateSceneUnknownNodes(pyblish.api.ContextPlugin,
     def get_description() -> str:
         return inspect.cleandoc("""
             ## Unknown Nodes Found
-            
+
             Unknown nodes were found in the scene. This often happens if nodes
             from plug-ins are used but are not available on this machine.
-            Note: Some studios use unknown nodes to store data on (as 
+            Note: Some studios use unknown nodes to store data on (as
             attributes) because it's a lightweight node.
-            
+
             ### How to Fix
-            
+
             You can either:
             - Install the missing plug-in that the unknown nodes belong to.
             - Delete the unknown nodes from the scene. You can use the "Repair"

--- a/client/ayon_maya/plugins/publish/validate_unknown_nodes.py
+++ b/client/ayon_maya/plugins/publish/validate_unknown_nodes.py
@@ -1,0 +1,94 @@
+from maya import cmds
+
+import os
+import pyblish.api
+from ayon_maya.api.action import SelectInvalidAction
+from ayon_core.pipeline import registered_host
+from ayon_core.pipeline.publish import (
+    ValidateContentsOrder,
+    RepairContextAction,
+    PublishValidationError,
+    OptionalPyblishPluginMixin
+)
+
+
+def force_delete(node: str) -> None:
+    """Forcefully deletes a node in the Maya scene.
+
+    Args:
+        node (str): invalid node to delete
+    """
+    if cmds.objExists(node):
+        cmds.lockNode(node, lock=False)
+        cmds.delete(node)
+
+
+class ValidateSceneUnknownNodes(pyblish.api.ContextPlugin,
+                                OptionalPyblishPluginMixin):
+    """Checks to see if there are any unknown nodes in the scene.
+
+    This often happens if nodes from plug-ins are used but are not available
+    on this machine.
+
+    Note: Some studios use unknown nodes to store data on (as attributes)
+        because it's a lightweight node.
+
+    This differs from validate no unknown nodes since it checks the
+    full scene - not just the nodes in the instance.
+
+    """
+
+    order = ValidateContentsOrder
+    hosts = ['maya']
+    families = ["model", "rig", "mayaScene", "look", "renderlayer", "yetiRig"]
+    optional = True
+    label = "Unknown Nodes"
+    actions = [SelectInvalidAction, RepairContextAction]
+
+    def _is_workfile_extension_align_with_extension_mapping(self, context) -> bool:
+        """Check if the workfile extension is aligned with the extension mapping.
+
+        This is to prevent false positives when the workfile extension is not
+        aligned with the extension mapping.
+
+        Args:
+            context (pyblish.api.Context): The publish context.
+        """
+        maya_settings = context.data["project_settings"]["maya"]
+        ext_mapping = {
+            item["name"]: item["value"]
+            for item in maya_settings["ext_mapping"]
+        }
+        host = registered_host()
+        current_file = host.get_current_workfile()
+        extension = os.path.splitext(current_file)[-1].strip(".")
+        correct_extension = ext_mapping.get(context.data["productBaseType"])
+        return extension == correct_extension
+
+    @staticmethod
+    def get_invalid(context) -> list:
+        return cmds.ls(type="unknown")
+
+    def process(self, context):
+        """Process all the nodes in the instance"""
+        if not self.is_active(context.data):
+            return
+
+        if not self._is_workfile_extension_align_with_extension_mapping(context):
+            self.log.warning(
+                "Workfile extension is not aligned with the extension mapping. "
+                "Skipping unknown nodes validation to prevent false positives."
+            )
+            return
+
+        invalid = self.get_invalid(context)
+        if invalid:
+            raise PublishValidationError("Unknown nodes found: {0}".format(invalid))
+
+    @classmethod
+    def repair(cls, context):
+        for node in cls.get_invalid(context):
+            try:
+                force_delete(node)
+            except RuntimeError as exc:
+                cls.log.error(exc)

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -943,6 +943,10 @@ class PublishersModel(BaseSettingsModel):
         default_factory=BasicValidateModel,
         title="Validate Node No Ghosting",
     )
+    ValidateSceneUnknownNodes: BasicValidateModel = SettingsField(
+        default_factory=BasicValidateModel,
+        title="Validate Scene Unknown Nodes"
+    )
     ValidateShapeDefaultNames: BasicValidateModel = SettingsField(
         default_factory=BasicValidateModel,
         title="Validate Shape Default Names",
@@ -1586,6 +1590,11 @@ DEFAULT_PUBLISH_SETTINGS = {
     "ValidateRigControllersArnoldAttributes": {
         "enabled": True,
         "optional": False,
+        "active": True
+    },
+    "ValidateSceneUnknownNodes": {
+        "enabled": True,
+        "optional": True,
         "active": True
     },
     "ValidateSingleAssembly": {


### PR DESCRIPTION
## Changelog Description
This PR is to implement validator for scene unknown nodes
Fixes https://github.com/ynput/ayon-maya/issues/228
## Additional review information
Marked it as draft because the repair action might not be deletion of the node. Maybe perhaps saving the workfile scene could help.

## Testing notes:
1. Create any nodes(AAS, RSProxy) which is related to external renderers such as Arnold, Redshift etc.
2. Disable the external renderers
3. Create model with that node
4. Validation blocks if the unknown nodes are detected