### PR TITLE
ReferenceLoader: Update Namespace for switching container

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -121,14 +121,16 @@ def unlocked(node):
         node (str): The name of the node to unlock.
     """
     has_locked = cmds.lockNode(node, query=True, lock=True)[0]
-    cmds.lockNode(node, lock=False)
-
+    node_uuid = cmds.ls(node, uuid=True)[0]
     try:
+        cmds.lockNode(node, lock=False)
         yield
 
     finally:
-        if cmds.objExists(node):
-            cmds.lockNode(node, lock=has_locked)
+        if not cmds.objExists(node):
+            # Try and find the node by uuid
+            node = cmds.ls(node_uuid)[0]
+        cmds.lockNode(node, lock=has_locked)
 
 
 @contextlib.contextmanager

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4373,10 +4373,6 @@ def update_animation_instance(
     )
 
     for object_set in object_sets:
-        # Only consider empty object sets
-        members = cmds.sets(object_set, query=True)
-        if members:
-            continue
         # Ignore referenced object sets
         if cmds.referenceQuery(object_set, isNodeReferenced=True):
             continue

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4341,6 +4341,91 @@ def get_creator_identifier(node: str) -> str | None:
     return get_attribute(f"{node}.creator_identifier")
 
 
+def update_animation_instance(
+    container: dict,
+    context: dict,
+    namespace: str
+) -> None:
+    """Update the name of animation instance
+
+    Args:
+        container (dict): container
+        context (dict): context
+        namespace (str): namespace
+    """
+    members = get_container_members(container)
+    object_sets = set()
+    for member in members:
+        object_sets.update(
+            cmds.listSets(object=member, extendToShape=False) or []
+        )
+    object_sets = cmds.ls(object_sets, type="objectSet")
+    create_context = CreateContext(registered_host(), discover_publish_plugins=False)
+    animation_creator_identifier = "io.openpype.creators.maya.animation"
+    animation_creator = create_context.creators.get(animation_creator_identifier)
+    variant = get_rig_animation_instance_variant(context, namespace)
+    target_name = animation_creator.get_product_name(
+        project_name=create_context.get_current_project_name(),
+        folder_entity=create_context.get_current_folder_entity(),
+        task_entity=create_context.get_current_task_entity(),
+        variant=variant,
+        instance=None
+    )
+
+    for object_set in object_sets:
+        # Only consider empty object sets
+        members = cmds.sets(object_set, query=True)
+        if members:
+            continue
+        # Ignore referenced object sets
+        if cmds.referenceQuery(object_set, isNodeReferenced=True):
+            continue
+        # Then only here confirm whether this is an animation instance, if so
+        # then we will want to auto-remove the instance
+        if get_creator_identifier(object_set) == animation_creator_identifier:
+            new_objectset = cmds.rename(object_set, target_name)
+            set_attribute(node=new_objectset, attribute="productName", value=new_objectset)
+
+
+def get_rig_animation_instance_variant(context, namespace, options=None)-> str:
+    folder_entity = context["folder"]
+    product_entity = context["product"]
+    product_type = product_entity["productType"]
+    product_base_type = product_entity.get("productBaseType")
+    if not product_base_type:
+        product_base_type = product_type
+    product_name = product_entity["name"]
+
+    custom_product_name = options.get("animationProductName")
+    if custom_product_name:
+        for old_key, new_key in (
+            ("{family}", "{product[basetype]}"),
+            ("{asset}", "{folder[name]}"),
+            ("{subset}", "asset"),
+        ):
+            if old_key in custom_product_name:
+                log.warning(f"Using deprecated template key '{old_key}'")
+                custom_product_name = custom_product_name.replace(
+                    old_key, new_key
+                )
+
+        formatting_data = {
+            "folder": {
+                "name": folder_entity["name"]
+            },
+            "product": {
+                "name": product_name,
+                "type": product_type,
+                "basetype": product_base_type,
+            },
+        }
+        return get_custom_namespace(
+            custom_product_name.format(**formatting_data)
+        )
+
+    return namespace
+
+
 def create_rig_animation_instance(
     nodes, context, namespace, options=None, log=None
 ):
@@ -4389,40 +4474,7 @@ def create_rig_animation_instance(
     )
     assert roots, "No root nodes in rig, this is a bug."
 
-    folder_entity = context["folder"]
-    product_entity = context["product"]
-    product_type = product_entity["productType"]
-    product_base_type = product_entity.get("productBaseType")
-    if not product_base_type:
-        product_base_type = product_type
-    product_name = product_entity["name"]
-
-    custom_product_name = options.get("animationProductName")
-    if custom_product_name:
-        for old_key, new_key in (
-            ("{family}", "{product[basetype]}"),
-            ("{asset}", "{folder[name]}"),
-            ("{subset}", "asset"),
-        ):
-            if old_key in custom_product_name:
-                log.warning(f"Using deprecated template key '{old_key}'")
-                custom_product_name = custom_product_name.replace(
-                    old_key, new_key
-                )
-
-        formatting_data = {
-            "folder": {
-                "name": folder_entity["name"]
-            },
-            "product": {
-                "name": product_name,
-                "type": product_type,
-                "basetype": product_base_type,
-            },
-        }
-        namespace = get_custom_namespace(
-            custom_product_name.format(**formatting_data)
-        )
+    namespace = get_rig_animation_instance_variant(context, namespace, options=options)
 
     if log:
         log.info("Creating product: {}".format(namespace))

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -122,8 +122,8 @@ def unlocked(node):
     """
     has_locked = cmds.lockNode(node, query=True, lock=True)[0]
     node_uuid = cmds.ls(node, uuid=True)[0]
