### PR TITLE
Templated builder: add missing options of keep placeholder and create first workfile

### DIFF
--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -686,9 +686,10 @@ def on_new():
     """Set project resolution and fps when create a new file.
     If the project has a workfile template, create it.
     """
+    from .workfile_template_builder import create_first_workfile_template
+
     log.info("Running callback on new..")
     with lib.suspended_refresh():
-        from .workfile_template_builder import create_first_workfile_template
         create_first_workfile_template()
         lib.set_context_settings()
 

--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -688,10 +688,18 @@ def on_new():
     """
     from .workfile_template_builder import create_first_workfile_template
 
+    project_name = get_current_project_name()
+    project_settings = get_project_settings(project_name)
+    maya_settings = project_settings["maya"]
+    should_create_template = (
+        not os.getenv("AYON_MAYA_WORKFILE_PATH")
+        or maya_settings["open_workfile_post_initialization"]
+    )
+
     log.info("Running callback on new..")
     with lib.suspended_refresh():
         lib.set_context_settings()
-        if not os.getenv("AYON_MAYA_WORKFILE_PATH"):
+        if should_create_template:
             create_first_workfile_template()
 
     _remove_workfile_lock()

--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -683,9 +683,13 @@ def on_open():
 
 
 def on_new():
-    """Set project resolution and fps when create a new file"""
+    """Set project resolution and fps when create a new file.
+    If the project has a workfile template, create it.
+    """
     log.info("Running callback on new..")
     with lib.suspended_refresh():
+        from .workfile_template_builder import create_first_workfile_template
+        create_first_workfile_template()
         lib.set_context_settings()
 
     _remove_workfile_lock()

--- a/client/ayon_maya/api/pipeline.py
+++ b/client/ayon_maya/api/pipeline.py
@@ -690,8 +690,9 @@ def on_new():
 
     log.info("Running callback on new..")
     with lib.suspended_refresh():
-        create_first_workfile_template()
         lib.set_context_settings()
+        if not os.getenv("AYON_MAYA_WORKFILE_PATH"):
+            create_first_workfile_template()
 
     _remove_workfile_lock()
 

--- a/client/ayon_maya/api/workfile_template_builder.py
+++ b/client/ayon_maya/api/workfile_template_builder.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from maya import cmds
 
@@ -10,6 +11,7 @@ from ayon_core.pipeline import (
 )
 from ayon_core.pipeline.workfile.workfile_template_builder import (
     TemplateAlreadyImported,
+    TemplateProfileNotFound,
     AbstractTemplateBuilder,
     PlaceholderPlugin,
     PlaceholderItem,
@@ -19,6 +21,8 @@ from ayon_core.tools.workfile_template_build import (
 )
 
 from .lib import read, imprint, get_main_window
+
+log = logging.getLogger(__name__)
 
 PLACEHOLDER_SET = "PLACEHOLDERS_SET"
 
@@ -242,6 +246,17 @@ class MayaPlaceholderPlugin(PlaceholderPlugin):
                 data[key] = json.loads(value)
 
         return data
+
+
+def create_first_workfile_template(*args):
+    builder = MayaTemplateBuilder(registered_host())
+    try:
+        builder.build_template(workfile_creation_enabled=True)
+
+    except TemplateProfileNotFound:
+        log.warning(
+            "Template profile not found. Skipping..."
+        )
 
 
 def build_workfile_template(*args):

--- a/server/settings/templated_workfile_settings.py
+++ b/server/settings/templated_workfile_settings.py
@@ -16,6 +16,13 @@ class WorkfileBuildProfilesModel(BaseSettingsModel):
         default_factory=list, title="Task names"
     )
     path: str = SettingsField("", title="Path to template")
+    keep_placeholder: bool = SettingsField(
+        False,
+        title="Keep placeholders")
+    create_first_version: bool = SettingsField(
+        True,
+        title="Create first version"
+    )
 
 
 class TemplatedProfilesModel(BaseSettingsModel):


### PR DESCRIPTION
## Changelog Description
This PR is to add missing keep placeholder and create first workfile options for templated builder

## Additional review information
Fixes: https://github.com/ynput/ayon-maya/issues/226
Closes: https://github.com/ynput/ayon-maya/pull/307
Secondary PR: https://github.com/ynput/ayon-maya/pull/454
## Testing notes:
1. Tweak `ayon+settings://maya/templated_workfile_build/profiles`
2. Launch Maya
3. Should be built accordingly when you launch new scene. If you dont have existing workfile, it would save the workfile if you enable `create_first_workfile` 
