### PR TITLE
Expose `exportSkin` and `exportSkels` options to USD extractor + allow configuring defaults

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -173,7 +173,27 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
     label = "Extract Maya USD Asset"
     families = ["mayaUsd"]
 
+    # Settings
     overrides = []
+    stripNamespaces: bool = True
+    worldspace: bool = True
+    exportComponentTags: bool = False
+    exportVisibility: bool = True
+    mergeTransformAndShape: bool = True
+    defaultMeshScheme: str = "catmullClark"
+    exportBlendShapes: bool = True
+    exportSkin: str = "none"
+    exportSkels: str = "none"
+    exportCollectionBasedBindings: bool = False
+    exportColorSets: bool = True
+    exportDisplayColor: bool = False
+    exportMaterials: bool = True
+    exportAssignedMaterials: bool = False
+    exportInstances: bool = True
+    exportUVs: bool = True
+    upAxis: str = "mayaPrefs"
+    unit: str = "mayaPrefs"
+
     # Default prefix for custom attributes to USD attributes
     # if no other mapping is provided
     custom_attr_namespace: str = ""
@@ -238,15 +258,15 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
             "chaser": None,
             "chaserArgs": None,
             "defaultUSDFormat": "usdc",
-            "defaultMeshScheme": "catmullClark",
-            "stripNamespaces": True,
-            "mergeTransformAndShape": True,
-            "exportDisplayColor": False,
-            "exportColorSets": True,
-            "exportInstances": True,
-            "exportUVs": True,
-            "exportVisibility": True,
-            "exportComponentTags": False,
+            "defaultMeshScheme": self.defaultMeshScheme,
+            "stripNamespaces": self.stripNamespaces,
+            "mergeTransformAndShape": self.mergeTransformAndShape,
+            "exportDisplayColor": self.exportDisplayColor,
+            "exportColorSets": self.exportColorSets,
+            "exportInstances": self.exportInstances,
+            "exportUVs": self.exportUVs,
+            "exportVisibility": self.exportVisibility,
+            "exportComponentTags": self.exportComponentTags,
             "exportRefsAsInstanceable": False,
             "eulerFilter": True,
             "renderableOnly": False,
@@ -255,15 +275,17 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
             "jobContext": None,
             "filterTypes": None,
             "staticSingleSample": True,
-            "worldspace": True,
-            "exportCollectionBasedBindings": False,
+            "worldspace": self.worldspace,
+            "exportCollectionBasedBindings": (
+                self.exportCollectionBasedBindings
+            ),
             "exportBlendShapes": True,
-            "exportSkels": "none",
-            "exportSkin": "none",
-            "exportMaterials": False,
-            "exportAssignedMaterials": False,
-            "upAxis": "mayaPrefs",
-            "unit": "mayaPrefs",
+            "exportSkels": self.exportSkels,
+            "exportSkin": self.exportSkin,
+            "exportMaterials": self.exportMaterials,
+            "exportAssignedMaterials": self.exportAssignedMaterials,
+            "upAxis": self.upAxis,
+            "unit": self.unit,
         }
 
     def parse_overrides(self, overrides, options):
@@ -593,7 +615,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                 label="Strip Namespaces",
                 tooltip="Strip Namespaces in the USD Export",
                 visible=visible,
-                default=True
+                default=cls.stripNamespaces,
             ),
             "worldspace": BoolDef(
                 "worldspace",
@@ -601,7 +623,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                 tooltip="Export all root prim using their full worldspace "
                         "transform instead of their local transform.",
                 visible=visible,
-                default=True
+                default=cls.worldspace,
             ),
             "exportComponentTags": BoolDef(
                 "exportComponentTags",
@@ -609,7 +631,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                 tooltip="When enabled, export any geometry component tags "
                         "as UsdGeomSubset data.",
                 visible=visible,
-                default=False
+                default=cls.exportComponentTags,
             ),
             "exportVisibility": BoolDef(
                 "exportVisibility",
@@ -617,7 +639,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                 tooltip="Export any state and animation on Maya visibility"
                         " attributes.",
                 visible=visible,
-                default=True
+                default=cls.exportVisibility,
             ),
             "mergeTransformAndShape": BoolDef(
                 "mergeTransformAndShape",
@@ -631,7 +653,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                     "nodes when imported into Maya from USD."
                 ),
                 visible=visible,
-                default=True
+                default=cls.mergeTransformAndShape,
             ),
             "defaultMeshScheme": EnumDef(
                 "defaultMeshScheme",
@@ -650,14 +672,14 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                     "USD_ATTR_subdivisionScheme attribute."
                 ),
                 visible=visible,