+    cmds.lockNode(node, lock=False)
     try:
-        cmds.lockNode(node, lock=False)
         yield
 
     finally:

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -128,8 +128,11 @@ def unlocked(node):
 
     finally:
         if not cmds.objExists(node):
-            # Try and find the node by uuid
-            node = cmds.ls(node_uuid)[0]
+            # Node might have been renamed or deleted; try and find it by uuid.
+            nodes_from_id = cmds.ls(node_uuid, long=True) or []
+            if not nodes_from_id:
+                return
+            node = nodes_from_id[0]
         cmds.lockNode(node, lock=has_locked)
 
 

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -127,7 +127,8 @@ def unlocked(node):
         yield
 
     finally:
-        cmds.lockNode(node, lock=has_locked)
+        if cmds.objExists(node):
+            cmds.lockNode(node, lock=has_locked)
 
 
 @contextlib.contextmanager

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -4474,10 +4474,10 @@ def create_rig_animation_instance(
     )
     assert roots, "No root nodes in rig, this is a bug."
 
-    namespace = get_rig_animation_instance_variant(context, namespace, options=options)
+    variant = get_rig_animation_instance_variant(context, namespace, options=options)
 
     if log:
-        log.info("Creating product: {}".format(namespace))
+        log.info("Creating product: {}".format(variant))
 
     # Fill creator identifier
     creator_identifier = "io.openpype.creators.maya.animation"
