### PR TITLE
MayaUSD: Fix the duplicate overrides in USD options

### DIFF
--- a/client/ayon_maya/plugins/create/create_maya_usd.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd.py
@@ -259,4 +259,4 @@ class CreateMayaUsdModel(CreateMayaUsd):
         return attr_defs
 
     def get_publish_families(self):
-        return ["model", "usd"]
+        return ["model", "usd", "mayaUsd.filterProperties"]

--- a/client/ayon_maya/plugins/create/create_maya_usd.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd.py
@@ -239,7 +239,7 @@ class CreateMayaUsd(plugin.MayaCreator):
 
 
 class CreateMayaUsdModel(CreateMayaUsd):
-    identifier = "io.ayon.creators.maya.mayamayaUsd.model"
+    identifier = "io.ayon.creators.maya.mayaUsd.model"
     label = "Maya USD: Model"
     product_base_type = "model"
     product_type = product_base_type

--- a/client/ayon_maya/plugins/create/create_maya_usd.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd.py
@@ -257,3 +257,6 @@ class CreateMayaUsdModel(CreateMayaUsd):
                 attr_def.default = True
 
         return attr_defs
+
+    def get_publish_families(self):
+        return ["model"]

--- a/client/ayon_maya/plugins/create/create_maya_usd.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd.py
@@ -239,7 +239,7 @@ class CreateMayaUsd(plugin.MayaCreator):
 
 
 class CreateMayaUsdModel(CreateMayaUsd):
-    identifier = "io.ayon.creators.maya.mayamayaUsd.model"
+    identifier = "io.ayon.creators.maya.mayausd.model"
     label = "Maya USD: Model"
     product_base_type = "model"
     product_type = product_base_type

--- a/client/ayon_maya/plugins/create/create_maya_usd.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd.py
@@ -259,4 +259,4 @@ class CreateMayaUsdModel(CreateMayaUsd):
         return attr_defs
 
     def get_publish_families(self):
-        return ["model", "usd", "mayaUsd.filterProperties"]
+        return ["usd.model", "usd", "mayaUsd.filterProperties"]

--- a/client/ayon_maya/plugins/create/create_maya_usd.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd.py
@@ -259,4 +259,4 @@ class CreateMayaUsdModel(CreateMayaUsd):
         return attr_defs
 
     def get_publish_families(self):
-        return ["model"]
+        return ["usd", "model"]

--- a/client/ayon_maya/plugins/create/create_maya_usd.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd.py
@@ -239,7 +239,7 @@ class CreateMayaUsd(plugin.MayaCreator):
 
 
 class CreateMayaUsdModel(CreateMayaUsd):
-    identifier = "io.ayon.creators.maya.mayausd.model"
+    identifier = "io.ayon.creators.maya.mayamayaUsd.model"
     label = "Maya USD: Model"
     product_base_type = "model"
     product_type = product_base_type
@@ -259,4 +259,4 @@ class CreateMayaUsdModel(CreateMayaUsd):
         return attr_defs
 
     def get_publish_families(self):
-        return ["usd.model", "usd", "mayaUsd.filterProperties"]
+        return ["usd", "mayaUsd.model", "mayaUsd.filterProperties"]

--- a/client/ayon_maya/plugins/create/create_maya_usd.py
+++ b/client/ayon_maya/plugins/create/create_maya_usd.py
@@ -259,4 +259,4 @@ class CreateMayaUsdModel(CreateMayaUsd):
         return attr_defs
 
     def get_publish_families(self):
-        return ["usd", "model"]
+        return ["model", "usd"]

--- a/client/ayon_maya/plugins/create/create_model.py
+++ b/client/ayon_maya/plugins/create/create_model.py
@@ -18,6 +18,9 @@ class CreateModel(plugin.MayaCreator):
     write_face_sets = True
     include_shaders = False
 
