### PR TITLE
Bugfix: Prevents failure when removing references.

### DIFF
--- a/client/ayon_maya/plugins/create/create_mayascene.py
+++ b/client/ayon_maya/plugins/create/create_mayascene.py
@@ -7,6 +7,6 @@ class CreateMayaScene(plugin.MayaCreator):
     identifier = "io.openpype.creators.maya.mayascene"
     name = "mayaScene"
     label = "Maya Scene"
-    product_base_type = "mayascene"
+    product_base_type = "mayaScene"
     product_type = product_base_type
     icon = "file-archive-o"

--- a/client/ayon_maya/plugins/load/load_reference.py
+++ b/client/ayon_maya/plugins/load/load_reference.py
@@ -320,7 +320,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
                 continue
 
             # Ignore referenced object sets
-            if cmds.referenceQuery(isNodeReferenced=object_set):
+            if cmds.referenceQuery(object_set, isNodeReferenced=True):
                 continue
 
             # Then only here confirm whether this is an animation instance, if so

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -218,6 +218,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
             "filterTypes": (list, None),  # optional list
             "staticSingleSample": bool,
             "worldspace": bool,
+            "exportSkels": str,
         }
 
     @property
@@ -232,7 +233,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
             "defaultMeshScheme": "catmullClark",
             "stripNamespaces": True,
             "mergeTransformAndShape": True,
-            "exportDisplayColor": False,
+            "exportDisplayColor": True,
             "exportColorSets": True,
             "exportInstances": True,
             "exportUVs": True,
@@ -246,7 +247,8 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
             "jobContext": None,
             "filterTypes": None,
             "staticSingleSample": True,
-            "worldspace": True
+            "worldspace": True,
+            "exportSkels": "auto"
         }
 
     def parse_overrides(self, overrides, options):

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -219,6 +219,8 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
             "staticSingleSample": bool,
             "worldspace": bool,
             "exportSkels": str,
+            "exportSkin": str,
+            "exportBlendShapes": bool,
         }
 
     @property
@@ -248,7 +250,9 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
             "filterTypes": None,
             "staticSingleSample": True,
             "worldspace": True,
-            "exportSkels": "auto"
+            "exportBlendShapes": False,
+            "exportSkels": "auto",
+            "exportSkin": "auto"
         }
 
     def parse_overrides(self, overrides, options):
@@ -599,6 +603,29 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                     ),
                     visible=visible,
                     default=True),
+            EnumDef("exportSkin",
+                    label="Export Skin",
+                    items=[
+                        {"value": "none", "label": "None"},
+                        {"value": "auto", "label": "Auto"},
+                        {"value": "explicit", "label": "Explicit"},
+                    ],
+                    tooltip=(
+                        "Export skin cluster data.\n\n"
+                        "None: do not export skin clusters.\n"
+                        "Auto: export skin clusters if present.\n"
+                        "Explicit: only export explicitly tagged skin clusters."
+                    ),
+                    visible=visible,
+                    default="none"
+            ),
+            BoolDef("exportBlendShapes",
+                    label="Export Blendshapes",
+                    tooltip=(
+                        "Export Blendshapes with Animation"
+                    ),
+                    visible=visible,
+                    default=False),
             EnumDef("defaultMeshScheme",
                     label="Default Subdivision Method",
                     items=[

--- a/client/ayon_maya/version.py
+++ b/client/ayon_maya/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'maya' version."""
-__version__ = "0.6.2+sas"
+__version__ = "0.6.3+sas"

--- a/client/ayon_maya/version.py
+++ b/client/ayon_maya/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'maya' version."""
-__version__ = "0.6.3+sas"
+__version__ = "0.6.3+sas2"

--- a/client/ayon_maya/version.py
+++ b/client/ayon_maya/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'maya' version."""
-__version__ = "0.6.1+dev"
+__version__ = "0.6.2+sas"

--- a/package.py
+++ b/package.py
@@ -1,6 +1,6 @@
 name = "maya"
 title = "Maya"
-version = "0.6.2+sas"
+version = "0.6.3+sas"
 app_host_name = "maya"
 client_dir = "ayon_maya"
 project_can_override_addon_version = True

--- a/package.py
+++ b/package.py
@@ -1,6 +1,6 @@
 name = "maya"
 title = "Maya"
-version = "0.6.1+dev"
+version = "0.6.2+sas"
 app_host_name = "maya"
 client_dir = "ayon_maya"
 project_can_override_addon_version = True

--- a/package.py
+++ b/package.py
@@ -1,6 +1,6 @@
 name = "maya"
 title = "Maya"
-version = "0.6.3+sas"
+version = "0.6.3+sas2"
 app_host_name = "maya"
 client_dir = "ayon_maya"
 project_can_override_addon_version = True


### PR DESCRIPTION
# Summary
Bugfix: `~client/ayon_maya/plugins/load/load_reference.py`, line 323:
```
if cmds.referenceQuery(isNodeReferenced=object_set):
```
Switched to:
```
if cmds.referenceQuery(object_set, isNodeReferenced=True):
```
This prevents the `_remove_rig()` method from failing.

# Notes

The feature branch was created from the latest `develop`, which carries with it additional changes. The change may need to be redone. **Please advice on the best course of action before attempting to merge!**