@@ -4492,7 +4492,7 @@ def create_rig_animation_instance(
         cmds.select(rig_sets + roots, noExpand=True)
         create_context.create(
             creator_identifier=creator_identifier,
-            variant=namespace,
+            variant=variant,
             pre_create_data={
                 "use_selection": True,
                 "lock_instance": options.get("lock_instance", False)

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -741,24 +741,7 @@ class Loader(LoaderPlugin):
             self.log.debug("No custom group_name, no group will be created.")
             options["attach_to_root"] = False
 
-        folder_entity = context["folder"]
-        product_entity = context["product"]
-        product_name = product_entity["name"]
-        product_type = product_entity["productType"]
-        product_base_type = product_entity.get("productBaseType")
-        if not product_base_type:
-             product_base_type = product_type
-
-        formatting_data = {
-            "folder": {
-                "name": folder_entity["name"],
-            },
-            "product": {
-                "name": product_name,
-                "type": product_type,
-                "baseType": product_base_type,
-            },
-        }
+        formatting_data = self.get_namespace_template_data(context)
         namespace_template = custom_naming["namespace"]
         group_name_template = custom_naming["group_name"]
 
@@ -795,6 +778,48 @@ class Loader(LoaderPlugin):
         custom_group_name = group_name_template.format(**formatting_data)
 
         return custom_group_name, custom_namespace, options
+
+    def get_namespace_template_data(self, context: dict) -> dict:
+        """Get namespace template data
+
+        Args:
+            context (dict): Context data
+
+        Returns:
+            dict: template data for getting namespace
+        """
+        folder_entity = context["folder"]
+        product_entity = context["product"]
+        product_type = product_entity["productType"]
+        product_base_type = (
+            product_entity.get("productBaseType") or product_type
+        )
+
+        return {
+            "folder": {
+                "name": folder_entity["name"],
+            },
+            "product": {
+                "name": product_entity["name"],
+                "type": product_type,
+                "baseType": product_base_type,
+            },
+        }
+
+    def get_resolved_namespace_template(self, context: dict, loader_key: str) -> str:
+        """Get the resolved namespace template for a given loader key and context.
+
+        Args:
+            context (dict): The context dictionary.
+            loader_key (str): The loader key.
+
+        Returns:
+            str: The resolved namespace template.
+        """
+        settings = self.load_settings[loader_key]
+        namespace_template = settings.get("namespace")
+        formatting_data = self.get_namespace_template_data(context)
+        return namespace_template.format(**formatting_data)
 
 
 class ReferenceLoader(Loader):
@@ -1023,7 +1048,6 @@ class ReferenceLoader(Loader):
             ("project_name", context["project"]["name"]),
         ]:
             lib.set_attribute(node=node, attribute=attr_name, value=value)
-
         # When an animation or pointcache gets connected to an Xgen container,
         # the compound attribute "xgenContainers" gets created. When animation
         # containers gets updated we also need to update the cacheFileName on

--- a/client/ayon_maya/api/plugin.py
+++ b/client/ayon_maya/api/plugin.py
@@ -806,21 +806,6 @@ class Loader(LoaderPlugin):
             },
         }
 
-    def get_resolved_namespace_template(self, context: dict, loader_key: str) -> str:
-        """Get the resolved namespace template for a given loader key and context.
-
-        Args:
-            context (dict): The context dictionary.
-            loader_key (str): The loader key.
-
-        Returns:
-            str: The resolved namespace template.
-        """
-        settings = self.load_settings[loader_key]
-        namespace_template = settings.get("namespace")
-        formatting_data = self.get_namespace_template_data(context)
-        return namespace_template.format(**formatting_data)
-
 
 class ReferenceLoader(Loader):
     """A basic ReferenceLoader for Maya

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -427,8 +427,8 @@ class ReferenceLoader(plugin.ReferenceLoader):
                 "skipping namespace update."
             )
             return
-        custom_namespace = namespace_template.format(
-            **self.get_namespace_template_data(context)
+        custom_namespace = namespace_template.format_map(
+            self.get_namespace_template_data(context)
         )
         new_namespace = get_custom_namespace(custom_namespace)
         old_namespace = cmds.referenceQuery(

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -261,12 +261,10 @@ class ReferenceLoader(plugin.ReferenceLoader):
 
     def switch(self, container, context):
         self.update(container, context)
-        project_name = context["project"]["name"]
-        settings = get_project_settings(project_name)
-        loader_settings = settings["maya"]["load"].get("reference_loader", {})
-        update_namespace = loader_settings.get("update_namespace_on_switch", False)
+        reference_loader_settings = self.load_settings.get("reference_loader", {})
+        update_namespace = reference_loader_settings.get("update_namespace_on_switch", False)
         if update_namespace:
-            self._update_namespace(container, context, loader_settings)
+            self._update_namespace(container, context, reference_loader_settings)
 
     def update(self, container, context):
         with preserve_modelpanel_cameras(container, log=self.log):
@@ -407,20 +405,20 @@ class ReferenceLoader(plugin.ReferenceLoader):
             self,
             container: dict,
             context: dict,
-            settings: dict,
+            reference_loader_settings: dict,
         ) -> None:
         """Update the namespace of the reference node.
 
         Args:
             container (dict): The container dictionary.
             context (dict): The context dictionary.
