### PR TITLE
Export Pointcache: Write Face Sets: Disable forced shader assignments by default

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_pointcache.py
+++ b/client/ayon_maya/plugins/publish/extract_pointcache.py
@@ -68,6 +68,7 @@ class ExtractAlembic(plugin.MayaExtractorPlugin,
     writeColorSets = False
     writeCreases = False
     writeFaceSets = False
+    writeFaceSetsForceFaceAssignment = False
     writeNormals = True
     writeUVSets = False
     writeVisibility = False
@@ -242,7 +243,10 @@ class ExtractAlembic(plugin.MayaExtractorPlugin,
         with contextlib.ExitStack() as stack:
             stack.enter_context(suspended_refresh(suspend=suspend))
             stack.enter_context(maintained_selection())
-            if instance.data.get("writeFaceSets", True):
+            if (
+                kwargs.get("writeFaceSets")
+                and self.writeFaceSetsForceFaceAssignment
+            ):
                 meshes = cmds.ls(nodes, type="mesh", long=True)
                 stack.enter_context(force_shader_assignments_to_faces(meshes))
             cmds.select(nodes, noExpand=True)

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -397,6 +397,14 @@ class ExtractAlembicModel(BasicExtractorModel):
         title="Write Face Sets",
         description="Write face sets with the geometry."
     )
+    writeFaceSetsForceFaceAssignment: bool = SettingsField(
+        title="Write Face Sets: Force all assignments",
+        description=(
+            "When writing with face sets is enabled then force all"
+            " assignments to be face assignments on export so that all"
+            " material assignments become face sets."
+        )
+    )
     writeNormals: bool = SettingsField(
         title="Write Normals",
         description="Write normals with the deforming geometry."
@@ -1902,6 +1910,7 @@ DEFAULT_PUBLISH_SETTINGS = {
         "writeColorSets": False,
         "writeCreases": False,
         "writeFaceSets": False,
+        "writeFaceSetsForceFaceAssignment": False,
         "writeNormals": True,
         "writeUVSets": False,
         "writeVisibility": False


### PR DESCRIPTION
## Changelog Description

Make the forced face shader assignment optional (for the studio admin) to allow disabling/enabling that feature. Also, disable it by default now because the behavior is rather special and non-standard for Alembic export behavior.

To preserve the original behavior, make sure to enable the `writeFaceSetsForceFaceAssignment` flag in settings

## Additional review information

This also fixes that if this setting would be enabled, but writing face sets would be disabled then it should not trigger - whereas previously the forced face shader assignment _always_ triggered.

Fix https://github.com/ynput/ayon-maya/issues/440

## Testing notes:
1. Extract Pointcache Write face sets should work with that flag enabled in settings, but with `writeFaceSetsForceFaceAssignment` disabled.
2. Extract Pointcache Write face sets should work with that flag enabled in settings, but with `writeFaceSetsForceFaceAssignment` enabled.
3. Different in resulting file should be that with it enabled any non-face assignments should've still ben turned into face sets on write.