### PR TITLE
Maya 2027: Fix RuntimeError shown in getter/setter function for context data  

### DIFF
--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -174,7 +174,7 @@ class MayaHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
         data = data[0]  # Maya seems to return a list
         # Maya 2027+ does not return bytes, so we convert it
-        if int(cmds.about(version=True)) > 2027 and isinstance(data, str):
+        if int(cmds.about(version=True)) >= 2027 and isinstance(data, str):
             data = data.encode("utf-8")
         decoded = base64.b64decode(data).decode("utf-8")
         return json.loads(decoded)
@@ -183,9 +183,9 @@ class MayaHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         json_str = json.dumps(data)
         # Always base64 encode
         encoded = base64.b64encode(json_str.encode("utf-8"))
-        # Convert bytes to str for fileInfo storage in Maya 2027+
-        # because it doesn't take `bytes` anymore
-        if int(cmds.about(version=True)) > 2027:
+        # Convert bytes to str for fileInfo storage
+        # fileInfo expects a string value, not bytes
+        if int(cmds.about(version=True)) >= 2027 and isinstance(encoded, bytes):
             encoded = encoded.decode("utf-8")
         return cmds.fileInfo("OpenPypeContext", encoded)
 

--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -173,13 +173,17 @@ class MayaHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             return {}
 
         data = data[0]  # Maya seems to return a list
-        decoded = base64.b64decode(data).decode("utf-8")
-        return json.loads(decoded)
+        if int(cmds.about(version=True)) < 2027:
+            decoded = base64.b64decode(data).decode("utf-8")
+            return json.loads(decoded)
+        return json.loads(data)
 
     def update_context_data(self, data, changes):
         json_str = json.dumps(data)
-        encoded = base64.b64encode(json_str.encode("utf-8"))
-        return cmds.fileInfo("OpenPypeContext", encoded)
+        if int(cmds.about(version=True)) < 2027:
+            encoded = base64.b64encode(json_str.encode("utf-8"))
+            return cmds.fileInfo("OpenPypeContext", encoded)
+        return cmds.fileInfo("OpenPypeContext", json_str)
 
     def _register_callbacks(self):
         for handler, event in self._op_events.copy().items():

--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -173,7 +173,7 @@ class MayaHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             return {}
 
         data = data[0]  # Maya seems to return a list
-        # Always base64 decode
+        # Maya 2027+ does not return bytes, so we convert it
         if int(cmds.about(version=True)) > 2027 and isinstance(data, str):
             data = data.encode("utf-8")
         decoded = base64.b64decode(data).decode("utf-8")

--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -182,12 +182,12 @@ class MayaHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     def update_context_data(self, data, changes):
         json_str = json.dumps(data)
         # Always base64 encode
-        encoded_bytes = base64.b64encode(json_str.encode("utf-8"))
-        # Convert bytes to str for fileInfo storage
+        encoded = base64.b64encode(json_str.encode("utf-8"))
+        # Convert bytes to str for fileInfo storage in Maya 2027+
+        # because it doesn't take `bytes` anymore
         if int(cmds.about(version=True)) > 2027:
-            encoded_str = encoded_bytes.decode("utf-8")
-            return cmds.fileInfo("OpenPypeContext", encoded_str)
-        return cmds.fileInfo("OpenPypeContext", encoded_bytes)
+            encoded = encoded.decode("utf-8")
+        return cmds.fileInfo("OpenPypeContext", encoded)
 
     def _register_callbacks(self):
         for handler, event in self._op_events.copy().items():

--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -173,17 +173,21 @@ class MayaHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             return {}
 
         data = data[0]  # Maya seems to return a list
-        if int(cmds.about(version=True)) < 2027:
-            decoded = base64.b64decode(data).decode("utf-8")
-            return json.loads(decoded)
-        return json.loads(data)
+        # Always base64 decode
+        if int(cmds.about(version=True)) > 2027 and isinstance(data, str):
+            data = data.encode("utf-8")
+        decoded = base64.b64decode(data).decode("utf-8")
+        return json.loads(decoded)
 
     def update_context_data(self, data, changes):
         json_str = json.dumps(data)
-        if int(cmds.about(version=True)) < 2027:
-            encoded = base64.b64encode(json_str.encode("utf-8"))
-            return cmds.fileInfo("OpenPypeContext", encoded)
-        return cmds.fileInfo("OpenPypeContext", json_str)
+        # Always base64 encode
+        encoded_bytes = base64.b64encode(json_str.encode("utf-8"))
+        # Convert bytes to str for fileInfo storage
+        if int(cmds.about(version=True)) > 2027:
+            encoded_str = encoded_bytes.decode("utf-8")
+            return cmds.fileInfo("OpenPypeContext", encoded_str)
+        return cmds.fileInfo("OpenPypeContext", encoded_bytes)
 
     def _register_callbacks(self):
         for handler, event in self._op_events.copy().items():


### PR DESCRIPTION
## Changelog Description
This PR is to fix the runtime error shown(encoding/decoding error) in get/update context data from AYON which is newly shown in Maya 2027 
Resolve https://github.com/ynput/ayon-maya/issues/426
## Additional review information
n/a

## Testing notes:
1. Launch Publisher UI in Maya
2. Refresh/Save Instances in Publisher UI, Validation check and repair action performed
3. Publish 
4. Should be all working.
