### PR TITLE
Review: greasePencil and bluePencils into viewport options

### DIFF
--- a/client/ayon_maya/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_maya/plugins/publish/extract_thumbnail.py
@@ -53,11 +53,12 @@ class ExtractThumbnail(plugin.MayaExtractorPlugin,
             instance, camera, path,
             start=1, end=1,
             capture_preset=capture_preset)
+        # Force thumbnail capture to JPG if blue pencil is enabled
+        # as png captures alpha channels which maps out only the
+        # blue pencil's annotation and it doesn't show the composited
+        # version of the thumbnail.
+        # This is temporary until a better solution is implemented.
         if preset["viewport_options"].get("bluePencil"):
-            # Force thumbnail capture to JPG if blue pencil is enabled
-            # as png captures alpha channels which maps out only the
-            # blue pencil's annotation and it doesn't show the composited
-            # version of the thumbnail.
             self.log.debug(
                 "Blue Pencil is enabled; forcing thumbnail capture to JPG "
                 "so annotations are composited over the thumbnail image "

--- a/client/ayon_maya/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_maya/plugins/publish/extract_thumbnail.py
@@ -53,6 +53,9 @@ class ExtractThumbnail(plugin.MayaExtractorPlugin,
             instance, camera, path,
             start=1, end=1,
             capture_preset=capture_preset)
+        if preset["viewport_options"].get("bluePencil"):
+            self.log.debug("Blue pencil is enabled, setting compression to jpg")
+            preset["compression"] = "jpg"
 
         preset["camera_options"].update({
             "displayGateMask": False,

--- a/client/ayon_maya/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_maya/plugins/publish/extract_thumbnail.py
@@ -54,6 +54,10 @@ class ExtractThumbnail(plugin.MayaExtractorPlugin,
             start=1, end=1,
             capture_preset=capture_preset)
         if preset["viewport_options"].get("bluePencil"):
+            # Force thumbnail capture to JPG if blue pencil is enabled
+            # as png captures alpha channels which maps out only the
+            # blue pencil's annotation and it doesn't show the composited
+            # version of the thumbnail.
             self.log.debug(
                 "Blue Pencil is enabled; forcing thumbnail capture to JPG "
                 "so annotations are composited over the thumbnail image "

--- a/client/ayon_maya/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_maya/plugins/publish/extract_thumbnail.py
@@ -54,7 +54,11 @@ class ExtractThumbnail(plugin.MayaExtractorPlugin,
             start=1, end=1,
             capture_preset=capture_preset)
         if preset["viewport_options"].get("bluePencil"):
-            self.log.debug("Blue pencil is enabled, setting compression to jpg")
+            self.log.debug(
+                "Blue Pencil is enabled; forcing thumbnail capture to JPG "
+                "so annotations are composited over the thumbnail image "
+                "instead of exported as a transparent annotation layer."
+            )
             preset["compression"] = "jpg"
 
         preset["camera_options"].update({

--- a/client/ayon_maya/vendor/python/capture.py
+++ b/client/ayon_maya/vendor/python/capture.py
@@ -731,11 +731,10 @@ def _applied_viewport_options(options, panel):
 
     options = dict(ViewportOptions, **(options or {}))
     plugin_options = options.pop("pluginObjects", {})
-    if "bluePencil" in options and "headsUpDisplay" not in options:
-        logger.warning(
-            "Blue Pencil is not visible as Heads Up Display is disabled."
-            "Enable Heads Up Display to see Blue Pencil."
-        )
+    if "bluePencil" in options:
+        logger.warning("Heads Up Display is required for Blue Pencil to be "
+                       "visible. Enabling it automatically.")
+        options["headsUpDisplay"] = True
     # BUGFIX Maya 2020 some keys in viewport options dict may not be unicode
     #        This is a local OpenPype edit to capture.py for issue #4730
     # TODO: Remove when dropping Maya 2020 compatibility

--- a/client/ayon_maya/vendor/python/capture.py
+++ b/client/ayon_maya/vendor/python/capture.py
@@ -731,7 +731,11 @@ def _applied_viewport_options(options, panel):
 
     options = dict(ViewportOptions, **(options or {}))
     plugin_options = options.pop("pluginObjects", {})
-
+    if "bluePencil" in options and "headsUpDisplay" not in options:
+        logger.warning(
+            "Blue Pencil is not visible as Heads Up Display is disabled."
+            "Enable Heads Up Display to see Blue Pencil."
+        )
     # BUGFIX Maya 2020 some keys in viewport options dict may not be unicode
     #        This is a local OpenPype edit to capture.py for issue #4730
     # TODO: Remove when dropping Maya 2020 compatibility

--- a/client/ayon_maya/vendor/python/capture.py
+++ b/client/ayon_maya/vendor/python/capture.py
@@ -12,7 +12,7 @@ import logging
 from maya import cmds
 from maya import mel
 
-from qtpy import QtGui, QtWidgets
+from qtpy import QtGui, QtWidgets, QtCore
 
 version_info = (2, 3, 0)
 
@@ -219,7 +219,7 @@ def capture(camera=None,
                 )
                 stack.enter_context(_isolated_nodes(isolate, panel))
                 stack.enter_context(_maintained_time())
-
+                stack.enter_context(_enforce_blue_pencil_state(viewport_options))
                 output = cmds.playblast(**all_playblast_kwargs)
 
         return output
@@ -685,6 +685,37 @@ def _applied_camera_options(options, panel):
                     continue
                 else:
                     _safe_setAttr(camera + "." + opt, value)
+
+
+@contextlib.contextmanager
+def _enforce_blue_pencil_state(viewport_options):
+    """Due to a bug in Maya it does not directly update the blue pencil
+    visibility state in new independent panels. This context manager enforces
+    the state of blue pencil in all modelPanels. That works around the bug
+    and ensures that the blue pencil state is consistent.
+
+    Issue confirmed on Windows on Maya 2026 and Maya 2027.
+    """
+    if not viewport_options.get("headsUpDisplay"):
+        # Only relevant if HUD is enabled
+        yield
+        return
+
+    if "bluePencil" not in viewport_options:
+        yield
+        return
+    state = bool(viewport_options["bluePencil"])
+    original = {}
+    try:
+        for panel in cmds.getPanel(type="modelPanel"):
+            original[panel] = cmds.modelEditor(
+                panel, query=True, bluePencil=True
+            )
+            cmds.modelEditor(panel, edit=True, bluePencil=state)
+        yield
+    finally:
+        for panel, original_state in original.items():
+            cmds.modelEditor(panel, edit=True, bluePencil=original_state)
 
 
 @contextlib.contextmanager

--- a/client/ayon_maya/vendor/python/capture.py
+++ b/client/ayon_maya/vendor/python/capture.py
@@ -351,7 +351,9 @@ ViewportOptions = {
     "handles": False,
     "pivots": False,
     "textures": False,
-    "strokes": False
+    "strokes": False,
+    "greasePencils": False,
+    "bluePencil": False,
 }
 
 Viewport2Options = {

--- a/client/ayon_maya/vendor/python/capture.py
+++ b/client/ayon_maya/vendor/python/capture.py
@@ -198,7 +198,8 @@ def capture(camera=None,
                 _applied_display_options(display_options),
                 _applied_viewport2_options(viewport2_options),
                 _isolated_nodes(isolate, panel),
-                _maintained_time()
+                _maintained_time(),
+                _enforce_blue_pencil_state(viewport_options)
             ):
                 output = cmds.playblast(**all_playblast_kwargs)
         else:

--- a/client/ayon_maya/vendor/python/capture.py
+++ b/client/ayon_maya/vendor/python/capture.py
@@ -731,10 +731,11 @@ def _applied_viewport_options(options, panel):
 
     options = dict(ViewportOptions, **(options or {}))
     plugin_options = options.pop("pluginObjects", {})
-    if "bluePencil" in options:
-        logger.warning("Heads Up Display is required for Blue Pencil to be "
-                       "visible. Enabling it automatically.")
-        options["headsUpDisplay"] = True
+    if options.get("bluePencil") and not options.get("headsUpDisplay"):
+        logger.warning(
+            "Blue Pencil is not visible when Heads Up Display is disabled. "
+            "Enable Heads Up Display to see Blue Pencil."
+        )
     # BUGFIX Maya 2020 some keys in viewport options dict may not be unicode
     #        This is a local OpenPype edit to capture.py for issue #4730
     # TODO: Remove when dropping Maya 2020 compatibility

--- a/client/ayon_maya/vendor/python/capture.py
+++ b/client/ayon_maya/vendor/python/capture.py
@@ -12,7 +12,7 @@ import logging
 from maya import cmds
 from maya import mel
 
-from qtpy import QtGui, QtWidgets, QtCore
+from qtpy import QtGui, QtWidgets
 
 version_info = (2, 3, 0)
 

--- a/server/settings/publish_playblast.py
+++ b/server/settings/publish_playblast.py
@@ -172,6 +172,7 @@ class ViewportOptionsSetting(BaseSettingsModel):
     fluids: bool = SettingsField(False, title="Fluids")
     follicles: bool = SettingsField(False, title="Follicles")
     greasePencils: bool = SettingsField(False, title="Grease Pencils")
+    bluePencil: bool = SettingsField(False, title="Blue Pencil")
     grid: bool = SettingsField(False, title="Grid")
     hairSystems: bool = SettingsField(True, title="Hair Systems")
     handles: bool = SettingsField(False, title="Handles")
@@ -359,6 +360,7 @@ DEFAULT_PLAYBLAST_SETTING = {
             "fluids": False,
             "follicles": False,
             "greasePencils": False,
+            "bluePencil": False,
             "grid": False,
             "hairSystems": True,
             "handles": False,


### PR DESCRIPTION
## Changelog Description
This PR is to add greasePencil and bluePencils as default viewport options. This also add the bluePencils into addon settings.
Resolve https://github.com/ynput/ayon-maya/issues/420

## Additional review information
If only bluePencil is enabled, it is only working when `ayon+settings://maya/publish/ExtractPlayblast/profiles/0/capture_preset/ViewportOptions/override_viewport_options` disabled.
If you want to enable `ayon+settings://maya/publish/ExtractPlayblast/profiles/0/capture_preset/ViewportOptions/override_viewport_options`  and make the blue pencil working, you need to enable `ayon+settings://maya/publish/ExtractPlayblast/profiles/0/capture_preset/ViewportOptions/headsUpDisplay` (See the screenshots) 
<img width="430" height="249" alt="image" src="https://github.com/user-attachments/assets/e67e73b0-9405-4f1a-a2ed-5edab073f5b0" />

## Testing notes:
1. Create Review
2. Draw with greasePencil or bluePencils
3. Enable `ayon+settings://maya/publish/ExtractPlayblast/profiles/0/capture_preset/ViewportOptions/bluePencil`
4. Publish