### PR TITLE
Replace `qargparse` usage with attribute definitions

### DIFF
--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -816,8 +816,20 @@ class ReferenceLoader(Loader):
             tooltip="How many times to load?"
         ),
         NumberDef(
-            "offset",
-            label="Position Offset",
+            "offsetX",
+            label="Position Offset X",
+            decimals=4,
+            tooltip="Offset loaded models for easier selection."
+        ),
+        NumberDef(
+            "offsetY",
+            label="Position Offset Y",
+            decimals=4,
+            tooltip="Offset loaded models for easier selection."
+        ),
+        NumberDef(
+            "offsetZ",
+            label="Position Offset Z",
             decimals=4,
             tooltip="Offset loaded models for easier selection."
         ),
@@ -859,8 +871,13 @@ class ReferenceLoader(Loader):
             options['group_name'] = group_name
 
             # Offset loaded product
-            if "offset" in options:
-                offset = [i * c for i in options["offset"]]
+            offset_step = [
+                options.get("offsetX") or 0,
+                options.get("offsetY") or 0,
+                options.get("offsetZ") or 0,
+            ]
+            if any(offset_step):
+                offset = [i * c for i in offset_step]
                 options["translate"] = offset
 
             self.log.info(options)

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -5,9 +5,8 @@ import os
 from urllib.parse import urlparse
 
 import ayon_api
-import qargparse
 
-from ayon_core.lib import BoolDef, Logger
+from ayon_core.lib import BoolDef, Logger, NumberDef
 from ayon_core.pipeline import (
     AVALON_INSTANCE_ID,
     AYON_INSTANCE_ID,
@@ -808,24 +807,28 @@ class ReferenceLoader(Loader):
     """
 
     options = [
-        qargparse.Integer(
+        NumberDef(
             "count",
             label="Count",
             default=1,
-            min=1,
-            help="How many times to load?"
+            minimum=1,
+            decimals=0,
+            tooltip="How many times to load?"
         ),
-        qargparse.Double3(
+        NumberDef(
             "offset",
             label="Position Offset",
-            help="Offset loaded models for easier selection."
+            decimals=4,
+            tooltip="Offset loaded models for easier selection."
         ),
-        qargparse.Boolean(
+        BoolDef(
             "attach_to_root",
             label="Group imported asset",
             default=True,
-            help="Should a group be created to encapsulate"
-                 " imported representation ?"
+            tooltip=(
+                "Should a group be created to encapsulate"
+                " imported representation?"
+            )
         )
     ]
 

--- a/client/ayon_maya/plugins/load/load_multiverse_usd_over.py
+++ b/client/ayon_maya/plugins/load/load_multiverse_usd_over.py
@@ -2,7 +2,7 @@
 import os
 
 import maya.cmds as cmds
-import qargparse
+from ayon_core.lib import TextDef
 from ayon_api import get_representation_by_id
 from ayon_maya.api import plugin
 from ayon_maya.api.lib import maintained_selection
@@ -24,10 +24,10 @@ class MultiverseUsdOverLoader(plugin.Loader):
     color = "orange"
 
     options = [
-        qargparse.String(
+        TextDef(
             "Which Compound",
             label="Compound",
-            help="Select which compound to add this as a layer to."
+            tooltip="Select which compound to add this as a layer to."
         )
     ]
 

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -1,8 +1,8 @@
 import contextlib
 import difflib
 
-import qargparse
 from ayon_core.settings import get_project_settings
+from ayon_core.lib import BoolDef, TextDef
 from ayon_core.pipeline import get_current_project_name
 from ayon_core.pipeline.load import get_representation_context
 from ayon_maya.api import plugin
@@ -404,17 +404,17 @@ class MayaUSDReferenceLoader(ReferenceLoader):
     extensions = {"usd", "usda", "usdc"}
 
     options = ReferenceLoader.options + [
-        qargparse.Boolean(
+        BoolDef(
             "readAnimData",
             label="Load anim data",
             default=True,
-            help="Load animation data from USD file"
+            tooltip="Load animation data from USD file"
         ),
-        qargparse.Boolean(
+        BoolDef(
             "useAsAnimationCache",
             label="Use as animation cache",
             default=True,
-            help=(
+            tooltip=(
                 "Imports geometry prims with time-sampled point data using a "
                 "point-based deformer that references the imported "
                 "USD file.\n"
@@ -423,20 +423,20 @@ class MayaUSDReferenceLoader(ReferenceLoader):
                 "reduce the weight of the resulting Maya scene."
             )
         ),
-        qargparse.Boolean(
+        BoolDef(
             "importInstances",
             label="Import instances",
             default=True,
-            help=(
+            tooltip=(
                 "Import USD instanced geometries as Maya instanced shapes. "
                 "Will flatten the scene otherwise."
             )
         ),
-        qargparse.String(
+        TextDef(
             "primPath",
             label="Prim Path",
             default="/",
-            help=(
+            tooltip=(
                 "Name of the USD scope where traversing will begin.\n"
                 "The prim at the specified primPath (including the prim) will "
                 "be imported.\n"


### PR DESCRIPTION
## Changelog Description

Replace `qargparse` usage with attribute definitions

## Additional review information

May avoid errors like this in Maya 2027:
```python
# Traceback (most recent call last):
# #   File "C:\Work\REPO\ayon-core\client\ayon_core\vendor\python\qargparse.py", line 131, in <lambda>
#     arg.changed.connect(lambda: self.on_changed(arg))
                                ~~~~~~~~~~~~~~~^^^^^
# #   File "C:\Work\REPO\ayon-core\client\ayon_core\vendor\python\qargparse.py", line 187, in on_changed
#     self.changed.emit(arg)
    ~~~~~~~~~~~~~~~~~^^^^^
# RuntimeError: Internal C++ object (QArgumentParser) already deleted.
# Traceback (most recent call last):
# #   File "C:\Work\REPO\ayon-core\client\ayon_core\vendor\python\qargparse.py", line 167, in on_changed
#     reset.setVisible(arg["edited"])
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
```

## Testing notes:
1. Option box attributes should still work for ReferenceLoader and Maya USD Loader
