### PR TITLE
Implementation of auto-update scripts for terminals

### DIFF
--- a/client/ayon_maya/scripts/autoupdater.py
+++ b/client/ayon_maya/scripts/autoupdater.py
@@ -24,13 +24,12 @@ def auto_updater(
     nodes = cmds.file(
         filepath, sharedReferenceFile=False, returnNewNodes=True
     )
-    shapes = cmds.ls(nodes, transforms=True, long=True)
-    new_nodes = (list(set(nodes) - set(shapes)))
+    nodes = cmds.ls(nodes, type="transform", long=True)
 
     host = registered_host()
     create_context = CreateContext(host)
     creator_identifier = f"io.openpype.creators.maya.{product_base_type}"
-    cmds.select(new_nodes, noExpand=True)
+    cmds.select(nodes, noExpand=True)
     create_context.create(
         creator_identifier=creator_identifier,
         variant=variant,

--- a/client/ayon_maya/scripts/autoupdater.py
+++ b/client/ayon_maya/scripts/autoupdater.py
@@ -13,7 +13,7 @@ from maya import cmds
 
 def auto_updater(
     filepath: str,
-    productBaseType: str,
+    product_base_type: str,
     folder_name: str,
     task_name: str,
     variant: str

--- a/client/ayon_maya/scripts/autoupdater.py
+++ b/client/ayon_maya/scripts/autoupdater.py
@@ -1,5 +1,4 @@
 """Script for automatically creating and publishing assets after importing in Maya."""
-import json
 import os
 import argparse
 
@@ -42,13 +41,11 @@ def auto_updater(
     if logic.has_finished():
         print("Publish finished successfully.")
     elif logic.has_failed():
-        report = logic.get_publish_report()
-        print(json.dumps(report, indent=2))
-        report_dir = os.path.join(tempdir(), "publish_report.json")
-        with open(report_dir, "w") as f:
-            json.dump(report, f, indent=2)
-
-        print(f"Publish failed. Report saved to: {report_dir}")
+        staging_dir = tempdir()
+        os.makedirs(staging_dir, exist_ok=True)
+        report_path = os.path.join(staging_dir, "publish_report.json")
+        logic.store_publish_report(report_path)
+        print(f"Publish failed. Report saved to: {report_path}")
 
 if __name__ == "__main__":
     # Parse command-line arguments

--- a/client/ayon_maya/scripts/autoupdater.py
+++ b/client/ayon_maya/scripts/autoupdater.py
@@ -6,54 +6,36 @@ import argparse
 from ayon_core.pipeline import registered_host, tempdir
 from ayon_core.pipeline.create import CreateContext
 from ayon_core.pipeline.publish import PublishLogic
-from ayon_core.pipeline.context_tools import change_current_context
-from ayon_api import get_folder_by_name, get_task_by_name
 from maya import cmds
 
 
 def auto_updater(
     filepath: str,
     product_base_type: str,
-    folder_name: str,
-    task_name: str,
     variant: str
 ) -> None:
     """Automatically create and publish the assets after importing.
 
     Args:
         filepath (str): File path of the imported asset.
-        folder_name (str): folder name where the asset will be published.
-        task_name (str): Task name where the asset will be published.
-        productBaseType (str): Product base type for the asset to be published.
+        product_base_type (str): Product base type for the asset to be published.
         variant (str): Variant of the asset.
     """
     nodes = cmds.file(
         filepath, sharedReferenceFile=False, returnNewNodes=True
     )
-    shapes = cmds.ls(nodes, shapes=True, long=True)
+    shapes = cmds.ls(nodes, transforms=True, long=True)
     new_nodes = (list(set(nodes) - set(shapes)))
 
     host = registered_host()
     create_context = CreateContext(host)
-    creator_identifier = f"io.openpype.creators.maya.{productBaseType}"
+    creator_identifier = f"io.openpype.creators.maya.{product_base_type}"
     cmds.select(new_nodes, noExpand=True)
     create_context.create(
         creator_identifier=creator_identifier,
         variant=variant,
         pre_create_data={"use_selection": True}
     )
-    project_name = create_context.get_current_project_name()
-    folder_entity = get_folder_by_name(project_name, folder_name)
-    task_entity = get_task_by_name(project_name, folder_entity["id"], task_name)
-
-    if (
-        folder_entity != create_context.get_current_folder_entity() or
-        task_entity != create_context.get_current_task_entity()
-    ):
-        change_current_context(
-            folder_entity=folder_entity,
-            task_entity=task_entity
-        )
 
     logic = PublishLogic()
     logic.publish()
@@ -81,16 +63,6 @@ if __name__ == "__main__":
         help="Path to the asset file to import (e.g., .abc, .mb, .ma)."
     )
     parser.add_argument(
-        "--folderPath",
-        required=True,
-        help="Folder path where the product will be published."
-    )
-    parser.add_argument(
-        "--task",
-        required=True,
-        help="Task name under which the product will be published (default: Modeling)."
-    )
-    parser.add_argument(
         "--variant",
         required=True,
         help="Variant name for the product (e.g., 'v001', 'main')."
@@ -106,8 +78,6 @@ if __name__ == "__main__":
 
     auto_updater(
         filepath=args.filepath,
-        folder_name=args.folderPath,
-        task_name=args.task,
-        productBaseType=args.product_base_type,
+        product_base_type=args.product_base_type,
         variant=args.variant,
     )

--- a/client/ayon_maya/scripts/autoupdater.py
+++ b/client/ayon_maya/scripts/autoupdater.py
@@ -1,0 +1,113 @@
+"""Script for automatically creating and publishing assets after importing in Maya."""
+import json
+import os
+import argparse
+
+from ayon_core.pipeline import registered_host, tempdir
+from ayon_core.pipeline.create import CreateContext
+from ayon_core.pipeline.publish import PublishLogic
+from ayon_core.pipeline.context_tools import change_current_context
+from ayon_api import get_folder_by_name, get_task_by_name
+from maya import cmds
+
+
+def auto_updater(
+    filepath: str,
+    productBaseType: str,
+    folder_name: str,
+    task_name: str,
+    variant: str
+) -> None:
+    """Automatically create and publish the assets after importing.
+
+    Args:
+        filepath (str): File path of the imported asset.
+        folder_name (str): folder name where the asset will be published.
+        task_name (str): Task name where the asset will be published.
+        productBaseType (str): Product base type for the asset to be published.
+        variant (str): Variant of the asset.
+    """
+    nodes = cmds.file(
+        filepath, sharedReferenceFile=False, returnNewNodes=True
+    )
+    shapes = cmds.ls(nodes, shapes=True, long=True)
+    new_nodes = (list(set(nodes) - set(shapes)))
+
+    host = registered_host()
+    create_context = CreateContext(host)
+    creator_identifier = f"io.openpype.creators.maya.{productBaseType}"
+    cmds.select(new_nodes, noExpand=True)
+    create_context.create(
+        creator_identifier=creator_identifier,
+        variant=variant,
+        pre_create_data={"use_selection": True}
+    )
+    project_name = create_context.get_current_project_name()
+    folder_entity = get_folder_by_name(project_name, folder_name)
+    task_entity = get_task_by_name(project_name, folder_entity["id"], task_name)
+
+    if (
+        folder_entity != create_context.get_current_folder_entity() or
+        task_entity != create_context.get_current_task_entity()
+    ):
+        change_current_context(
+            folder_entity=folder_entity,
+            task_entity=task_entity
+        )
+
+    logic = PublishLogic()
+    logic.publish()
+
+    if logic.has_finished():
+        print("Publish finished successfully.")
+    elif logic.has_failed():
+        report = logic.get_publish_report()
+        print(json.dumps(report, indent=2))
+        report_dir = os.path.join(tempdir(), "publish_report.json")
+        with open(report_dir, "w") as f:
+            json.dump(report, f, indent=2)
+
+        print(f"Publish failed. Report saved to: {report_dir}")
+
+if __name__ == "__main__":
+    # Parse command-line arguments
+    # Usage: mayapy.exe autoupdater.py <filepath> <folder_name> <task_name> [productBaseType] [variant]
+    parser = argparse.ArgumentParser(
+        description="Import a file, create a product, and publish in Maya."
+    )
+    parser.add_argument(
+        "--filepath",
+        required=True,
+        help="Path to the asset file to import (e.g., .abc, .mb, .ma)."
+    )
+    parser.add_argument(
+        "--folderPath",
+        required=True,
+        help="Folder path where the product will be published."
+    )
+    parser.add_argument(
+        "--task",
+        required=True,
+        help="Task name under which the product will be published (default: Modeling)."
+    )
+    parser.add_argument(
+        "--variant",
+        required=True,
+        help="Variant name for the product (e.g., 'v001', 'main')."
+    )
+    parser.add_argument(
+        "--product-base-type",
+        default="model",
+        required=True,
+        help="Product base type (e.g., model, camera, rig). Default: model."
+    )
+
+    args = parser.parse_args()
+
+    auto_updater(
+        filepath=args.filepath,
+        folder_name=args.folderPath,
+        task_name=args.task,
+        productBaseType=args.product_base_type,
+        variant=args.variant,
+    )


### PR DESCRIPTION
## Changelog Description
This PR is to implement the auto-update scripts for loading a specific asset and publish in terminal.
Users can execute the script with terminal by `mayapy.exe` with AYON terminal and do a headless publish.

## Additional review information
Resolve https://github.com/ynput/ayon-maya/issues/192

## Testing notes:
1. Locate your `auto-updater` script.
2. Launch terminal via Launcher and choose your maya version
3. do a command like (the command below is for windows)
```
mayapy.exe "{YOUR_MAYA_ADDON_DIRECTORY}/scripts/auto_updater.py" --filepath  \storage05\incomming\ayon_general\test_goe.abc --folderPath lib --task generic --product-base-type model --variant headlessMain
```