### PR TITLE
Export Pointcache: Optimize forced shader assignments when writing face sets

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4645,8 +4645,13 @@ def force_shader_assignments_to_faces(shapes):
         if render_sets:
             all_render_sets.update(render_sets)
 
-    shapes_lookup = set(shapes)
+    shading_engines = cmds.ls(list(all_render_sets), type="shadingEngine")
+    if not shading_engines:
+        # Do nothing
+        yield
+        return
 
+    shapes_lookup = set(shapes)
     original_assignments = {}
     override_assignments = defaultdict(OpenMaya.MSelectionList)
     
@@ -4656,7 +4661,7 @@ def force_shader_assignments_to_faces(shapes):
         return sel.getDependNode(0)
     
     fn_set = OpenMaya.MFnSet()
-    for shading_engine in cmds.ls(list(all_render_sets), type="shadingEngine"):
+    for shading_engine in shading_engines:
         fn_set.setObject(get_mobject(shading_engine))
 
         # Include ALL originals, even those not among our shapes

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4647,53 +4647,38 @@ def force_shader_assignments_to_faces(shapes):
 
     shapes_lookup = set(shapes)
 
-    # Maya has the tendency to return component assignment using the transform
-    # name instead of the shape name, like `pCube1.f[1]` instead of
-    # `pCube1Shape.f[1]` so we need to take those into consideration as members
-    def get_parent(_shape: str) -> str:
-        return _shape.rsplit("|", 1)[0]
-
-    components_lookup = {f"{shape}." for shape in shapes}
-    components_lookup.update(f"{get_parent(shape)}." for shape in shapes)
-    components_lookup = tuple(components_lookup)  # support str.startswith
-
     original_assignments = {}
-    override_assignments = defaultdict(list)
+    override_assignments = defaultdict(OpenMaya.MSelectionList)
+    
+    def get_mobject(node_name: str) -> OpenMaya.MObject:
+        sel = OpenMaya.MSelectionList()
+        sel.add(node_name)
+        return sel.getDependNode(0)
+    
+    fn_set = OpenMaya.MFnSet()
     for shading_engine in cmds.ls(list(all_render_sets), type="shadingEngine"):
-        members = cmds.sets(shading_engine, query=True)
-        if not members:
-            continue
-
-        members = cmds.ls(members, long=True)
+        fn_set.setObject(get_mobject(shading_engine))
 
         # Include ALL originals, even those not among our shapes
+        members = fn_set.getMembers(flatten=False)
         original_assignments[shading_engine] = members
 
         has_conversions = False
-        for member in members:
-            # Only consider shapes from our inputs
-            if (
-                    member not in shapes_lookup
-                    and not member.startswith(components_lookup)
-            ):
+        for i in range(members.length()):
+            dag, component = members.getComponent(i)
+            shape_path = dag.fullPathName()
+            if shape_path not in shapes_lookup:
                 continue
 
-            if "." not in member:
-                # Convert to face assignments
-                member = f"{member}.f[*]"
-                if not cmds.objExists(member):
-                    # It is possible for a mesh to have no faces at all
-                    # for which we cannot convert to face assignments anyway.
-                    # It is a `mesh` node type - it just would error on
-                    # 'No object matches name' when trying to assign to the
-                    # faces. So we skip the conversion
-                    log.debug(
-                        "Skipping face assignment conversion because "
-                        f"no mesh faces were found: {member}")
-                    continue
-
+            if component.isNull():
+                # Convert to face assignment
+                override_assignments[shading_engine].add(
+                    f'{shape_path}.f[*]'
+                )
                 has_conversions = True
-            override_assignments[shading_engine].append(member)
+            else:
+                # Preserve component assignment
+                override_assignments[shading_engine].add((dag, component))
 
         if not has_conversions:
             # We can skip this shading engine completely because
@@ -4704,18 +4689,17 @@ def force_shader_assignments_to_faces(shapes):
     try:
         # Apply overrides
         for shading_engine, override_members in override_assignments.items():
-            # We force remove the members because this allows maya to take
-            # out the mesh (also without the components)
-            cmds.sets(clear=shading_engine)
-            cmds.sets(override_members, forceElement=shading_engine)
-
+            fn_set.setObject(get_mobject(shading_engine))
+            fn_set.clear()
+            fn_set.addMembers(override_members)
         yield
 
     finally:
         # Revert to original assignments
         for shading_engine, original_members in original_assignments.items():