-            settings (dict): The settings dictionary.
+            reference_loader_settings (dict): The reference loader settings dictionary.
         """
         # Update namespace on reference node
         container_node = container["objectName"]
         members = get_container_members(container)
         reference_node = get_reference_node(members, self.log)
-        namespace_template = settings.get("namespace")
+        namespace_template = reference_loader_settings.get("namespace")
         if not namespace_template:
             self.log.warning(
                 "No namespace template found in reference_loader settings; "

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -319,11 +319,6 @@ class ReferenceLoader(plugin.ReferenceLoader):
         # locked
         object_sets = cmds.ls(object_sets, type="objectSet")
         for object_set in object_sets:
-            # Only consider empty object sets
-            members = cmds.sets(object_set, query=True)
-            if not members:
-                continue
-
             # Only consider locked object sets
             locked = cmds.lockNode(object_set, query=True)
             if not locked:

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -440,7 +440,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
         if product_base_type == "rig":
             self.update_animation_instance(
                 container,
-                old_namespace,
+                context,
                 new_namespace
             )
         set_attribute(
@@ -460,37 +460,59 @@ class ReferenceLoader(plugin.ReferenceLoader):
     def update_animation_instance(
         self,
         container: dict,
-        old_namespace: str,
+        context: dict,
         new_namespace: str
     ) -> None:
-        """Update the name of animation instance
-
-        Args:
-            container (dict): container
-            old_namespace (str): old_namespace
-            new_namespace (str): new_namespace
-        """
+        """Recreate rig animation instance with the new namespace."""
         members = get_container_members(container)
         object_sets = set()
         for member in members:
             object_sets.update(
                 cmds.listSets(object=member, extendToShape=False) or []
             )
-        object_sets = cmds.ls(object_sets, type="objectSet")
-        for object_set in object_sets:
-            # Only consider empty object sets
-            members = cmds.sets(object_set, query=True)
-            if members:
-                continue
-            # Ignore referenced object sets
+
+        animation_sets = []
+        for object_set in cmds.ls(object_sets, type="objectSet") or []:
+            # Skip referenced sets
             if cmds.referenceQuery(object_set, isNodeReferenced=True):
                 continue
-            # Then only here confirm whether this is an animation instance, if so
-            # then we will want to auto-remove the instance
-            if get_creator_identifier(object_set) == "io.openpype.creators.maya.animation":
-                new_objectset = object_set.replace(old_namespace, new_namespace)
-                new_objectset = cmds.rename(object_set, new_objectset)
-                set_attribute(node=new_objectset, attribute="productName", value=new_objectset)
+            # Keep only the rig animation instance sets
+            if get_creator_identifier(object_set) != "io.openpype.creators.maya.animation":
+                continue
+            animation_sets.append(object_set)
+
+        if not animation_sets:
+            self.log.debug("No existing local animation instance found to update.")
+            return
+
+        # Preserve whether the existing instance was locked
+        lock_instance = any(
+            cmds.lockNode(obj_set, query=True, lock=True)[0]
+            for obj_set in animation_sets
+        )
+
+        # Recreate using canonical creator logic so naming + productName are correct
+        try:
+            create_rig_animation_instance(
+                nodes=members,
+                context=context,
+                namespace=new_namespace,
+                options={"lock_instance": lock_instance},
+                log=self.log
+            )
+        except RigSetsNotExistError as exc:
+            self.log.warning(
+                "Failed to recreate animation instance after namespace update: %s",
+                exc
+            )
+            return
+
+        # Remove old animation instance set(s) only after successful recreation
+        for object_set in animation_sets:
+            if not cmds.objExists(object_set):
+                continue
+            with unlocked(object_set):
+                cmds.delete(object_set)
 
 
 class MayaUSDReferenceLoader(ReferenceLoader):

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -16,7 +16,6 @@ from ayon_maya.api.lib import (
     maintained_selection,
     parent_nodes,
     get_reference_node,
-    get_reference_node_parents,
     get_custom_namespace,
     set_attribute,
 )

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -455,10 +455,6 @@ class ReferenceLoader(plugin.ReferenceLoader):
             new_ref_node = reference_node.replace(old_namespace, new_namespace)
             cmds.rename(reference_node, new_ref_node)
 
-        # lock the reference node if it was locked before the namespace update
-        has_locked = cmds.lockNode(new_ref_node, query=True, lock=True)[0]
-        cmds.lockNode(new_ref_node, lock=has_locked)
-
         container["namespace"] = new_namespace
 
     def update_animation_instance(

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -419,8 +419,15 @@ class ReferenceLoader(plugin.ReferenceLoader):
         container_node = container["objectName"]
         members = get_container_members(container)
         reference_node = get_reference_node(members, self.log)
-        custom_namespace = self._get_switch_namespace_template(
-            context, settings
+        namespace_template = settings.get("namespace")
+        if not namespace_template:
+            self.log.warning(
+                "No namespace template found in reference_loader settings; "
+                "skipping namespace update."
+            )
+            return
+        custom_namespace = namespace_template.format(
+            **self.get_namespace_template_data(context)
         )
         new_namespace = get_custom_namespace(custom_namespace)
         old_namespace = cmds.referenceQuery(

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -15,6 +15,10 @@ from ayon_maya.api.lib import (
     get_creator_identifier,
     maintained_selection,
     parent_nodes,
+    get_reference_node,
+    get_reference_node_parents,
+    get_custom_namespace,
+    set_attribute,
 )
 from maya import cmds
 
@@ -257,6 +261,12 @@ class ReferenceLoader(plugin.ReferenceLoader):
 
     def switch(self, container, context):
         self.update(container, context)
+        project_name = context["project"]["name"]
+        settings = get_project_settings(project_name)
+        loader_settings = settings["maya"]["load"].get("reference_loader", {})
+        update_namespace = loader_settings.get("update_namespace_on_switch", False)
+        if update_namespace:
+            self._update_namespace(container, context, loader_settings)
 
     def update(self, container, context):
         with preserve_modelpanel_cameras(container, log=self.log):
@@ -392,6 +402,85 @@ class ReferenceLoader(plugin.ReferenceLoader):
         cmds.setAttr(f"{group_name}.selectHandleX", cx)
         cmds.setAttr(f"{group_name}.selectHandleY", cy)
         cmds.setAttr(f"{group_name}.selectHandleZ", cz)
+
+    def _update_namespace(
+            self,
+            container: dict,
+            context: dict,
+            settings: dict,
+        ) -> None:
+        """Update the namespace of the reference node.
+
+        Args:
+            container (dict): The container dictionary.
+            context (dict): The context dictionary.
+            settings (dict): The settings dictionary.
+        """
+        # Update namespace on reference node
+        container_node = container["objectName"]
+        members = get_container_members(container)
+        reference_node = get_reference_node(members, self.log)
+        custom_namespace = self._get_switch_namespace_template(
+            context, settings
+        )
+        new_namespace = get_custom_namespace(custom_namespace)
+        old_namespace = cmds.referenceQuery(
+            reference_node,
+            namespace=True
+        ).strip(":")
+        product_entity = context["product"]
+        product_base_type = product_entity.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_entity["productType"]
+        if product_base_type == "rig":
+            self.update_animation_instance(
+                container,
+                old_namespace,
+                new_namespace
+            )
+        cmds.namespace(rename=(old_namespace, new_namespace))
+        set_attribute(
+            node=container_node,
+            attribute="namespace",
+            value=new_namespace
+        )
+        container["namespace"] = new_namespace
+
+
+    def update_animation_instance(
+        self,
+        container: dict,
+        old_namespace: str,
+        new_namespace: str
+    ) -> None:
+        """Update the name of animation instance
+
+        Args:
+            container (dict): container
+            old_namespace (str): old_namespace
+            new_namespace (str): new_namespace
+        """
+        members = get_container_members(container)
+        object_sets = set()
+        for member in members:
+            object_sets.update(
+                cmds.listSets(object=member, extendToShape=False) or []
+            )
+        object_sets = cmds.ls(object_sets, type="objectSet")
+        for object_set in object_sets:
+            # Only consider empty object sets
+            members = cmds.sets(object_set, query=True)
+            if members:
+                continue
+            # Ignore referenced object sets
+            if cmds.referenceQuery(isNodeReferenced=object_set):
+                continue
+            # Then only here confirm whether this is an animation instance, if so
+            # then we will want to auto-remove the instance
+            if get_creator_identifier(object_set) == "io.openpype.creators.maya.animation":
+                new_objectset = object_set.replace(old_namespace, new_namespace)
+                cmds.rename(object_set, new_objectset)
+                set_attribute(node=object_set, attribute="productName", value=new_objectset)
 
 
 class MayaUSDReferenceLoader(ReferenceLoader):

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -19,6 +19,7 @@ from ayon_maya.api.lib import (
     get_custom_namespace,
     set_attribute,
     unlocked,
+    update_animation_instance,
 )
 from maya import cmds
 
@@ -438,7 +439,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
         if not product_base_type:
             product_base_type = product_entity["productType"]
         if product_base_type == "rig":
-            self.update_animation_instance(
+            update_animation_instance(
                 container,
                 context,
                 new_namespace
@@ -454,65 +455,6 @@ class ReferenceLoader(plugin.ReferenceLoader):
         with unlocked(reference_node):
             new_ref_node = reference_node.replace(old_namespace, new_namespace)
             cmds.rename(reference_node, new_ref_node)
-
-        container["namespace"] = new_namespace
-
-    def update_animation_instance(
-        self,
-        container: dict,
-        context: dict,
-        new_namespace: str
-    ) -> None:
-        """Recreate rig animation instance with the new namespace."""
-        members = get_container_members(container)
-        object_sets = set()
-        for member in members:
-            object_sets.update(
-                cmds.listSets(object=member, extendToShape=False) or []
-            )
-
-        animation_sets = []
-        for object_set in cmds.ls(object_sets, type="objectSet") or []:
-            # Skip referenced sets
-            if cmds.referenceQuery(object_set, isNodeReferenced=True):
-                continue
-            # Keep only the rig animation instance sets
-            if get_creator_identifier(object_set) != "io.openpype.creators.maya.animation":
-                continue
-            animation_sets.append(object_set)
-
-        if not animation_sets:
-            self.log.debug("No existing local animation instance found to update.")
-            return
-
-        # Preserve whether the existing instance was locked
-        lock_instance = any(
-            cmds.lockNode(obj_set, query=True, lock=True)[0]
-            for obj_set in animation_sets
-        )
-
-        # Recreate using canonical creator logic so naming + productName are correct
-        try:
-            create_rig_animation_instance(
-                nodes=members,
-                context=context,
-                namespace=new_namespace,
-                options={"lock_instance": lock_instance},
-                log=self.log
-            )
-        except RigSetsNotExistError as exc:
-            self.log.warning(
-                "Failed to recreate animation instance after namespace update: %s",
-                exc
-            )
-            return
-
-        # Remove old animation instance set(s) only after successful recreation
-        for object_set in animation_sets:
-            if not cmds.objExists(object_set):
-                continue
-            with unlocked(object_set):
-                cmds.delete(object_set)
 
 
 class MayaUSDReferenceLoader(ReferenceLoader):

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -320,7 +320,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
         for object_set in object_sets:
             # Only consider empty object sets
             members = cmds.sets(object_set, query=True)
-            if members:
+            if not members:
                 continue
 
             # Only consider locked object sets

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -455,8 +455,6 @@ class ReferenceLoader(plugin.ReferenceLoader):
         with unlocked(reference_node):
             cmds.rename(reference_node, f"{new_namespace}RN")
 
-        # Keep container metadata in sync
-        container["namespace"] = new_namespace
 
 class MayaUSDReferenceLoader(ReferenceLoader):
     """Reference USD file to native Maya nodes using MayaUSDImport reference"""

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -485,8 +485,8 @@ class ReferenceLoader(plugin.ReferenceLoader):
             # then we will want to auto-remove the instance
             if get_creator_identifier(object_set) == "io.openpype.creators.maya.animation":
                 new_objectset = object_set.replace(old_namespace, new_namespace)
-                cmds.rename(object_set, new_objectset)
-                set_attribute(node=object_set, attribute="productName", value=new_objectset)
+                new_objectset = cmds.rename(object_set, new_objectset)
+                set_attribute(node=new_objectset, attribute="productName", value=new_objectset)
 
 
 class MayaUSDReferenceLoader(ReferenceLoader):

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -479,7 +479,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
             if members:
                 continue
             # Ignore referenced object sets
-            if cmds.referenceQuery(isNodeReferenced=object_set):
+            if cmds.referenceQuery(object_set, isNodeReferenced=True):
                 continue
             # Then only here confirm whether this is an animation instance, if so
             # then we will want to auto-remove the instance

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -453,9 +453,10 @@ class ReferenceLoader(plugin.ReferenceLoader):
         cmds.namespace(rename=(old_namespace, new_namespace))
 
         with unlocked(reference_node):
-            new_ref_node = reference_node.replace(old_namespace, new_namespace)
-            cmds.rename(reference_node, new_ref_node)
+            cmds.rename(reference_node, f"{new_namespace}RN")
 
+        # Keep container metadata in sync
+        container["namespace"] = new_namespace
 
 class MayaUSDReferenceLoader(ReferenceLoader):
     """Reference USD file to native Maya nodes using MayaUSDImport reference"""

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -18,6 +18,7 @@ from ayon_maya.api.lib import (
     get_reference_node,
     get_custom_namespace,
     set_attribute,
+    unlocked,
 )
 from maya import cmds
 
@@ -444,14 +445,23 @@ class ReferenceLoader(plugin.ReferenceLoader):
                 old_namespace,
                 new_namespace
             )
-        cmds.namespace(rename=(old_namespace, new_namespace))
         set_attribute(
             node=container_node,
             attribute="namespace",
             value=new_namespace
         )
-        container["namespace"] = new_namespace
 
+        cmds.namespace(rename=(old_namespace, new_namespace))
+
+        with unlocked(reference_node):
+            new_ref_node = reference_node.replace(old_namespace, new_namespace)
+            cmds.rename(reference_node, new_ref_node)
+
+        # lock the reference node if it was locked before the namespace update
+        has_locked = cmds.lockNode(new_ref_node, query=True, lock=True)[0]
+        cmds.lockNode(new_ref_node, lock=has_locked)
+
+        container["namespace"] = new_namespace
 
     def update_animation_instance(
         self,

--- a/server/settings/loaders.py
+++ b/server/settings/loaders.py
@@ -136,7 +136,13 @@ class ReferenceLoaderModel(BaseSettingsModel):
         )
     )
     update_namespace_on_switch: bool = SettingsField(
-        title="Update Namespace on Switch"
+        title="Update Namespace on Switch",
+        description = (
+            "When enabled, the namespace of the reference node will be updated "
+            "accordingly to what folder path and task type the updated assets belong "
+            "to. This is useful when the reference is loaded with a different  "
+            "folder path or task type than the original one."
+        )
     )
 
 

--- a/server/settings/loaders.py
+++ b/server/settings/loaders.py
@@ -135,6 +135,9 @@ class ReferenceLoaderModel(BaseSettingsModel):
             "directly."
         )
     )
+    update_namespace_on_switch: bool = SettingsField(
+        title="Update Namespace on Switch"
+    )
 
 
 class ImportLoaderModel(BaseSettingsModel):
@@ -322,7 +325,8 @@ DEFAULT_LOADERS_SETTING = {
         "group_name": "_GRP",
         "display_handle": True,
         "lock_animation_instance_on_load": False,
-        "create_camera_instance_on_load": False
+        "create_camera_instance_on_load": False,
+        "update_namespace_on_switch": False,
     },
     "import_loader": {
         "enabled": True,


### PR DESCRIPTION
## Changelog Description
This PR is to add support to update Namespace for switching container
Resolve https://github.com/ynput/ayon-maya/issues/14
## Additional review information
The method needs some discussion as it may not be safe to do so.
<img width="1175" height="663" alt="image" src="https://github.com/user-attachments/assets/f96a201d-9e22-41cd-aba8-d10549ff6266" />
Test with loading rig and see if the product name of the animation instance has been switched as the namespace switched.
Test with the general load(e.g. model, pointcache) and switch assets and see if the namespace has been updated. 

## Testing notes:
1. Turn on `ayon+settings://maya/load/reference_loader/update_namespace_on_switch`
2. Load asset
3. Switch Asset
4. Namespace should be updated accordingly