+    def get_publish_families(self):
+        return ["model", "model.extract"]
+
     def get_instance_attr_defs(self):
 
         return [

--- a/client/ayon_maya/plugins/create/create_model.py
+++ b/client/ayon_maya/plugins/create/create_model.py
@@ -19,7 +19,7 @@ class CreateModel(plugin.MayaCreator):
     include_shaders = False
 
     def get_publish_families(self):
-        return ["model", "model.extract"]
+        return ["model.extract"]
 
     def get_instance_attr_defs(self):
 

--- a/client/ayon_maya/plugins/publish/collect_fbx_model.py
+++ b/client/ayon_maya/plugins/publish/collect_fbx_model.py
@@ -10,7 +10,7 @@ class CollectFbxModel(plugin.MayaInstancePlugin,
 
     order = pyblish.api.CollectorOrder + 0.2
     label = "Collect Fbx Model"
-    families = ["model"]
+    families = ["model.extract"]
     optional = True
 
     def process(self, instance):
@@ -26,4 +26,4 @@ class CollectFbxModel(plugin.MayaInstancePlugin,
         for key in {
             "bakeComplexAnimation", "bakeResampleAnimation",
             "skins", "constraints", "lights"}:
-                instance.data[key] = False
+            instance.data[key] = False

--- a/client/ayon_maya/plugins/publish/collect_gltf.py
+++ b/client/ayon_maya/plugins/publish/collect_gltf.py
@@ -8,7 +8,7 @@ class CollectGLTF(plugin.MayaInstancePlugin):
 
     order = pyblish.api.CollectorOrder + 0.2
     label = "Collect Asset for GLTF/GLB export"
-    families = ["model", "animation", "pointcache"]
+    families = ["model.extract", "animation", "pointcache"]
 
     def process(self, instance):
         if not instance.data.get("families"):

--- a/client/ayon_maya/plugins/publish/collect_look.py
+++ b/client/ayon_maya/plugins/publish/collect_look.py
@@ -718,7 +718,7 @@ class CollectModelRenderSets(CollectLook):
     """
 
     order = pyblish.api.CollectorOrder + 0.21
-    families = ["model"]
+    families = ["model.extract"]
     label = "Collect Model Render Sets"
 
     def collect_sets(self, instance):

--- a/client/ayon_maya/plugins/publish/collect_maya_usd_export_filter_properties.py
+++ b/client/ayon_maya/plugins/publish/collect_maya_usd_export_filter_properties.py
@@ -10,7 +10,7 @@ class CollectMayaUsdFilterProperties(plugin.MayaInstancePlugin,
 
     order = pyblish.api.CollectorOrder
     label = "Maya USD Export Chaser: Filter Properties"
-    families = ["mayaUsd"]
+    families = ["mayaUsd", "mayaUsd.filterProperties"]
 
     default_filter = ""
 

--- a/client/ayon_maya/plugins/publish/collect_model.py
+++ b/client/ayon_maya/plugins/publish/collect_model.py
@@ -20,7 +20,7 @@ class CollectModelData(plugin.MayaInstancePlugin):
 
     order = pyblish.api.CollectorOrder + 0.2
     label = 'Collect Model Data'
-    families = ["model"]
+    families = ["model", "usd.model"]
 
     def process(self, instance):
         # Extract only current frame (override)

--- a/client/ayon_maya/plugins/publish/collect_model.py
+++ b/client/ayon_maya/plugins/publish/collect_model.py
@@ -20,7 +20,7 @@ class CollectModelData(plugin.MayaInstancePlugin):
 
     order = pyblish.api.CollectorOrder + 0.2
     label = 'Collect Model Data'
-    families = ["model", "usd.model"]
+    families = ["model", "mayaUsd.model"]
 
     def process(self, instance):
         # Extract only current frame (override)

--- a/client/ayon_maya/plugins/publish/collect_pointcache_visible_only.py
+++ b/client/ayon_maya/plugins/publish/collect_pointcache_visible_only.py
@@ -6,7 +6,12 @@ class CollectPointcacheVisibleOnly(plugin.MayaInstancePlugin):
     """Collect pointcache visible only data for instance."""
 
     order = pyblish.api.CollectorOrder + 0.4
-    families = ["pointcache", "animation", "model", "vrayproxy.alembic"]
+    families = [
+        "pointcache",
+        "animation",
+        "model.extract",
+        "vrayproxy.alembic"
+    ]
     label = "Collect Pointcache Visible Only"
 
     def process(self, instance):

--- a/client/ayon_maya/plugins/publish/extract_gpu_cache.py
+++ b/client/ayon_maya/plugins/publish/extract_gpu_cache.py
@@ -10,7 +10,7 @@ class ExtractGPUCache(plugin.MayaExtractorPlugin,
     """Extract the content of the instance to a GPU cache file."""
 
     label = "GPU Cache"
-    families = ["model", "animation", "pointcache"]
+    families = ["model.extract", "animation", "pointcache"]
     targets = ["local", "remote"]
     step = 1.0
     stepSave = 1

--- a/client/ayon_maya/plugins/publish/extract_look.py
+++ b/client/ayon_maya/plugins/publish/extract_look.py
@@ -886,7 +886,7 @@ class ExtractModelRenderSets(ExtractLook):
 
     label = "Model Render Sets"
     hosts = ["maya"]
-    families = ["model"]
+    families = ["model.extract"]
     scene_type_prefix = "meta.render."
     look_data_type = "meta.render.json"
 

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -532,7 +532,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
                 continue
 
             publish_attributes = value_changes["publish_attributes"]
-            class_name = cls.__name__
+            class_name = cls.__class__.__name__
             if class_name not in publish_attributes:
                 continue
 
@@ -558,7 +558,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
             plugin_attr_values = (
                 instance.data
                 .get("publish_attributes", {})
-                .get(cls.__name__, {})
+                .get(cls.__class__.__name__, {})
             )
             is_enabled = plugin_attr_values.get("active", cls.active)
         defs = super().get_attr_defs_for_instance(create_context, instance)
@@ -866,6 +866,13 @@ class ExtractMayaUsdModel(ExtractMayaUsd):
 
     def process(self, instance):
         # TODO: Fix this without changing instance data
+        families = set(instance.data.get("families") or [])
+        if "mayaUsd" in families:
+            self.log.debug(
+                "Skipping ExtractMayaUsdModel because instance already "
+                "matches dedicated mayaUsd extractor."
+            )
+            return
         instance.data["exportAnimationData"] = False
         super().process(instance)
 

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -837,13 +837,6 @@ class ExtractMayaUsdModel(ExtractMayaUsd):
 
     def process(self, instance):
         # TODO: Fix this without changing instance data
-        families = set(instance.data.get("families") or [])
-        if "mayaUsd" in families:
-            self.log.debug(
-                "Skipping ExtractMayaUsdModel because instance already "
-                "matches dedicated mayaUsd extractor."
-            )
-            return
         instance.data["exportAnimationData"] = False
         super().process(instance)
 

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -858,7 +858,7 @@ class ExtractMayaUsdModel(ExtractMayaUsd):
     """
 
     label = "Extract USD"
-    families = ["model", "mayaUsd.model"]
+    families = ["mayaUsd.model"]
 
     # Exposed in settings
     optional = True
@@ -868,6 +868,14 @@ class ExtractMayaUsdModel(ExtractMayaUsd):
         # TODO: Fix this without changing instance data
         instance.data["exportAnimationData"] = False
         super().process(instance)
+
+
+class ExtractModelMayaUsd(ExtractMayaUsdModel):
+    """Extract USD for regular Model instances."""
+
+    families = ["model.extract"]
+    optional = False
+    active = True
 
 
 class ExtractMayaUsdPointcache(ExtractMayaUsd):

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -858,7 +858,7 @@ class ExtractMayaUsdModel(ExtractMayaUsd):
     """
 
     label = "Extract USD"
-    families = ["mayaUsd.model"]
+    families = ["mayaUsd.model", "model.extract"]
 
     # Exposed in settings
     optional = True
@@ -868,14 +868,6 @@ class ExtractMayaUsdModel(ExtractMayaUsd):
         # TODO: Fix this without changing instance data
         instance.data["exportAnimationData"] = False
         super().process(instance)
-
-
-class ExtractModelMayaUsd(ExtractMayaUsdModel):
-    """Extract USD for regular Model instances."""
-
-    families = ["model.extract"]
-    optional = False
-    active = True
 
 
 class ExtractMayaUsdPointcache(ExtractMayaUsd):

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -858,7 +858,7 @@ class ExtractMayaUsdModel(ExtractMayaUsd):
     """
 
     label = "Extract USD"
-    families = ["model"]
+    families = ["model", "usd.model"]
 
     # Exposed in settings
     optional = True

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -864,11 +864,6 @@ class ExtractMayaUsdModel(ExtractMayaUsd):
     optional = True
     active = True
 
-    def process(self, instance):
-        # TODO: Fix this without changing instance data
-        instance.data["exportAnimationData"] = False
-        super().process(instance)
-
 
 class ExtractMayaUsdPointcache(ExtractMayaUsd):
     """Extractor for Maya USD for 'pointcache' family"""

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -517,35 +517,6 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
         create_context.add_value_changed_callback(cls.on_values_changed)
 
     @classmethod
-    def on_values_changed(cls, event):
-        """Update instance attribute definitions on attribute changes."""
-        for instance_change in event["changes"]:
-            # First check if there's a change we want to respond to
-            instance = instance_change["instance"]
-            if instance is None:
-                # Change is on context
-                continue
-
-            # Check if active state is toggled
-            value_changes = instance_change["changes"]
-            if "publish_attributes" not in value_changes:
-                continue
-
-            publish_attributes = value_changes["publish_attributes"]
-            class_name = cls.__class__.__name__
-            if class_name not in publish_attributes:
-                continue
-
-            if "active" not in publish_attributes[class_name]:
-                continue
-
-            # Update the attribute definitions
-            new_attrs = cls.get_attr_defs_for_instance(
-                event["create_context"], instance
-            )
-            instance.set_publish_plugin_attr_defs(class_name, new_attrs)
-
-    @classmethod
     def get_attr_defs_for_instance(cls, create_context, instance):
         is_enabled = cls.enabled
         if not is_enabled:
@@ -558,7 +529,7 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
             plugin_attr_values = (
                 instance.data
                 .get("publish_attributes", {})
-                .get(cls.__class__.__name__, {})
+                .get(cls.__name__, {})
             )
             is_enabled = plugin_attr_values.get("active", cls.active)
         defs = super().get_attr_defs_for_instance(create_context, instance)

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -517,6 +517,35 @@ class ExtractMayaUsd(plugin.MayaExtractorPlugin,
         create_context.add_value_changed_callback(cls.on_values_changed)
 
     @classmethod
+    def on_values_changed(cls, event):
+        """Update instance attribute definitions on attribute changes."""
+        for instance_change in event["changes"]:
+            # First check if there's a change we want to respond to
+            instance = instance_change["instance"]
+            if instance is None:
+                # Change is on context
+                continue
+
+            # Check if active state is toggled
+            value_changes = instance_change["changes"]
+            if "publish_attributes" not in value_changes:
+                continue
+
+            publish_attributes = value_changes["publish_attributes"]
+            class_name = cls.__name__
+            if class_name not in publish_attributes:
+                continue
+
+            if "active" not in publish_attributes[class_name]:
+                continue
+
+            # Update the attribute definitions
+            new_attrs = cls.get_attr_defs_for_instance(
+                event["create_context"], instance
+            )
+            instance.set_publish_plugin_attr_defs(class_name, new_attrs)
+
+    @classmethod
     def get_attr_defs_for_instance(cls, create_context, instance):
         is_enabled = cls.enabled
         if not is_enabled:
@@ -837,6 +866,13 @@ class ExtractMayaUsdModel(ExtractMayaUsd):
 
     def process(self, instance):
         # TODO: Fix this without changing instance data
+        families = set(instance.data.get("families") or [])
+        if "mayaUsd" in families:
+            self.log.debug(
+                "Skipping ExtractMayaUsdModel because instance already "
+                "matches dedicated mayaUsd extractor."
+            )
+            return
         instance.data["exportAnimationData"] = False
         super().process(instance)
 

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -862,7 +862,7 @@ class ExtractMayaUsdModel(ExtractMayaUsd):
 
     # Exposed in settings
     optional = True
-    active = False
+    active = True
 
     def process(self, instance):
         # TODO: Fix this without changing instance data

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -866,13 +866,6 @@ class ExtractMayaUsdModel(ExtractMayaUsd):
 
     def process(self, instance):
         # TODO: Fix this without changing instance data
-        families = set(instance.data.get("families") or [])
-        if "mayaUsd" in families:
-            self.log.debug(
-                "Skipping ExtractMayaUsdModel because instance already "
-                "matches dedicated mayaUsd extractor."
-            )
-            return
         instance.data["exportAnimationData"] = False
         super().process(instance)
 

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -864,6 +864,11 @@ class ExtractMayaUsdModel(ExtractMayaUsd):
     optional = True
     active = True
 
+    def process(self, instance):
+        # TODO: Fix this without changing instance data
+        instance.data["exportAnimationData"] = False
+        super().process(instance)
+
 
 class ExtractMayaUsdPointcache(ExtractMayaUsd):
     """Extractor for Maya USD for 'pointcache' family"""

--- a/client/ayon_maya/plugins/publish/extract_maya_usd.py
+++ b/client/ayon_maya/plugins/publish/extract_maya_usd.py
@@ -858,7 +858,7 @@ class ExtractMayaUsdModel(ExtractMayaUsd):
     """
 
     label = "Extract USD"
-    families = ["model", "usd.model"]
+    families = ["model", "mayaUsd.model"]
 
     # Exposed in settings
     optional = True

--- a/client/ayon_maya/plugins/publish/extract_model.py
+++ b/client/ayon_maya/plugins/publish/extract_model.py
@@ -26,7 +26,7 @@ class ExtractModel(plugin.MayaExtractorPlugin,
     """
 
     label = "Model (Maya Scene)"
-    families = ["model"]
+    families = ["model.extract"]
     scene_type = "ma"
     optional = True
 

--- a/client/ayon_maya/plugins/publish/extract_obj.py
+++ b/client/ayon_maya/plugins/publish/extract_obj.py
@@ -64,7 +64,7 @@ class ExtractObj(plugin.MayaExtractorPlugin,
     """
     order = pyblish.api.ExtractorOrder
     label = "Extract OBJ"
-    families = ["model"]
+    families = ["model.extract"]
     optional = True
 
     # Default OBJ export options.

--- a/client/ayon_maya/plugins/publish/extract_pointcache.py
+++ b/client/ayon_maya/plugins/publish/extract_pointcache.py
@@ -38,7 +38,7 @@ class ExtractAlembic(plugin.MayaExtractorPlugin,
 
     label = "Extract Pointcache (Alembic)"
     hosts = ["maya"]
-    families = ["pointcache", "model", "vrayproxy.alembic"]
+    families = ["pointcache", "model.extract", "vrayproxy.alembic"]
     targets = ["local", "remote"]
     optional = False
     # From settings

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -2033,7 +2033,7 @@ DEFAULT_PUBLISH_SETTINGS = {
         "optional": False,
         "active": True,
         "families": [
-            "model",
+            "model.extract",
             "animation",
             "pointcache"
         ],
@@ -2066,7 +2066,7 @@ DEFAULT_PUBLISH_SETTINGS = {
         "active": True,
         "families": [
             "pointcache",
-            "model",
+            "model.extract",
             "vrayproxy.alembic"
         ],
         "attr": "",

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -2151,7 +2151,7 @@ DEFAULT_PUBLISH_SETTINGS = {
     "ExtractMayaUsdModel": {
         "enabled": True,
         "optional": True,
-        "active": False,
+        "active": True,
     },
     "ExtractMayaUsdPointcache": {
         "enabled": True,


### PR DESCRIPTION
## Changelog Description
This PR is to remove the duplicate overrides in USD options in MayaUSD publish. This also avoids the two extractors exporting the assets twices which error out the integrator.
Resolve https://github.com/ynput/ayon-maya/issues/461

## Additional review information
Marked it as draft as it needs more clarification for the legacy creator.

## Testing notes:
1. Create Maya USD instance with your model hierarchies.
2. Publish
