### PR TITLE
Renderlayer should not error when collection is under the group and overrides have setup 

### DIFF
--- a/client/ayon_maya/api/lib_rendersetup.py
+++ b/client/ayon_maya/api/lib_rendersetup.py
@@ -364,28 +364,29 @@ def iter_layer_overrides(layer):
     Yields:
         Override: Each override object found in the layer hierarchy.
     """
-    queue = [layer]
-    # layer.getChildren() does not return groups even though
-    # getChildren on groups or collections does return them
-    if hasattr(layer, "getChildren"):
-        queue.extend(layer.getChildren())
+    stack = []
+    # Seed stack with both the layer's children and groups (layer.getChildren()
+    # omits groups, unlike groups/collections themselves).
     if hasattr(layer, "getGroups"):
-        queue.extend([g for g in layer.getGroups() if g.isEnabled()])
+        stack.extend(reversed([g for g in layer.getGroups() if g.isEnabled()]))
+    if hasattr(layer, "getChildren"):
+        # Pushed last so it's visited first when popping from the stack.
+        stack.extend(reversed(layer.getChildren()))
 
-    for obj in queue:
+    while stack:
+        obj = stack.pop()
         if isinstance(obj, Override):
             yield obj
-        else:
-            if hasattr(obj, "isRenderable") and not obj.isRenderable():
-                # Skip disabled groups/collections as their overrides are not
-                # active
-                continue
-            if hasattr(obj, "isEnabled") and not obj.isEnabled():
-                continue
+            continue
 
-            if hasattr(obj, "getChildren"):
-                queue.extend(obj.getChildren())
+        if hasattr(obj, "isRenderable") and not obj.isRenderable():
+            # Skip disabled groups/collections as their overrides are not active
+            continue
+        if hasattr(obj, "isEnabled") and not obj.isEnabled():
+            continue
 
+        if hasattr(obj, "getChildren"):
+            stack.extend(reversed(obj.getChildren()))
 
 def get_shader_in_layer(node, layer):
     """Return the assigned shader in a renderlayer without switching layers.

--- a/client/ayon_maya/api/lib_rendersetup.py
+++ b/client/ayon_maya/api/lib_rendersetup.py
@@ -14,6 +14,7 @@ import logging
 import maya.app.renderSetup.model.utils as utils
 from maya.app.renderSetup.model import renderSetup
 from maya.app.renderSetup.model.override import (
+    Override,
     AbsOverride,
     RelOverride,
     UniqueOverride
@@ -299,7 +300,7 @@ def get_attr_overrides(node_attr, layer,
     # Iterate over the overrides in reverse so we get the last
     # overrides first and can "break" whenever an absolute
     # override is reached
-    layer_overrides = list(utils.getOverridesRecursive(rs_layer))
+    layer_overrides = list(iter_layer_overrides(rs_layer))
     for layer_override in reversed(layer_overrides):
 
         if skip_disabled and not layer_override.isEnabled():
@@ -347,6 +348,23 @@ def get_attr_overrides(node_attr, layer,
             break
 
     return reversed(plug_overrides)
+
+
+def iter_layer_overrides(layer):
+    """Iterate layer overrides.
+
+    Args:
+        layer (RenderLayer): RenderLayer to iterate the overrides for
+
+    Yields:
+        Override: Each override object found in the layer hierarchy.
+    """
+    queue = [layer]
+    for obj in queue:
+        if isinstance(obj, Override):
+            yield obj
+        else:
+            queue.extend(obj.getChildren())
 
 
 def get_shader_in_layer(node, layer):

--- a/client/ayon_maya/api/lib_rendersetup.py
+++ b/client/ayon_maya/api/lib_rendersetup.py
@@ -11,7 +11,6 @@ from maya import cmds
 import maya.api.OpenMaya as om
 import logging
 
-import maya.app.renderSetup.model.utils as utils
 from maya.app.renderSetup.model import renderSetup
 from maya.app.renderSetup.model.override import (
     Override,

--- a/client/ayon_maya/api/lib_rendersetup.py
+++ b/client/ayon_maya/api/lib_rendersetup.py
@@ -367,16 +367,24 @@ def iter_layer_overrides(layer):
     queue = [layer]
     # layer.getChildren() does not return groups even though
     # getChildren on groups or collections does return them
-    queue.extend(layer.getGroups())
+    if hasattr(layer, "getChildren"):
+        queue.extend(layer.getChildren())
+    if hasattr(layer, "getGroups"):
+        queue.extend([g for g in layer.getGroups() if g.isEnabled()])
+
     for obj in queue:
         if isinstance(obj, Override):
             yield obj
         else:
-            if not obj.isEnabled():
+            if hasattr(obj, "isRenderable") and not obj.isRenderable():
                 # Skip disabled groups/collections as their overrides are not
                 # active
                 continue
-            queue.extend(obj.getChildren())
+            if hasattr(obj, "isEnabled") and not obj.isEnabled():
+                continue
+
+            if hasattr(obj, "getChildren"):
+                queue.extend(obj.getChildren())
 
 
 def get_shader_in_layer(node, layer):

--- a/client/ayon_maya/api/lib_rendersetup.py
+++ b/client/ayon_maya/api/lib_rendersetup.py
@@ -351,7 +351,13 @@ def get_attr_overrides(node_attr, layer,
 
 def iter_layer_overrides(layer):
     """Iterate layer overrides.
-
+    Note: We cannot use `maya.app.renderSetup.model.utils.getOverridesRecursive`
+        here because it traverses via `getChildren()` which, on a RenderLayer
+        (unlike on a Group or Collection), does NOT return groups. That means
+        any overrides living inside groups would be silently skipped.
+        We work around this by seeding the queue with both `getChildren()` and
+        `getGroups()` for the top-level layer only; from that point on,
+        `getChildren()` on groups/collections correctly returns nested items.
     Args:
         layer (RenderLayer): RenderLayer to iterate the overrides for
 
@@ -359,10 +365,17 @@ def iter_layer_overrides(layer):
         Override: Each override object found in the layer hierarchy.
     """
     queue = [layer]
+    # layer.getChildren() does not return groups even though
+    # getChildren on groups or collections does return them
+    queue.extend(layer.getGroups())
     for obj in queue:
         if isinstance(obj, Override):
             yield obj
         else:
+            if not obj.isEnabled():
+                # Skip disabled groups/collections as their overrides are not
+                # active
+                continue
             queue.extend(obj.getChildren())
 
 


### PR DESCRIPTION
## Changelog Description
This PR is to make sure renderlayer does not result any error whe collection is under the group and overrides have been created.
Fixes: https://github.com/ynput/ayon-maya/issues/195

## Additional review information
n/a

## Testing notes:
1. Create a renderlayer
2. Have the collection with absolute overrides and parented it to the group under renderlayer
3. Have the collection with absolute override under renderlayer(without group).
4. Open Publisher
5. Publish
6. Should not error any validator(except the validation error) and published successfully to farm