-                default="catmullClark"
+                default=cls.defaultMeshScheme,
             ),
             "exportBlendShapes": BoolDef(
                 "exportBlendShapes",
                 label="Export Blendshapes",
                 tooltip="Enable or disable export of blend shapes.",
                 visible=visible,
-                default=True
+                default=cls.exportBlendShapes,
             ),
             "exportSkin": EnumDef("exportSkin",
                     label="Export Skin",
@@ -673,7 +695,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                         "Explicit: only export explicitly tagged skin clusters."
                     ),
                     visible=visible,
-                    default="none"
+                    default=cls.exportSkin,
             ),
             "exportSkels": EnumDef("exportSkels",
                     label="Export Skeletons",
@@ -690,7 +712,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                         "Explicit: only export those under SkelRoots."
                     ),
                     visible=visible,
-                    default="none"
+                    default=cls.exportSkels,
             ),
             "exportCollectionBasedBindings": BoolDef(
                 "exportCollectionBasedBindings",
@@ -706,49 +728,49 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                     "collection-based bindings are enabled."
                 ),
                 visible=visible,
-                default=False
+                default=cls.exportCollectionBasedBindings,
             ),
             "exportColorSets": BoolDef(
                 "exportColorSets",
                 label="Export Color Sets",
                 tooltip="Enable or disable the export of color sets.",
                 visible=visible,
-                default=True
+                default=cls.exportColorSets,
             ),
             "exportDisplayColor": BoolDef(
                 "exportDisplayColor",
                 label="Export Display Color",
                 tooltip="Enable or disable the export of display color.",
                 visible=visible,
-                default=False
+                default=cls.exportDisplayColor,
             ),
             "exportMaterials": BoolDef(
                 "exportMaterials",
                 label="Export Materials",
                 tooltip="Enable or disable the export of materials.",
                 visible=visible,
-                default=True
+                default=cls.exportMaterials,
             ),
             "exportAssignedMaterials": BoolDef(
                 "exportAssignedMaterials",
                 label="Export Assigned Materials",
                 tooltip="Export materials only if they are assigned to a mesh.",
                 visible=visible,
-                default=False
+                default=cls.exportAssignedMaterials,
             ),
             "exportInstances": BoolDef(
                 "exportInstances",
                 label="Export Instances",
                 tooltip="Enable or disable the export of instances.",
                 visible=visible,
-                default=True
+                default=cls.exportInstances,
             ),
             "exportUVs": BoolDef(
                 "exportUVs",
                 label="Export UVs",
                 tooltip="Enable or disable the export of UV sets.",
                 visible=visible,
-                default=True
+                default=cls.exportUVs,
             ),
             "upAxis": EnumDef(
                 "upAxis",
@@ -767,7 +789,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                     "not match."
                 ),
                 visible=visible,
-                default="mayaPrefs"
+                default=cls.upAxis,
             ),
             "unit": EnumDef(
                 "unit",
@@ -789,7 +811,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                     "not match."
                 ),
                 visible=visible,
-                default="mayaPrefs"
+                default=cls.unit,
             )
         }
 

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -279,7 +279,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
             "exportCollectionBasedBindings": (
                 self.exportCollectionBasedBindings
             ),
-            "exportBlendShapes": True,
+            "exportBlendShapes": self.exportBlendShapes,
             "exportSkels": self.exportSkels,
             "exportSkin": self.exportSkin,
             "exportMaterials": self.exportMaterials,

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -221,6 +221,8 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
             "worldspace": bool,
             "exportCollectionBasedBindings": bool,
             "exportBlendShapes": bool,
+            "exportSkels": str,
+            "exportSkin": str,
             "exportMaterials": bool,
             "exportAssignedMaterials": bool,
             "upAxis": str,
@@ -256,6 +258,8 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
             "worldspace": True,
             "exportCollectionBasedBindings": False,
             "exportBlendShapes": True,
+            "exportSkels": "none",
+            "exportSkin": "none",
             "exportMaterials": False,
             "exportAssignedMaterials": False,
             "upAxis": "mayaPrefs",
@@ -654,6 +658,39 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                 tooltip="Enable or disable export of blend shapes.",
                 visible=visible,
                 default=True
