### PR TITLE
Bug: handle deepexr extension

### DIFF
--- a/client/ayon_maya/api/lib_renderproducts.py
+++ b/client/ayon_maya/api/lib_renderproducts.py
@@ -522,7 +522,7 @@ class RenderProductsArnold(ARenderProducts):
         "png": "png",
         "tiff": "tif",
         "mtoa_shaders": "ass",  # TODO: research what those last two should be
-        "maya": "",
+        "maya": "maya",
     }
 
     def get_renderer_prefix(self):
@@ -715,8 +715,10 @@ class RenderProductsArnold(ARenderProducts):
 
         default_ext = self._get_attr("defaultRenderGlobals.imfPluginKey")
         # Normalize imfPluginKey to expected file extension (deepexr -> exr)
-        if default_ext == "deepexr":
-            default_ext = self.aiDriverExtension["deepexr"]
+        # Use already existing mapping for Arnold AOV driver extensions as it already
+        # contains the same mapping for deepexr -> exr and jpeg -> jpg
+        if default_ext in {"deepexr", "jpeg"}:
+            default_ext = self.aiDriverExtension[default_ext]
         colorspace = self._get_colorspace(
             "defaultArnoldDriver.colorManagement"
         )

--- a/client/ayon_maya/api/lib_renderproducts.py
+++ b/client/ayon_maya/api/lib_renderproducts.py
@@ -714,6 +714,10 @@ class RenderProductsArnold(ARenderProducts):
         ]
 
         default_ext = self._get_attr("defaultRenderGlobals.imfPluginKey")
+        # handle deep exrs (maya will report `deepexr` as the
+        # imfPluginKey but we want to use `exr` as extension)
+        if default_ext == "deepexr":
+            default_ext = "exr"
         colorspace = self._get_colorspace(
             "defaultArnoldDriver.colorManagement"
         )

--- a/client/ayon_maya/api/lib_renderproducts.py
+++ b/client/ayon_maya/api/lib_renderproducts.py
@@ -714,10 +714,9 @@ class RenderProductsArnold(ARenderProducts):
         ]
 
         default_ext = self._get_attr("defaultRenderGlobals.imfPluginKey")
-        # handle deep exrs (maya will report `deepexr` as the
-        # imfPluginKey but we want to use `exr` as extension)
+        # Normalize imfPluginKey to expected file extension (deepexr -> exr)
         if default_ext == "deepexr":
-            default_ext = "exr"
+            default_ext = self.aiDriverExtension["deepexr"]
         colorspace = self._get_colorspace(
             "defaultArnoldDriver.colorManagement"
         )


### PR DESCRIPTION
## Changelog Description
When setting the renderer to deep exr, AYON detected the file extension as `deepexr`. This fix is changing it to `exr.

## Additional review information
*imfPluginKey* for deepexr is `deepexr` - correct it to just `exr` in that case.

Closed #458

## Testing notes:
Try to render (and publish) deep exr sequence in Maya.