-            cmds.sets(clear=shading_engine)
-            cmds.sets(original_members, forceElement=shading_engine)
+           fn_set.setObject(get_mobject(shading_engine))
+           fn_set.clear()
+           fn_set.addMembers(original_members)
 
 
 def nodetype_exists(nodetype: str) -> bool:

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4624,6 +4624,32 @@ def get_sequence(filepath, pattern="%04d"):
     ]
 
 
+def _get_mobject(node_name: str) -> OpenMaya.MObject:
+    sel = OpenMaya.MSelectionList()
+    sel.add(node_name)
+    return sel.getDependNode(0)
+
+
+def _fast_clear_set(object_set: str):
+    """MFnSet.clear() can be very slow for shading engines that contain many
+    face assignment. By just breaking all connections to the "dagSetMembers"
+    we get the same result without the slow performance.
+
+    Arguments:
+        object_set (str): The name of the objectSet or shadingEngine to clear.
+    """
+    fn = OpenMaya.MFnDependencyNode(_get_mobject(object_set))
+    dag_set_members = fn.findPlug("dagSetMembers", False)
+    mod = OpenMaya.MDGModifier()
+    for i in range(dag_set_members.numElements()):
+        elem = dag_set_members.elementByPhysicalIndex(i)
+        if elem.isConnected:
+            src_plugs = elem.connectedTo(True, False)
+            for src in src_plugs:
+                mod.disconnect(src, elem)
+    mod.doIt()
+
+
 @contextlib.contextmanager
 def force_shader_assignments_to_faces(shapes):
     """Replaces any non-face shader assignments with shader assignments
@@ -4655,14 +4681,9 @@ def force_shader_assignments_to_faces(shapes):
     original_assignments = {}
     override_assignments = defaultdict(OpenMaya.MSelectionList)
     
-    def get_mobject(node_name: str) -> OpenMaya.MObject:
-        sel = OpenMaya.MSelectionList()
-        sel.add(node_name)
-        return sel.getDependNode(0)
-    
     fn_set = OpenMaya.MFnSet()
     for shading_engine in shading_engines:
-        fn_set.setObject(get_mobject(shading_engine))
+        fn_set.setObject(_get_mobject(shading_engine))
 
         # Include ALL originals, even those not among our shapes
         members = fn_set.getMembers(flatten=False)
@@ -4694,17 +4715,17 @@ def force_shader_assignments_to_faces(shapes):
     try:
         # Apply overrides
         for shading_engine, override_members in override_assignments.items():
-            fn_set.setObject(get_mobject(shading_engine))
-            fn_set.clear()
+            _fast_clear_set(shading_engine)
+            fn_set.setObject(_get_mobject(shading_engine))
             fn_set.addMembers(override_members)
         yield
 
     finally:
         # Revert to original assignments
         for shading_engine, original_members in original_assignments.items():
-           fn_set.setObject(get_mobject(shading_engine))
-           fn_set.clear()
-           fn_set.addMembers(original_members)
+            _fast_clear_set(shading_engine)
+            fn_set.setObject(_get_mobject(shading_engine))
+            fn_set.addMembers(original_members)
 
 
 def nodetype_exists(nodetype: str) -> bool:


### PR DESCRIPTION
## Changelog Description

Export Pointcache: Optimize forced shader assignments when writing face sets

## Additional review information

Fix #441 

To performance test:
```python
import datetime

from ayon_maya.api.lib import force_shader_assignments_to_faces
from maya import cmds


##############################################

prev_time = datetime.datetime.now()

def log(*args, reset=False):
    global prev_time
    if reset:
        prev_time = datetime.datetime.now()

    now = datetime.datetime.now()

    ts = now.strftime("%H:%M:%S")
    diff = now - prev_time
    diff_s = diff.total_seconds() % 60
    diff_m = diff.total_seconds() // 60
    diff_str = f"{diff_m:.0f}m {diff_s:5.2f}s"
    print(f"[{ts} +{diff_str}]", *args)
    prev_time = now


##############################################

def add_cubes(count=100):
    root = cmds.group(empty=True, name="root")
    for i in range(count):
        transform, _ = cmds.polyCube(name=f"cube{i:02d}")
        cmds.parent(transform, root)


def main():
    cmds.file(newFile=True, force=True)
    log("start", reset=True)

    log("add cubes")
    add_cubes(5_000)
    log("cubes added")

    meshes = cmds.ls("cube*", type="mesh", long=True)
    log("found", len(meshes), "cubes")

    log("pre enter")
    with force_shader_assignments_to_faces(meshes):
        log("in")
        pass
    log("out")


if __name__ == "__main__":
    main()
```

## Testing notes:

1. Publishing with write face sets should still work and produce correct results.
2. It should be faster.