+            ),
+            "exportSkin": EnumDef("exportSkin",
+                    label="Export Skin",
+                    items=[
+                        {"value": "none", "label": "None"},
+                        {"value": "auto", "label": "Auto"},
+                        {"value": "explicit", "label": "Explicit"},
+                    ],
+                    tooltip=(
+                        "Export skin cluster data.\n\n"
+                        "None: do not export skin clusters.\n"
+                        "Auto: export skin clusters if present.\n"
+                        "Explicit: only export explicitly tagged skin clusters."
+                    ),
+                    visible=visible,
+                    default="none"
+            ),
+            "exportSkels": EnumDef("exportSkels",
+                    label="Export Skeletons",
+                    items=[
+                        {"value": "none", "label": "None"},
+                        {"value": "auto", "label": "Auto"},
+                        {"value": "explicit", "label": "Explicit"},
+                    ],
+                    tooltip=(
+                        "Determines how to export skeletons.\n\n"
+                        "None: No skeleton are exported.\n"
+                        "Auto: All skeletons will be exported, SkelRoots"
+                        " may be created.\n"
+                        "Explicit: only export those under SkelRoots."
+                    ),
+                    visible=visible,
+                    default="none"
             ),
             "exportCollectionBasedBindings": BoolDef(
                 "exportCollectionBasedBindings",

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -626,6 +626,7 @@ class ExtractMayaUsdModel(BaseSettingsModel):
 
 
 class ExtractMayaUsdGeneralModel(BasicExtractorModel):
+
     overrides: list[str] = SettingsField(
         enum_resolver=extract_maya_usd_overrides_enum,
         title="Exposed Overrides",
@@ -633,6 +634,26 @@ class ExtractMayaUsdGeneralModel(BasicExtractorModel):
             "Expose the attribute in this list to the user when publishing."
         )
     )
