### PR TITLE
filter camera candidates by type

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_camera_mayaScene.py
+++ b/client/ayon_maya/plugins/publish/extract_camera_mayaScene.py
@@ -145,7 +145,8 @@ class ExtractCameraMayaScene(plugin.MayaExtractorPlugin,
         members = set(cmds.ls(instance.data['setMembers'], leaf=True,
                       shapes=True, long=True, dag=True))
         cameras = set(cmds.ls(members, leaf=True, shapes=True, long=True,
-                      dag=True, type="camera"))
+                      dag=True))
+        cameras = cmds.ls(cameras, type="camera", long=True)  # filter out non-camera leaf nodes
 
         # validate required settings
         assert isinstance(step, float), "Step must be a float value"

--- a/client/ayon_maya/plugins/publish/extract_camera_mayaScene.py
+++ b/client/ayon_maya/plugins/publish/extract_camera_mayaScene.py
@@ -144,9 +144,7 @@ class ExtractCameraMayaScene(plugin.MayaExtractorPlugin,
         # get cameras
         members = set(cmds.ls(instance.data['setMembers'], leaf=True,
                       shapes=True, long=True, dag=True))
-        cameras = set(cmds.ls(members, leaf=True, shapes=True, long=True,
-                      dag=True))
-        cameras = cmds.ls(cameras, type="camera", long=True)  # filter out non-camera leaf nodes
+        cameras = set(cmds.ls(members, type="camera", long=True))
 
         # validate required settings
         assert isinstance(step, float), "Step must be a float value"


### PR DESCRIPTION
## Changelog Description
Filter camera nodes based on type to exclude nested objects

## Additional review information
It seems that `cmds.ls(...., leaf=True, shapes=True, type="camera")` returns all the leaf shapes of camera nodes, even if these aren't cameras.
So I'm adding a second step to filter out non camera shapes

## Testing notes:
1. create a camera
2. create a locator and parent it under the camera
3. publish
<img width="273" height="155" alt="image" src="https://github.com/user-attachments/assets/8f80032c-6bcc-45bf-a3c7-7e436b9092b8" />

test script:
```py
from maya import cmds


#########################
# init
cmds.file(new=True, force=True)
box, _ = cmds.polyCube()
cam, _ = cmds.camera()
null = cmds.spaceLocator()
cmds.parent(null, cam)


#########################

members = [cam, box]  # note: null is excluded
print(f"{members=}")
# members=['camera1', 'pCube1']

shapes = cmds.ls(members, dag=True, shapes=True, leaf=True, long=True)
print(f"1 {shapes=}")
# 1 shapes=['|camera1|cameraShape1', '|camera1|locator1|locatorShape1', '|pCube1|pCubeShape1']

shapes = cmds.ls(members, dag=True, shapes=True, leaf=True, long=True, type="camera")
print(f"2 {shapes=}")
# 2 shapes=['|camera1|cameraShape1', '|camera1|locator1|locatorShape1', '|pCube1|pCubeShape1']

shapes = cmds.ls(members, dag=True, shapes=True, leaf=True, long=True, type="camera")
cameras = cmds.ls(shapes, long=True, type="camera")
print(f"3 {cameras=}")
# 3 cameras=['|camera1|cameraShape1']
```

## debug messages:
```py
# add these somewhere after line 154
self.log.debug(f"{shapes=}")
self.log.debug(f"{cameras=}")
self.log.debug(f"{transforms=}")
```
```
DEBUG: shapes={'|camera1|locator1|locatorShape1', '|camera1|cameraShape1'}
DEBUG: cameras=['|camera1|cameraShape1']
DEBUG: transforms=['|camera1']
```

## original error message
```
DEBUG: Looking in settings for scene type ...
DEBUG: Using ma as scene type
Traceback (most recent call last):
  File "/home/v/.local/share/AYON/dependency_packages/ayon_2602231723_linux-rocky9.zip/dependencies/pyblish/plugin.py", line 528, in __explicit_process
    runner(*args)
  File "/home/v/dev/ayon-maya/client/ayon_maya/plugins/publish/extract_camera_mayaScene.py", line 214, in process
    stack.enter_context(transfer_image_planes(
  File "/mnt/pipeline/apps/maya/maya2026/lib/python3.11/contextlib.py", line 517, in enter_context
    result = _enter(cm)
             ^^^^^^^^^^
  File "/mnt/pipeline/apps/maya/maya2026/lib/python3.11/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/home/v/dev/ayon-maya/client/ayon_maya/plugins/publish/extract_camera_mayaScene.py", line 282, in transfer_image_planes
    image_planes = cmds.listConnections(image_plane_plug,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: No object matches name: |camera1|locator1|locatorShape1.imagePlane
```



