### PR TITLE
Fix JSON syntax flag for `custom_attr_mapping` in settings

### DIFF
--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -787,6 +787,7 @@ class ExtractMayaUsdGeneralModel(BasicExtractorModel):
             " Matches the USD_UserExportedAttributesJson structure used by"
             " mayaUSDExport."
         ),
+        widget="textarea",
         syntax="json",
     )
 


### PR DESCRIPTION
## Changelog Description

Fix JSON syntax flag for `custom_attr_mapping` in settings

## Additional review information

Fixes:
```
DEBUG   settings.settings_field    | SettingsField: syntax is only supported for textarea widget
```

## Testing notes:
1. Settings should work; no warning logs for this addon on server logs.
