### PR TITLE
fix: temporarily disable the smooth warning in lib.displaySmoothness

### DIFF
--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -1153,21 +1153,28 @@ def displaySmoothness(nodes,
 
     originals = dict((node, parse(node)) for node in nodes)
 
-    try:
-        # Apply current state
-        cmds.displaySmoothness(nodes,
-                               divisionsU=divisionsU,
-                               divisionsV=divisionsV,
-                               pointsWire=pointsWire,
-                               pointsShaded=pointsShaded,
-                               polygonObject=polygonObject)
-        yield
-    finally:
-        # Revert state
-        _iteritems = getattr(originals, "iteritems", originals.items)
-        for node, state in _iteritems():
-            if state:
-                cmds.displaySmoothness(node, **state)
+    # Temporarily disable the smooth warning dialog for meshes
+    meshes = cmds.ls(nodes, type="mesh") or []
+    disable_smooth_warn = {f"{mesh}.smoothWarn": False for mesh in meshes}
+
+    with attribute_values(disable_smooth_warn):
+        try:
+            # Apply current state
+            cmds.displaySmoothness(
+                nodes,
+                divisionsU=divisionsU,
+                divisionsV=divisionsV,
+                pointsWire=pointsWire,
+                pointsShaded=pointsShaded,
+                polygonObject=polygonObject,
+            )
+            yield
+        finally:
+            # Revert state
+            _iteritems = getattr(originals, "iteritems", originals.items)
+            for node, state in _iteritems():
+                if state:
+                    cmds.displaySmoothness(node, **state)
 
 
 @contextlib.contextmanager

--- a/client/ayon_maya/api/lib.py
+++ b/client/ayon_maya/api/lib.py
@@ -1171,8 +1171,7 @@ def displaySmoothness(nodes,
             yield
         finally:
             # Revert state
-            _iteritems = getattr(originals, "iteritems", originals.items)
-            for node, state in _iteritems():
+            for node, state in originals.items():
                 if state:
                     cmds.displaySmoothness(node, **state)
 


### PR DESCRIPTION
## Changelog Description
temporarily disable the smooth warning popup when exporting Models

## Additional review information
in `ExtractModel` and `ExtractObj` we change the display smoothness to 1 and then revert back to the original value.
If the model has a high poly count we may trigger a popup warning, which can stop the publish process

<img width="529" height="156" alt="image" src="https://github.com/user-attachments/assets/b68dfb7c-c24b-4b34-bc26-2d32f77bd234" />

attribute ref: https://download.autodesk.com/us/maya/2010help/Nodes/mesh.html#attrsmoothWarn
<img width="669" height="57" alt="image" src="https://github.com/user-attachments/assets/0ce40513-a584-4506-9d44-a3cc50d25c88" />



## Testing notes (before this PR):
1. open maya
2. create a plane. set its subdivisions to 500x500 (or more)
3. click publish
4. go grab a coffee while you wait for the publish to process
5. come back to your desk to notice that the model has not been published, but instead you got this lovely popup

## Testing notes (with this PR):
1. repeat steps 1-4 from above
5. publish completes without any maya popups

## Testing notes (in python form):
```py
from maya import cmds
from ayon_maya.api import lib

# setup test geometry
my_plane, shape = cmds.polyPlane(sx=500, sy=500)  # this will show an warning
cmds.displaySmoothness(polygonObject=3)           # so will this

# this will show a warning
cmds.displaySmoothness(polygonObject=1)
cmds.displaySmoothness(polygonObject=3)

# no warning here
with lib.displaySmoothness(
    my_plane,
    polygonObject=1,
):
    print("Hello, world!")
    

# this will still show a warning
cmds.displaySmoothness(polygonObject=1)
cmds.displaySmoothness(polygonObject=3)
```