+    # Maya USD export options exposed to settings so defaults can be set
+    stripNamespaces: bool = SettingsField(title="Strip Namespaces", default=True)
+    worldspace: bool = SettingsField(title="World-Space", default=True)
+    exportComponentTags: bool = SettingsField(title="Export Component Tags", default=False)
+    exportVisibility: bool = SettingsField(title="Export Visibility", default=True)
+    mergeTransformAndShape: bool = SettingsField(title="Merge Transform and Shape", default=True)
+    defaultMeshScheme: str = SettingsField(default="catmullClark", title="Default Subdivision Method")
+    exportBlendShapes: bool = SettingsField(title="Export BlendShapes", default=True)
+    exportSkin: str = SettingsField(default="none", title="Export Skin")
+    exportSkels: str = SettingsField(default="none", title="Export Skeletons")
+    exportCollectionBasedBindings: bool = SettingsField(title="Export Collection Based Bindings", default=False)
+    exportColorSets: bool = SettingsField(title="Export Color Sets", default=True)
+    exportDisplayColor: bool = SettingsField(title="Export Display Color", default=False)
+    exportMaterials: bool = SettingsField(title="Export Materials", default=True)
+    exportAssignedMaterials: bool = SettingsField(title="Export Assigned Materials", default=False)
+    exportInstances: bool = SettingsField(title="Export Instances", default=True)
+    exportUVs: bool = SettingsField(title="Export UVs", default=True)
+    upAxis: str = SettingsField(enum_resolver=up_axis_enum, title="Up Axis", default="mayaPrefs")
+    unit: str = SettingsField(title="Export Unit", default="mayaPrefs")
+
     custom_attr_namespace: str = SettingsField(
         title="Custom Attribute Default Namespace", default="userProperties:"
     )

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -2155,7 +2155,7 @@ DEFAULT_PUBLISH_SETTINGS = {
         "active": True,
         "overrides": [
             "stripNamespaces",
-            "worldSpace",
+            "worldspace",
             "exportComponentTags",
             "exportVisibility",
             "mergeTransformAndShape",

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -556,6 +556,7 @@ class ExtractMayaUsdCustomAttrNameMappingModel(BaseSettingsModel):
     usd_name: str = SettingsField("", title="USD name")
 
 
+# TODO: This model seems to be unused?
 class ExtractMayaUsdModel(BaseSettingsModel):
     """Export USD using Maya's mayaUsd plug-in
 
@@ -824,7 +825,9 @@ class ExtractMayaUsdGeneralModel(BasicExtractorModel):
             " attributes to USD when no explicit usdAttrName is provided."
         ),
     )
-    custom_attr_name_mapping: list[str] = SettingsField(
+    custom_attr_name_mapping: list[
+        ExtractMayaUsdCustomAttrNameMappingModel
+    ] = SettingsField(
         title="Custom Attribute Name Mapping",
         default_factory=list,
         description=(

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -21,6 +21,8 @@ def extract_maya_usd_overrides_enum():
         {"label": "Merge Transform and Shape", "value": "mergeTransformAndShape"},
         {"label": "Default Subdivision Method", "value": "defaultMeshScheme"},
         {"label": "Export BlendShapes", "value": "exportBlendShapes"},
+        {"label": "Export Skins", "value": "exportSkin"},
+        {"label": "Export Skeletons", "value": "exportSkels"},
         {"label": "Export Collection Based Bindings", "value": "exportCollectionBasedBindings"},
         {"label": "Export Color Sets", "value": "exportColorSets"},
         {"label": "Export Display Color", "value": "exportDisplayColor"},

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -625,6 +625,35 @@ class ExtractMayaUsdModel(BaseSettingsModel):
         return value
 
 
+def default_mesh_scheme_enum():
+    return [
+        {"label": "Catmull Clark", "value": "catmullClark"},
+        {"label": "Loop", "value": "loop"},
+        {"label": "Bilinear", "value": "bilinear"},
+        {"label": "None", "value": "none"},
+    ]
+
+
+def export_skin_enum():
+    return [
+        {"label": "None", "value": "none"},
+        {"label": "Auto", "value": "auto"},
+        {"label": "Explicit", "value": "explicit"},
+    ]
+
+
+def unit_enum():
+    return [
+        {"label": "Maya Preferences", "value": "mayaPrefs"},
+        {"label": "None", "value": "none"},
+        {"label": "Millimeters", "value": "mm"},
+        {"label": "Centimeters", "value": "cm"},
+        {"label": "Meters", "value": "m"},
+        {"label": "Inches", "value": "in"},
+        {"label": "Feet", "value": "ft"},
+    ]
+
+
 class ExtractMayaUsdGeneralModel(BasicExtractorModel):
 
     overrides: list[str] = SettingsField(
@@ -640,10 +669,10 @@ class ExtractMayaUsdGeneralModel(BasicExtractorModel):
     exportComponentTags: bool = SettingsField(title="Export Component Tags", default=False)
     exportVisibility: bool = SettingsField(title="Export Visibility", default=True)
     mergeTransformAndShape: bool = SettingsField(title="Merge Transform and Shape", default=True)
-    defaultMeshScheme: str = SettingsField(default="catmullClark", title="Default Subdivision Method")
+    defaultMeshScheme: str = SettingsField(enum_resolver=default_mesh_scheme_enum, default="catmullClark", title="Default Subdivision Method")
     exportBlendShapes: bool = SettingsField(title="Export BlendShapes", default=True)
-    exportSkin: str = SettingsField(default="none", title="Export Skin")
-    exportSkels: str = SettingsField(default="none", title="Export Skeletons")
+    exportSkin: str = SettingsField(enum_resolver=export_skin_enum, default="none", title="Export Skin")
+    exportSkels: str = SettingsField(enum_resolver=export_skin_enum, default="none", title="Export Skeletons")
     exportCollectionBasedBindings: bool = SettingsField(title="Export Collection Based Bindings", default=False)
     exportColorSets: bool = SettingsField(title="Export Color Sets", default=True)
     exportDisplayColor: bool = SettingsField(title="Export Display Color", default=False)
@@ -652,7 +681,7 @@ class ExtractMayaUsdGeneralModel(BasicExtractorModel):
     exportInstances: bool = SettingsField(title="Export Instances", default=True)
     exportUVs: bool = SettingsField(title="Export UVs", default=True)
     upAxis: str = SettingsField(enum_resolver=up_axis_enum, title="Up Axis", default="mayaPrefs")
-    unit: str = SettingsField(title="Export Unit", default="mayaPrefs")
+    unit: str = SettingsField(enum_resolver=unit_enum, title="Export Unit", default="mayaPrefs")
 
     custom_attr_namespace: str = SettingsField(
         title="Custom Attribute Default Namespace", default="userProperties:"

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -608,6 +608,7 @@ class ExtractMayaUsdGeneralModel(BasicExtractorModel):
         title="Strip Namespaces",
         default=True,
         description="Strip namespaces from Maya node names when writing USD.",
+        section="Export defaults",
     )
     worldspace: bool = SettingsField(
         title="World-Space",
@@ -675,7 +676,7 @@ class ExtractMayaUsdGeneralModel(BasicExtractorModel):
         title="Export Skeletons",
         description=(
             "How to export skeletons:\n"
-            "- **none** none\n"
+            "- **none** do not export\n"
             "- **auto** export all skeletons (may create SkelRoots)\n"
             "- **explicit** only those under SkelRoots."
         ),

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -665,86 +665,181 @@ def maya_usd_up_axis_enum():
 
 
 class ExtractMayaUsdGeneralModel(BasicExtractorModel):
-
     overrides: list[str] = SettingsField(
         enum_resolver=extract_maya_usd_overrides_enum,
         title="Exposed Overrides",
         description=(
             "Expose the attribute in this list to the user when publishing."
-        )
+        ),
     )
     # Maya USD export options exposed to settings so defaults can be set
     stripNamespaces: bool = SettingsField(
-        title="Strip Namespaces", default=True, section="Defaults"
+        title="Strip Namespaces",
+        default=True,
+        description="Strip namespaces from Maya node names when writing USD.",
     )
-    worldspace: bool = SettingsField(title="World-Space", default=True)
+    worldspace: bool = SettingsField(
+        title="World-Space",
+        default=True,
+        description=(
+            "Export root prims using their full world-space transforms "
+            "instead of local transforms."
+        ),
+    )
     exportComponentTags: bool = SettingsField(
-        title="Export Component Tags", default=False
+        title="Export Component Tags",
+        default=False,
+        description=(
+            "When enabled, export geometry component tags as UsdGeomSubset "
+            "data."
+        ),
     )
     exportVisibility: bool = SettingsField(
-        title="Export Visibility", default=True
+        title="Export Visibility",
+        default=True,
+        description=(
+            "Export visibility state and animation from Maya visibility"
+            " attributes."
+        ),
     )
     mergeTransformAndShape: bool = SettingsField(
-        title="Merge Transform and Shape", default=True
+        title="Merge Transform and Shape",
+        default=True,
+        description=(
+            "Combine Maya transform and shape into a single USD prim that has "
+            "transform and geometry. Results in smaller and faster scenes; "
+            "gprims are unpacked back into transform+shape when imported into "
+            "Maya."
+        ),
     )
     defaultMeshScheme: str = SettingsField(
         enum_resolver=maya_usd_default_mesh_scheme_enum,
         default="catmullClark",
         title="Default Subdivision Method",
+        description=(
+            "Default subdivision method for meshes. Options: catmullClark, "
+            "loop, bilinear, none. Per-mesh scheme can be authored with a "
+            "USD_ATTR_subdivisionScheme attribute."
+        ),
     )
     exportBlendShapes: bool = SettingsField(
-        title="Export BlendShapes", default=True
+        title="Export BlendShapes",
+        default=True,
+        description="Enable or disable export of blend shape (morph) data.",
     )
     exportSkin: str = SettingsField(
         enum_resolver=maya_usd_export_skin_enum,
         default="none",
         title="Export Skin",
+        description=(
+            "How to export skin cluster data:\n"
+            "- **none** do not export\n"
+            "- **auto** export if present\n"
+            "- **explicit** - export only explicitly tagged skin clusters."
+        ),
     )
     exportSkels: str = SettingsField(
         enum_resolver=maya_usd_export_skin_enum,
         default="none",
         title="Export Skeletons",
+        description=(
+            "How to export skeletons:\n"
+            "- **none** none\n"
+            "- **auto** export all skeletons (may create SkelRoots)\n"
+            "- **explicit** only those under SkelRoots."
+        ),
     )
     exportCollectionBasedBindings: bool = SettingsField(
-        title="Export Collection Based Bindings", default=False
+        title="Export Collection Based Bindings",
+        default=False,
+        description=(
+            "When enabled, export material bindings as collection-based"
+            " assignments. This authors materialCollections (`-mcs`) and binds"
+            " materials to collections instead of per-gprim direct bindings."
+        ),
     )
     exportColorSets: bool = SettingsField(
-        title="Export Color Sets", default=True
+        title="Export Color Sets",
+        default=True,
+        description="Enable or disable exporting of color sets.",
     )
     exportDisplayColor: bool = SettingsField(
-        title="Export Display Color", default=False
+        title="Export Display Color",
+        default=False,
+        description=(
+            "Enable or disable exporting of display color information."
+        ),
     )
     exportMaterials: bool = SettingsField(
-        title="Export Materials", default=True
+        title="Export Materials",
+        default=True,
+        description="Enable or disable export of materials.",
     )
     exportAssignedMaterials: bool = SettingsField(
-        title="Export Assigned Materials", default=False
+        title="Export Assigned Materials",
+        default=False,
+        description="Only export materials that are assigned to meshes.",
     )
     exportInstances: bool = SettingsField(
-        title="Export Instances", default=True
+        title="Export Instances",
+        default=True,
+        description="Enable or disable export of instanced geometry.",
     )
-    exportUVs: bool = SettingsField(title="Export UVs", default=True)
+    exportUVs: bool = SettingsField(
+        title="Export UVs",
+        default=True,
+        description="Enable or disable export of UV sets.",
+    )
     upAxis: str = SettingsField(
         enum_resolver=maya_usd_up_axis_enum,
         title="Up Axis",
         default="mayaPrefs",
+        description=(
+            "Control the up-axis authored in USD:\n"
+            "- **mayaPrefs** follows Maya preferences\n"
+            "- **none** authors no up-axis\n"
+            "- or explicitly choose **y** or **z** to author that axis and "
+            "convert data if needed."
+        ),
     )
     unit: str = SettingsField(
         enum_resolver=maya_usd_unit_enum,
         title="Export Unit",
         default="mayaPrefs",
+        description=(
+            "Control units authored in USD:\n"
+            "- **mayaPrefs** follows Maya preferences\n"
+            "- **none** authors no units\n"
+            "- or choose explicit units (mm, cm, m, in, ft) to author and"
+            " convert data accordingly."
+        ),
     )
 
     custom_attr_namespace: str = SettingsField(
         title="Custom Attribute Default Namespace",
         default="userProperties:",
         section="Custom Attributes",
+        description=(
+            "Default namespace prefix used when exporting custom Maya"
+            " attributes to USD when no explicit usdAttrName is provided."
+        ),
     )
     custom_attr_name_mapping: list[str] = SettingsField(
-        title="Custom Attribute Name Mapping", default_factory=list
+        title="Custom Attribute Name Mapping",
+        default_factory=list,
+        description=(
+            "Direct mappings from Maya attribute names to USD attribute"
+            " names. Specify as a list of mappings."
+        ),
     )
     custom_attr_mapping: str = SettingsField(
-        title="Advanced Custom Attribute Mapping", default="{}"
+        title="Advanced Custom Attribute Mapping",
+        default="{}",
+        description=(
+            "Advanced JSON mapping for Maya->USD attribute conversions."
+            " Matches the USD_UserExportedAttributesJson structure used by"
+            " mayaUSDExport."
+        ),
     )
 
 

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -625,7 +625,7 @@ class ExtractMayaUsdModel(BaseSettingsModel):
         return value
 
 
-def default_mesh_scheme_enum():
+def maya_usd_default_mesh_scheme_enum():
     return [
         {"label": "Catmull Clark", "value": "catmullClark"},
         {"label": "Loop", "value": "loop"},
@@ -634,7 +634,7 @@ def default_mesh_scheme_enum():
     ]
 
 
-def export_skin_enum():
+def maya_usd_export_skin_enum():
     return [
         {"label": "None", "value": "none"},
         {"label": "Auto", "value": "auto"},
@@ -642,7 +642,7 @@ def export_skin_enum():
     ]
 
 
-def unit_enum():
+def maya_usd_unit_enum():
     return [
         {"label": "Maya Preferences", "value": "mayaPrefs"},
         {"label": "None", "value": "none"},
@@ -651,6 +651,16 @@ def unit_enum():
         {"label": "Meters", "value": "m"},
         {"label": "Inches", "value": "in"},
         {"label": "Feet", "value": "ft"},
+    ]
+
+
+def maya_usd_up_axis_enum():
+    """Get Up Axis enumerator."""
+    return [
+        {"value": "mayaPrefs", "label": "Maya Preferences"},
+        {"value": "none", "label": "None"},
+        {"value": "y", "label": "y"},
+        {"value": "z", "label": "z"},
     ]
 
 
@@ -664,27 +674,71 @@ class ExtractMayaUsdGeneralModel(BasicExtractorModel):
         )
     )
     # Maya USD export options exposed to settings so defaults can be set
-    stripNamespaces: bool = SettingsField(title="Strip Namespaces", default=True)
+    stripNamespaces: bool = SettingsField(
+        title="Strip Namespaces", default=True, section="Defaults"
+    )
     worldspace: bool = SettingsField(title="World-Space", default=True)
-    exportComponentTags: bool = SettingsField(title="Export Component Tags", default=False)
-    exportVisibility: bool = SettingsField(title="Export Visibility", default=True)
-    mergeTransformAndShape: bool = SettingsField(title="Merge Transform and Shape", default=True)
-    defaultMeshScheme: str = SettingsField(enum_resolver=default_mesh_scheme_enum, default="catmullClark", title="Default Subdivision Method")
-    exportBlendShapes: bool = SettingsField(title="Export BlendShapes", default=True)
-    exportSkin: str = SettingsField(enum_resolver=export_skin_enum, default="none", title="Export Skin")
-    exportSkels: str = SettingsField(enum_resolver=export_skin_enum, default="none", title="Export Skeletons")
-    exportCollectionBasedBindings: bool = SettingsField(title="Export Collection Based Bindings", default=False)
-    exportColorSets: bool = SettingsField(title="Export Color Sets", default=True)
-    exportDisplayColor: bool = SettingsField(title="Export Display Color", default=False)
-    exportMaterials: bool = SettingsField(title="Export Materials", default=True)
-    exportAssignedMaterials: bool = SettingsField(title="Export Assigned Materials", default=False)
-    exportInstances: bool = SettingsField(title="Export Instances", default=True)
+    exportComponentTags: bool = SettingsField(
+        title="Export Component Tags", default=False
+    )
+    exportVisibility: bool = SettingsField(
+        title="Export Visibility", default=True
+    )
+    mergeTransformAndShape: bool = SettingsField(
+        title="Merge Transform and Shape", default=True
+    )
+    defaultMeshScheme: str = SettingsField(
+        enum_resolver=maya_usd_default_mesh_scheme_enum,
+        default="catmullClark",
+        title="Default Subdivision Method",
+    )
+    exportBlendShapes: bool = SettingsField(
+        title="Export BlendShapes", default=True
+    )
+    exportSkin: str = SettingsField(
+        enum_resolver=maya_usd_export_skin_enum,
+        default="none",
+        title="Export Skin",
+    )
+    exportSkels: str = SettingsField(
+        enum_resolver=maya_usd_export_skin_enum,
+        default="none",
+        title="Export Skeletons",
+    )
+    exportCollectionBasedBindings: bool = SettingsField(
+        title="Export Collection Based Bindings", default=False
+    )
+    exportColorSets: bool = SettingsField(
+        title="Export Color Sets", default=True
+    )
+    exportDisplayColor: bool = SettingsField(
+        title="Export Display Color", default=False
+    )
+    exportMaterials: bool = SettingsField(
+        title="Export Materials", default=True
+    )
+    exportAssignedMaterials: bool = SettingsField(
+        title="Export Assigned Materials", default=False
+    )
+    exportInstances: bool = SettingsField(
+        title="Export Instances", default=True
+    )
     exportUVs: bool = SettingsField(title="Export UVs", default=True)
-    upAxis: str = SettingsField(enum_resolver=up_axis_enum, title="Up Axis", default="mayaPrefs")
-    unit: str = SettingsField(enum_resolver=unit_enum, title="Export Unit", default="mayaPrefs")
+    upAxis: str = SettingsField(
+        enum_resolver=maya_usd_up_axis_enum,
+        title="Up Axis",
+        default="mayaPrefs",
+    )
+    unit: str = SettingsField(
+        enum_resolver=maya_usd_unit_enum,
+        title="Export Unit",
+        default="mayaPrefs",
+    )
 
     custom_attr_namespace: str = SettingsField(
-        title="Custom Attribute Default Namespace", default="userProperties:"
+        title="Custom Attribute Default Namespace",
+        default="userProperties:",
+        section="Custom Attributes",
     )
     custom_attr_name_mapping: list[str] = SettingsField(
         title="Custom Attribute Name Mapping", default_factory=list
@@ -2012,6 +2066,24 @@ DEFAULT_PUBLISH_SETTINGS = {
             "mergeTransformAndShape",
             "defaultMeshScheme"
         ],
+        "stripNamespaces": True,
+        "worldspace": True,
+        "exportComponentTags": False,
+        "exportVisibility": True,
+        "mergeTransformAndShape": True,
+        "defaultMeshScheme": "catmullClark",
+        "exportBlendShapes": True,
+        "exportSkin": "none",
+        "exportSkels": "none",
+        "exportCollectionBasedBindings": False,
+        "exportColorSets": True,
+        "exportDisplayColor": False,
+        "exportMaterials": True,
+        "exportAssignedMaterials": False,
+        "exportInstances": True,
+        "exportUVs": True,
+        "upAxis": "mayaPrefs",
+        "unit": "mayaPrefs",
         "custom_attr_namespace": "userProperties:",
         "custom_attr_name_mapping": [],
         "custom_attr_mapping": "{}",

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -556,76 +556,6 @@ class ExtractMayaUsdCustomAttrNameMappingModel(BaseSettingsModel):
     usd_name: str = SettingsField("", title="USD name")
 
 
-# TODO: This model seems to be unused?
-class ExtractMayaUsdModel(BaseSettingsModel):
-    """Export USD using Maya's mayaUsd plug-in
-
-    Custom attributes overrides allow user defined attributes to be exported
-    using custom naming overrides, e.g. by prefixing them all with a default
-    namespace or specifying explict Maya name to USD name mapping.
-
-    You can also customize it with the mapping JSON which expects a key
-    for each Maya attribute name to customize output values for, using the
-    [custom attribute `USD_UserExportedAttributesJson` syntax](https://github.com/Autodesk/maya-usd/blob/dev/lib/mayaUsd/commands/Readme.md#specifying-arbitrary-attributes-for-export).
-
-    Any existing `USD_UserExportedAttributesJson` attribute on nodes in the
-    scene will still be the strongest opinion - hence these mappings only
-    apply defaults if not explicitly specified in the scene.
-    """
-    custom_attr_namespace: str = SettingsField(
-        section="Custom Attributes",
-        title="Custom Attribute Default Namespace",
-        description=(
-            "Default USD attribute name prefix for custom attributes to be"
-            " exported. For example, setting this to an empty string would"
-            " make custom attribute `myAttr` exported directly as `myAttr`"
-            " instead of `userProperties:myAttr` in the resulting USD file."
-            " In the majority of cases you will want to leave this at the"
-            " default `userProperties:` because that is where you store user"
-            " defined properties."
-        )
-    )
-    custom_attr_name_mapping: list[
-        ExtractMayaUsdCustomAttrNameMappingModel
-    ] = SettingsField(
-        title="Custom Attribute Name Mapping",
-        description=(
-            "Specify a Maya name to USD attribute name mapping "
-            "for custom attributes"
-        )
-    )
-    custom_attr_mapping: str = SettingsField(
-        title="Advanced Custom Attribute Mapping",
-        widget="textarea",
-        description=(
-            "Default [custom attribute `USD_UserExportedAttributesJson`](https://github.com/Autodesk/maya-usd/blob/dev/lib/mayaUsd/commands/Readme.md#specifying-arbitrary-attributes-for-export)."
-            "\n\n"
-            "Use this if you want to override other data or more than just "
-            "the name, like e.g. `usdAttrType` or "
-            "`translateMayaDoubleToUsdSinglePrecision`."
-            "\n\n"
-            "Any `USD_UserExportedAttributesJson` attribute existing"
-            " on the node attribute will not be overridden."
-        )
-    )
-
-    @validator("custom_attr_mapping")
-    def validate_json(cls, value):
-        if not value.strip():
-            return "{}"
-        try:
-            converted_value = json.loads(value)
-            success = isinstance(converted_value, dict)
-        except json.JSONDecodeError:
-            success = False
-
-        if not success:
-            raise BadRequestException(
-                "The attributes can't be parsed as json object"
-            )
-        return value
-
-
 def maya_usd_default_mesh_scheme_enum():
     return [
         {"label": "Catmull Clark", "value": "catmullClark"},
@@ -816,6 +746,19 @@ class ExtractMayaUsdGeneralModel(BasicExtractorModel):
         ),
     )
 
+    """
+    Custom attributes overrides allow user defined attributes to be exported
+    using custom naming overrides, e.g. by prefixing them all with a default
+    namespace or specifying explict Maya name to USD name mapping.
+
+    You can also customize it with the mapping JSON which expects a key
+    for each Maya attribute name to customize output values for, using the
+    [custom attribute `USD_UserExportedAttributesJson` syntax](https://github.com/Autodesk/maya-usd/blob/dev/lib/mayaUsd/commands/Readme.md#specifying-arbitrary-attributes-for-export).
+
+    Any existing `USD_UserExportedAttributesJson` attribute on nodes in the
+    scene will still be the strongest opinion - hence these mappings only
+    apply defaults if not explicitly specified in the scene.
+    """  # noqa
     custom_attr_namespace: str = SettingsField(
         title="Custom Attribute Default Namespace",
         default="userProperties:",
@@ -843,7 +786,24 @@ class ExtractMayaUsdGeneralModel(BasicExtractorModel):
             " Matches the USD_UserExportedAttributesJson structure used by"
             " mayaUSDExport."
         ),
+        syntax="json",
     )
+
+    @validator("custom_attr_mapping")
+    def validate_json(cls, value):
+        if not value.strip():
+            return "{}"
+        try:
+            converted_value = json.loads(value)
+            success = isinstance(converted_value, dict)
+        except json.JSONDecodeError:
+            success = False
+
+        if not success:
+            raise BadRequestException(
+                "The attributes can't be parsed as json object"
+            )
+        return value
 
 
 class ExtractMayaSceneRawModel(BasicExtractorModel):


### PR DESCRIPTION
## Changelog Description

Expose two more attributes to settings for Maya USD Exports and also allow configuring the defaults for those overridden or non-overridden attributes to the settings as well.

## Additional review information

Fix https://github.com/ynput/ayon-maya/issues/436
Fix https://github.com/ynput/ayon-maya/issues/445


## Testing notes:

1. Maya USD Export settings should work
