### PR TITLE
YN-1000 - Fix audio offset on collect_review.

### DIFF
--- a/client/ayon_maya/plugins/publish/collect_review.py
+++ b/client/ayon_maya/plugins/publish/collect_review.py
@@ -148,7 +148,7 @@ class CollectReview(plugin.MayaInstancePlugin):
             def get_audio_node_data(node):
                 audio_frame_offset = cmds.getAttr("{}.offset".format(node))
                 timeline_frame = instance.data["frameStartHandle"]
-                offset_seconds = (audio_frame_offset - timeline_frame) / instance.data["fps"]
+                offset_seconds = (audio_frame_offset - timeline_frame) / float(instance.data["fps"])
                 return {
                     "offset": offset_seconds,
                     "filename": cmds.getAttr("{}.filename".format(node))

--- a/client/ayon_maya/plugins/publish/collect_review.py
+++ b/client/ayon_maya/plugins/publish/collect_review.py
@@ -146,8 +146,11 @@ class CollectReview(plugin.MayaInstancePlugin):
             )
 
             def get_audio_node_data(node):
+                audio_frame_offset = cmds.getAttr("{}.offset".format(node))
+                timeline_frame = instance.data["frameStartHandle"]
+                offset_seconds = (audio_frame_offset - timeline_frame) / instance.data["fps"]
                 return {
-                    "offset": cmds.getAttr("{}.offset".format(node)),
+                    "offset": offset_seconds,
                     "filename": cmds.getAttr("{}.filename".format(node))
                 }
 

--- a/client/ayon_maya/plugins/publish/collect_review.py
+++ b/client/ayon_maya/plugins/publish/collect_review.py
@@ -150,7 +150,7 @@ class CollectReview(plugin.MayaInstancePlugin):
                 timeline_frame = instance.data["frameStartHandle"]
                 offset_seconds = (audio_frame_offset - timeline_frame) / float(instance.data["fps"])
                 return {
-                    "offset": offset_seconds,
+                    "offset_in_seconds": offset_seconds,
                     "filename": cmds.getAttr("{}.filename".format(node))
                 }
 


### PR DESCRIPTION
## Changelog Description

Changes:
* [x] Make `collect_review` plugin compute an audio offset in seconds instead of reporting the audio start frame

## Additional review information
This PR needs to be tested with https://github.com/ynput/ayon-core/pull/2004

## Testing notes:
1. Create a timeline in Maya with an audio node and audio offset (positive or negative)
2. Publish a new review
3. Ensure audio offset is properly applied on resulting review product
